### PR TITLE
feat(hooks): auto-rebuild dist after src/ commits

### DIFF
--- a/scripts/git-hooks/post-commit
+++ b/scripts/git-hooks/post-commit
@@ -1,0 +1,30 @@
+#!/bin/sh
+# Post-commit hook: rebuild dist/ when src/ or tsconfig changes.
+#
+# Why: dist/ is gitignored. Without auto-rebuild after src/ commits, the
+# locally-running server keeps executing pre-commit compiled code while the
+# repo HEAD reflects newer src — silently defeating local falsifier checks.
+# Observed 2026-05-06 (mini-agent #91 + agent-middleware #3) — same drift class
+# 8 hours apart, both required manual `pnpm build` rescue.
+#
+# Install: bash scripts/install-git-hooks.sh
+# Build runs in background so commits stay fast; failures land in
+# /tmp/post-commit-build-<repo>.log. Server still needs manual restart.
+
+CHANGED=$(git diff-tree --no-commit-id --name-only -r HEAD 2>/dev/null | grep -E '^(src/|tsconfig\.json$)')
+[ -z "$CHANGED" ] && exit 0
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+LOG=/tmp/post-commit-build-$(basename "$REPO_ROOT").log
+
+echo "[post-commit] src/ touched — rebuilding dist/ in background (log: $LOG)"
+(
+  cd "$REPO_ROOT" || exit 1
+  if pnpm build >"$LOG" 2>&1; then
+    echo "[post-commit] ✓ dist/ rebuilt for $(basename "$REPO_ROOT")" >>"$LOG"
+  else
+    echo "[post-commit] ✗ build failed for $(basename "$REPO_ROOT") — see $LOG"
+  fi
+) &
+disown 2>/dev/null || true
+exit 0

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# Install repo-tracked git hooks into .git/hooks/.
+# Idempotent: backs up existing hooks once to <hook>.pre-install.bak.
+#
+# Usage: bash scripts/install-git-hooks.sh
+
+set -e
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+SRC_DIR="$REPO_ROOT/scripts/git-hooks"
+DEST_DIR="$REPO_ROOT/.git/hooks"
+
+if [ ! -d "$SRC_DIR" ]; then
+  echo "✗ no $SRC_DIR — nothing to install"
+  exit 1
+fi
+
+for hook_src in "$SRC_DIR"/*; do
+  [ -f "$hook_src" ] || continue
+  name=$(basename "$hook_src")
+  dest="$DEST_DIR/$name"
+
+  if [ -f "$dest" ] && ! cmp -s "$hook_src" "$dest"; then
+    if [ ! -f "$dest.pre-install.bak" ]; then
+      cp "$dest" "$dest.pre-install.bak"
+      echo "  backed up existing $name → $name.pre-install.bak"
+    fi
+  fi
+
+  cp "$hook_src" "$dest"
+  chmod +x "$dest"
+  echo "✓ installed $name"
+done
+
+echo ""
+echo "Done. Hooks active in $DEST_DIR/"


### PR DESCRIPTION
## Summary
Adds a tracked post-commit hook that rebuilds `dist/` in the background whenever a commit touches `src/` or `tsconfig.json`. Eliminates the **stale-dist drift class** observed 2026-05-06.

## Why
`dist/` is gitignored. After committing src changes, if you don't run `pnpm build` manually, the locally-running server keeps using pre-commit compiled bytecode while HEAD points to newer source. Falsifier checks (e.g. "did the new instrumentation slog appear?") evaluate against a binary that doesn't yet contain the change — and you can't tell the difference from a real bug without checking `dist/*.js` mtime.

This hit twice in 8 hours:
- mini-agent #91 (KG-INGEST count: src=4, dist=3) — caught during falsifier verification, rescued with manual `pnpm build`.
- agent-middleware #3 (CYCLE-TRACE: src=2, dist=0, log=0, 8h post-commit) — same shape.

Filing a third symptom-issue would be cheaper than fixing the structural cause; this PR is the structural fix.

## What's in here
- `scripts/git-hooks/post-commit` — guard regex matches `^(src/|tsconfig\.json$)` in `git diff-tree HEAD`, then runs `pnpm build` backgrounded with logs at `/tmp/post-commit-build-<repo>.log`. No-op for memory/docs/config-only commits.
- `scripts/install-git-hooks.sh` — idempotent installer. Backs up any pre-existing hook to `<name>.pre-install.bak` before overwriting; additive, won't touch hooks not in `scripts/git-hooks/` (e.g. existing `pre-commit` typecheck stays put).

## Caveats
- Per-clone install (hooks live in `.git/hooks/`, not version-controlled themselves). Each developer runs the installer once.
- Build runs in background to keep commits fast — failures show up in `/tmp/post-commit-build-mini-agent.log`, not stderr. Trade-off: don't block the commit on transient build issues.
- **Does not restart the running server.** That remains manual (or future: a `dev` watcher mode). The hook closes the src→dist gap; src→running-process gap is a separate problem.

## Verification
- [x] Installer runs idempotently on this clone, backs up nothing (no prior post-commit hook), leaves existing custom `pre-commit` (typecheck) untouched.
- [x] Hook regex correctly rejects non-src changes (memory/, README, etc.) — verified inline.
- [ ] Next time a `src/*.ts` commit lands here, `/tmp/post-commit-build-mini-agent.log` should show `✓ dist/ rebuilt`.
- [ ] Reviewer cherry-picks the same two files into agent-middleware (or I follow up — flagged in description, not done in this PR to keep scope tight).

🤖 Generated with [Claude Code](https://claude.com/claude-code)