### PR TITLE
fix(loop): instrument soft-gate try-entry (#81)

### DIFF
--- a/src/loop.ts
+++ b/src/loop.ts
@@ -2676,6 +2676,7 @@ export class AgentLoop {
       // Soft falsifier gate — reuse shared extractDecisionBlock (fire-and-forget)
       try {
         const decision = extractDecisionBlock(response);
+        slog('LEDGER', `soft-gate enter: response=${response?.length ?? 0}ch hasMarker=${response ? /^##\s*Decision/m.test(response) : false} cycle=${this.cycleCount}`);
         if (decision?.chose) {
           writeCommitment({
             cycle_id: this.cycleCount,


### PR DESCRIPTION
Fixes #81 (instrumentation, not full root-cause fix).

## Context
8 hours of `commitments.jsonl` showing 0 new `cp:self` entries despite
cycles emitting `## Decision` blocks. Existing soft-gate code (loop.ts
L2677-2706) has 4 branches but no log at try entry — when none of them
fire, we have zero visibility.

## Patch
One line at L2680 inserting:
```ts
slog('LEDGER', `soft-gate enter: response=${response?.length ?? 0}ch hasMarker=${response ? /^##\s*Decision/m.test(response) : false} cycle=${this.cycleCount}`);
```

## Why this is the right next step
Cycle 80→128 hypothesis tree explored 4 axes (regex bug → silent catch
→ silent skip → response variable falsy). All speculation; no enter-log
to ground on. This patch makes the next debug pass deterministic:

| Observation in next server.log | Conclusion |
|---|---|
| `soft-gate enter: response=Nch hasMarker=true` then `commitment written` | Path works; previous silence was empty-marker cycles |
| `enter` fires but always `hasMarker=false` | Real fix is upstream emit habit (model not emitting `## Decision` in OODA response body) |
| 0 `enter` log entries despite cycles running | try block is being skipped — investigate L2670-2676 or upstream `response` assignment |

## Test plan
- [x] `npm run typecheck` passes
- [ ] After deploy, observe ≥1 `soft-gate enter:` line per OODA cycle in server.log
- [ ] Cross-check `tail commitments.jsonl` against `enter` log to verify branches behave as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)