### PR TITLE
fix: restore 5-layer web fetch architecture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,7 @@ Perception (See)  +  Skills (Know How)  +  Claude CLI (Execute)
 | Observability | `src/observability.ts` |
 | PerceptionStream | `src/perception-stream.ts` |
 | Logging | `src/logging.ts` |
+| CDP Fetch | `scripts/cdp-fetch.mjs` |
 | Pinchtab Setup | `scripts/pinchtab-setup.sh` |
 | Pinchtab Fetch | `scripts/pinchtab-fetch.sh` |
 | Pinchtab Interact | `scripts/pinchtab-interact.sh` |
@@ -431,7 +432,7 @@ TELEGRAM_BOT_TOKEN=xxx       # Telegram 接收+發送
 TELEGRAM_CHAT_ID=xxx         # 授權的 chat ID
 BRIDGE_HEADLESS=true         # Pinchtab headless Chrome
 BRIDGE_STEALTH=light         # Pinchtab anti-detection
-CDP_URL=                     # 連接現有 Chrome（設定後不啟動新 Chrome）
+CDP_PORT=9222                # Chrome CDP 直連 port（cdp-fetch.mjs 使用）
 BRIDGE_PROFILE=              # Chrome profile 目錄（預設 ~/.pinchtab/chrome-profile）
 ```
 
@@ -592,9 +593,15 @@ curl -sf http://localhost:3001/api/instance     # 當前實例資訊
 
 - TypeScript strict mode。編輯 .ts 檔案時，確保 field names 跨 endpoints、plugins、types 一致 — 跨層 mismatch（如 receivedAt vs updatedAt）曾造成 bug
 - HTML 檔案如果會發 API 呼叫，一律走 HTTP server route serve — 不要假設 file:// protocol 能用（CORS 限制）
-- **JS-heavy / 需登入的網站**（Facebook 等）必須用瀏覽器工具查看（`mcp__claude-in-chrome__*`）— WebFetch 無法渲染 JS-heavy 頁面，Pinchtab headless 模式沒有用戶 session。隱私限定貼文（如 Facebook 朋友限定）則需 Alex 手動協助
+- **Web 內容擷取五層架構**（`plugins/web-fetch.sh`）：
+  - Layer 1: `curl` — 靜態公開頁面（最快最省）
+  - Layer 2: Jina Reader (`r.jina.ai`) — JS-heavy 公開頁面（免費 10M tokens，乾淨 markdown 輸出）
+  - Layer 3: Chrome CDP (`scripts/cdp-fetch.mjs`) — 需登入頁面（用戶 Chrome session，port 9222）
+  - Layer 4: Pinchtab headless — stealth 備用（獨立 headless Chrome，port 9867）
+  - Layer 5: 人工協助
+- **CDP 與 Pinchtab 共存**：CDP 直連用戶 Chrome（port 9222），Pinchtab 跑獨立 headless（port 9867，不設 CDP_URL）。兩者不衝突
 - **X/Twitter 走 Grok API**（`plugins/x-perception.sh`）— 用 Grok x_search tool 搜尋，不依賴瀏覽器
-- **Pinchtab 安裝**：release 是 `.tar.gz` 格式（非裸 binary），repo 為 `pinchtab/pinchtab`。支援 `CDP_URL` 連接現有 Chrome、`BRIDGE_PROFILE` 指定 Chrome profile 目錄
+- **Pinchtab 安裝**：release 是 `.tar.gz` 格式（非裸 binary），repo 為 `pinchtab/pinchtab`。純 headless 模式（不設 CDP_URL）
 
 ## Deployment
 

--- a/scripts/cdp-fetch.mjs
+++ b/scripts/cdp-fetch.mjs
@@ -1,0 +1,418 @@
+#!/usr/bin/env node
+/**
+ * Chrome DevTools Protocol (CDP) Fetch — Zero Dependencies
+ *
+ * Uses Node.js native WebSocket + fetch to control Chrome browser.
+ * Requires Chrome running with --remote-debugging-port=9222
+ *
+ * Usage:
+ *   node scripts/cdp-fetch.mjs status                    # Check CDP availability
+ *   node scripts/cdp-fetch.mjs fetch <url>               # Fetch page content
+ *   node scripts/cdp-fetch.mjs open <url>                # Open visible tab (for login)
+ *   node scripts/cdp-fetch.mjs extract [tabId]           # Extract content from existing tab
+ *   node scripts/cdp-fetch.mjs close <tabId>             # Close a tab
+ */
+
+import { appendFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+
+const CDP_HOST = process.env.CDP_HOST || 'localhost';
+const CDP_PORT = process.env.CDP_PORT || '9222';
+const CDP_BASE = `http://${CDP_HOST}:${CDP_PORT}`;
+const TIMEOUT = parseInt(process.env.CDP_TIMEOUT || '15000');
+const MAX_CONTENT = parseInt(process.env.CDP_MAX_CONTENT || '8000');
+
+// ─── CDP Operation Logging ──────────────────────────────────────────────────
+
+const CDP_LOG_DIR = join(homedir(), '.mini-agent');
+const CDP_LOG_FILE = join(CDP_LOG_DIR, 'cdp.jsonl');
+
+function logCdpOp(op, detail = {}) {
+  try {
+    mkdirSync(CDP_LOG_DIR, { recursive: true });
+    const entry = JSON.stringify({
+      ts: new Date().toISOString(),
+      op,
+      ...detail,
+    });
+    appendFileSync(CDP_LOG_FILE, entry + '\n');
+  } catch { /* logging should never break CDP operations */ }
+}
+
+// ─── CDP HTTP API helpers ─────────────────────────────────────────────────────
+
+async function cdpAvailable() {
+  try {
+    const res = await fetch(`${CDP_BASE}/json/version`, { signal: AbortSignal.timeout(3000) });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+async function listTargets() {
+  const res = await fetch(`${CDP_BASE}/json`, { signal: AbortSignal.timeout(3000) });
+  return res.json();
+}
+
+async function createTarget(url) {
+  const res = await fetch(`${CDP_BASE}/json/new?${url}`, {
+    method: 'PUT',
+    signal: AbortSignal.timeout(5000),
+  });
+  return res.json();
+}
+
+async function closeTarget(targetId) {
+  await fetch(`${CDP_BASE}/json/close/${targetId}`, { signal: AbortSignal.timeout(3000) });
+}
+
+async function activateTarget(targetId) {
+  await fetch(`${CDP_BASE}/json/activate/${targetId}`, { signal: AbortSignal.timeout(3000) });
+}
+
+// ─── CDP WebSocket commands ───────────────────────────────────────────────────
+
+function cdpCommand(ws, method, params = {}) {
+  return new Promise((resolve, reject) => {
+    const id = Math.floor(Math.random() * 1e8);
+    const timeout = setTimeout(() => reject(new Error(`CDP command timeout: ${method}`)), TIMEOUT);
+
+    const handler = (event) => {
+      const msg = JSON.parse(event.data);
+      if (msg.id === id) {
+        clearTimeout(timeout);
+        ws.removeEventListener('message', handler);
+        if (msg.error) reject(new Error(`CDP error: ${msg.error.message}`));
+        else resolve(msg.result);
+      }
+    };
+
+    ws.addEventListener('message', handler);
+    ws.send(JSON.stringify({ id, method, params }));
+  });
+}
+
+function waitForEvent(ws, eventName, timeoutMs = TIMEOUT) {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error(`Waiting for ${eventName} timeout`)), timeoutMs);
+
+    const handler = (event) => {
+      const msg = JSON.parse(event.data);
+      if (msg.method === eventName) {
+        clearTimeout(timeout);
+        ws.removeEventListener('message', handler);
+        resolve(msg.params);
+      }
+    };
+
+    ws.addEventListener('message', handler);
+  });
+}
+
+function connectWs(wsUrl) {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(wsUrl);
+    const timeout = setTimeout(() => { ws.close(); reject(new Error('WebSocket connect timeout')); }, 5000);
+    ws.addEventListener('open', () => { clearTimeout(timeout); resolve(ws); });
+    ws.addEventListener('error', (e) => { clearTimeout(timeout); reject(e); });
+  });
+}
+
+// ─── Page content extraction ──────────────────────────────────────────────────
+
+async function extractPageContent(ws) {
+  // Get page title
+  const titleResult = await cdpCommand(ws, 'Runtime.evaluate', {
+    expression: 'document.title',
+    returnByValue: true,
+  });
+  const title = titleResult.result?.value || '';
+
+  // Get page URL
+  const urlResult = await cdpCommand(ws, 'Runtime.evaluate', {
+    expression: 'window.location.href',
+    returnByValue: true,
+  });
+  const pageUrl = urlResult.result?.value || '';
+
+  // Extract readable text content
+  const textResult = await cdpCommand(ws, 'Runtime.evaluate', {
+    expression: `
+      (() => {
+        // Remove scripts, styles, nav, footer
+        const clone = document.body.cloneNode(true);
+        clone.querySelectorAll('script, style, nav, footer, header, aside, [role="navigation"], [role="banner"]')
+          .forEach(el => el.remove());
+        return clone.innerText.replace(/\\n{3,}/g, '\\n\\n').trim();
+      })()
+    `,
+    returnByValue: true,
+  });
+  const text = textResult.result?.value || '';
+
+  // Extract all links
+  const linksResult = await cdpCommand(ws, 'Runtime.evaluate', {
+    expression: `
+      JSON.stringify(
+        Array.from(document.querySelectorAll('a[href]'))
+          .map(a => ({ text: a.innerText.trim().slice(0, 80), href: a.href }))
+          .filter(l => l.href.startsWith('http') && l.text)
+          .slice(0, 30)
+      )
+    `,
+    returnByValue: true,
+  });
+  let links = [];
+  try { links = JSON.parse(linksResult.result?.value || '[]'); } catch {}
+
+  return { title, url: pageUrl, text, links };
+}
+
+function detectAuthPage(content) {
+  const indicators = [
+    'sign in', 'log in', 'login', 'sign up', '登入', '登錄',
+    'password', 'captcha', 'verify', '驗證', 'authenticate',
+    'access denied', '403', 'forbidden', 'unauthorized',
+  ];
+  const lower = (content.title + ' ' + content.text.slice(0, 500)).toLowerCase();
+  return indicators.some(i => lower.includes(i));
+}
+
+// ─── Commands ─────────────────────────────────────────────────────────────────
+
+async function cmdStatus() {
+  if (!await cdpAvailable()) {
+    console.log('Chrome CDP: NOT AVAILABLE');
+    console.log('');
+    console.log('To enable, start Chrome with:');
+    console.log('  open -a "Google Chrome" --args --remote-debugging-port=9222');
+    console.log('');
+    console.log('Or add to Chrome shortcut/alias.');
+    process.exit(1);
+  }
+
+  const targets = await listTargets();
+  const pages = targets.filter(t => t.type === 'page');
+
+  console.log(`Chrome CDP: AVAILABLE (${CDP_BASE})`);
+  console.log(`Open tabs: ${pages.length}`);
+  console.log('');
+
+  for (const page of pages.slice(0, 10)) {
+    const title = (page.title || 'Untitled').slice(0, 60);
+    const url = (page.url || '').slice(0, 80);
+    console.log(`  [${page.id.slice(0, 8)}] ${title}`);
+    console.log(`           ${url}`);
+  }
+
+  if (pages.length > 10) {
+    console.log(`  ... and ${pages.length - 10} more`);
+  }
+}
+
+async function cmdFetch(url) {
+  if (!await cdpAvailable()) {
+    console.error('Chrome CDP not available. Start Chrome with --remote-debugging-port=9222');
+    process.exit(1);
+  }
+
+  // Create a new tab (background)
+  logCdpOp('fetch', { url });
+  const target = await createTarget(url);
+  const wsUrl = target.webSocketDebuggerUrl;
+
+  if (!wsUrl) {
+    console.error('Failed to get WebSocket URL for new tab');
+    process.exit(1);
+  }
+
+  let ws;
+  try {
+    ws = await connectWs(wsUrl);
+
+    // Enable Page events and navigate
+    await cdpCommand(ws, 'Page.enable');
+    await cdpCommand(ws, 'Runtime.enable');
+
+    // Navigate and wait for load
+    const loadPromise = waitForEvent(ws, 'Page.loadEventFired', TIMEOUT);
+    await cdpCommand(ws, 'Page.navigate', { url });
+    await loadPromise;
+
+    // Small delay for dynamic content
+    await new Promise(r => setTimeout(r, 1500));
+
+    // Extract content
+    const content = await extractPageContent(ws);
+
+    // Check if it's an auth page
+    if (detectAuthPage(content)) {
+      console.log(`AUTH_REQUIRED: ${url}`);
+      console.log(`Title: ${content.title}`);
+      console.log('');
+      console.log('This page requires login/verification.');
+      console.log(`Use: node scripts/cdp-fetch.mjs open "${url}" to open it visibly.`);
+
+      // Close the background tab
+      await closeTarget(target.id);
+    } else {
+      // Output content
+      console.log(`Title: ${content.title}`);
+      console.log(`URL: ${content.url}`);
+      console.log('');
+
+      if (content.text) {
+        console.log('--- Content ---');
+        console.log(content.text.slice(0, MAX_CONTENT));
+      }
+
+      if (content.links.length > 0) {
+        console.log('');
+        console.log('--- Links ---');
+        for (const link of content.links) {
+          console.log(`  ${link.text}: ${link.href}`);
+        }
+      }
+
+      // Close the tab after extraction
+      await closeTarget(target.id);
+    }
+  } finally {
+    if (ws && ws.readyState === WebSocket.OPEN) ws.close();
+  }
+}
+
+async function cmdOpen(url) {
+  if (!await cdpAvailable()) {
+    console.error('Chrome CDP not available. Start Chrome with --remote-debugging-port=9222');
+    process.exit(1);
+  }
+
+  // Create and activate a visible tab
+  logCdpOp('open', { url });
+  const target = await createTarget(url);
+  await activateTarget(target.id);
+
+  console.log(`Opened: ${url}`);
+  console.log(`Tab ID: ${target.id}`);
+  console.log('');
+  console.log('Page is now visible in Chrome.');
+  console.log('After logging in, use:');
+  console.log(`  node scripts/cdp-fetch.mjs extract ${target.id}`);
+}
+
+async function cmdExtract(tabId) {
+  if (!await cdpAvailable()) {
+    console.error('Chrome CDP not available');
+    process.exit(1);
+  }
+
+  // Find the target
+  const targets = await listTargets();
+  const target = targets.find(t =>
+    t.id === tabId || t.id.startsWith(tabId)
+  );
+
+  if (!target) {
+    console.error(`Tab not found: ${tabId}`);
+    console.log('Available tabs:');
+    targets.filter(t => t.type === 'page').forEach(t => {
+      console.log(`  [${t.id.slice(0, 8)}] ${t.title?.slice(0, 50) || t.url}`);
+    });
+    process.exit(1);
+  }
+
+  const wsUrl = target.webSocketDebuggerUrl;
+  if (!wsUrl) {
+    console.error('Cannot connect to this tab (no WebSocket URL)');
+    process.exit(1);
+  }
+
+  logCdpOp('extract', { tabId, url: target.url, title: target.title });
+
+  let ws;
+  try {
+    ws = await connectWs(wsUrl);
+    await cdpCommand(ws, 'Runtime.enable');
+
+    const content = await extractPageContent(ws);
+
+    console.log(`Title: ${content.title}`);
+    console.log(`URL: ${content.url}`);
+    console.log('');
+
+    if (content.text) {
+      console.log('--- Content ---');
+      console.log(content.text.slice(0, MAX_CONTENT));
+    }
+
+    if (content.links.length > 0) {
+      console.log('');
+      console.log('--- Links ---');
+      for (const link of content.links) {
+        console.log(`  ${link.text}: ${link.href}`);
+      }
+    }
+  } finally {
+    if (ws && ws.readyState === WebSocket.OPEN) ws.close();
+  }
+}
+
+async function cmdClose(tabId) {
+  const targets = await listTargets();
+  const target = targets.find(t => t.id === tabId || t.id.startsWith(tabId));
+  if (target) {
+    logCdpOp('close', { tabId, url: target.url, title: target.title });
+    await closeTarget(target.id);
+    console.log(`Closed tab: ${target.title || target.id}`);
+  } else {
+    console.error(`Tab not found: ${tabId}`);
+  }
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
+
+const [cmd, ...args] = process.argv.slice(2);
+
+try {
+  switch (cmd) {
+    case 'status':
+      await cmdStatus();
+      break;
+    case 'fetch':
+      if (!args[0]) { console.error('Usage: cdp-fetch.mjs fetch <url>'); process.exit(1); }
+      await cmdFetch(args[0]);
+      break;
+    case 'open':
+      if (!args[0]) { console.error('Usage: cdp-fetch.mjs open <url>'); process.exit(1); }
+      await cmdOpen(args[0]);
+      break;
+    case 'extract':
+      if (!args[0]) { console.error('Usage: cdp-fetch.mjs extract <tabId>'); process.exit(1); }
+      await cmdExtract(args[0]);
+      break;
+    case 'close':
+      if (!args[0]) { console.error('Usage: cdp-fetch.mjs close <tabId>'); process.exit(1); }
+      await cmdClose(args[0]);
+      break;
+    default:
+      console.log('cdp-fetch — Chrome DevTools Protocol content fetcher');
+      console.log('');
+      console.log('Commands:');
+      console.log('  status              Check Chrome CDP availability');
+      console.log('  fetch <url>         Fetch page content (background tab)');
+      console.log('  open <url>          Open visible tab (for login/verification)');
+      console.log('  extract <tabId>     Extract content from existing tab');
+      console.log('  close <tabId>       Close a tab');
+      console.log('');
+      console.log('Environment:');
+      console.log('  CDP_PORT=9222       Chrome debugging port');
+      console.log('  CDP_TIMEOUT=15000   Command timeout (ms)');
+      console.log('  CDP_MAX_CONTENT=8000  Max content chars');
+  }
+} catch (err) {
+  console.error(`Error: ${err.message}`);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- Restore `scripts/cdp-fetch.mjs` from git history for stable Chrome CDP direct connection (port 9222)
- Add Jina Reader as Layer 2 for JS-heavy public pages (clean markdown output, free 10M tokens)
- Update `plugins/web-fetch.sh` from 3-layer to 5-layer: curl → Jina → CDP → Pinchtab → human
- Pinchtab stays as pure headless fallback (no CDP_URL mode, which crashes on new tab creation)

## Test plan
- [x] Jina Reader: `curl -sL "https://r.jina.ai/https://soking.cc/research" | head -30`
- [x] CDP direct: `node scripts/cdp-fetch.mjs fetch "https://www.facebook.com/sokingwang"`
- [x] CDP status: `node scripts/cdp-fetch.mjs status`
- [ ] Full flow: `bash plugins/web-fetch.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)