### PR TITLE
fix(loop): dump head bytes on hasMarker=false soft-gate skip (#88 followup)

### DIFF
--- a/src/loop.ts
+++ b/src/loop.ts
@@ -2707,7 +2707,9 @@ export class AgentLoop {
               : '<no-header>';
             slog('LEDGER', `soft-gate skip: extractDecisionBlock returned null (response=${response.length}ch, has_decision_marker=true, snippet="${snippet}")`);
           } else {
-            slog('LEDGER', `soft-gate skip: extractDecisionBlock returned null (response=${response.length}ch, has_decision_marker=false)`);
+            // Issue #88 followup: also dump head when marker missing on substantial response (cl-5 false-branch evidence).
+            const head = response.slice(0, 200).replace(/\n/g, '\\n');
+            slog('LEDGER', `soft-gate skip: extractDecisionBlock returned null (response=${response.length}ch, has_decision_marker=false, head="${head}")`);
           }
         }
       } catch (err) {


### PR DESCRIPTION
## Summary
- Extend #88's snippet dump to the `hasMarker=false` branch — the actual production-firing case per cl-5 evidence
- 3-line addition mirrors the true-branch style (slice 0..200, escape newlines, dump in slog)

## Why
#88 instrumented the `hasMarker=true` branch (header detected, field-extract failed). But all 8 recent `soft-gate skip` events in production are `hasMarker=false` on substantial responses (e.g. response=2006ch, 1857ch, 1428ch, 1145ch). Without head bytes we cannot disambiguate three hypotheses:

- **(a) regex flavor** — CRLF/BOM/leading whitespace defeats `/^##\s*Decision/m`
- **(b) upstream mutation** — something between `callClaude` (loop.ts:2523) and soft-gate (loop.ts:2678) strips the header
- **(c) genuine non-Decision shape** — tool-only / hesitation-mutated / prefix-injected

After this lands, the next `hasMarker=false` slog will dump `head="..."` letting us read the cause in one cycle rather than continuing the hypothesis tree.

## Falsifier (post-merge, 5 cycles)
- head starts with `\\r\\n##` / `\\uFEFF##` → branch (a) → fix regex flavor
- head starts with non-`#` content → branch (b) → trace response var assignments
- head shows `## Decision` cleanly → branch (c) → regex compilation/escape issue

## Verification
- [x] `tsc --noEmit` passes
- [ ] Next production cycle with `response.length > 200 && hasMarker=false` produces `head="..."` in slog
- [ ] No false positives (head should never be logged when marker is true or response is short)

Refs: #88 (true-branch already merged), cl-5 ledger commitment (cycle 5, ttl 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)