### PR TITLE
fix(housekeeping): emit shell-executable cmd for graphify KG rebuild (#91)

### DIFF
--- a/src/housekeeping.ts
+++ b/src/housekeeping.ts
@@ -743,23 +743,26 @@ function dispatchKGIngestIfNeeded(): void {
     const workdir = process.cwd();
     slog('KG-INGEST', `Triggering auto-ingest: ${reason}`);
 
+    // graphify is wired to the shell worker (delegation.ts CAPABILITY_TO_WORKER),
+    // and shell-worker prompts are passed through verbatim to /bin/bash -c.
+    // Therefore the prompt MUST be a single executable command line — NOT prose.
+    // See agent-middleware#91 for the prior 156-FAIL incident caused by prose.
+    const kgRebuildCmd = [
+      `cd ${workdir}`,
+      'pnpm tsx scripts/kg-extract-chunks.ts --write',
+      'pnpm tsx scripts/kg-extract-entities.ts --write --limit 100',
+      'pnpm tsx scripts/kg-extract-edges.ts --write --limit 100',
+      'pnpm tsx scripts/kg-build-cooccurrence.ts --replace',
+      'pnpm tsx scripts/kg-build-frontmatter-edges.ts --write',
+      'pnpm tsx scripts/kg-detect-conflicts.ts --write',
+      'pnpm tsx scripts/kg-viz.ts',
+    ].join(' && ');
+
     spawnDelegation({
       type: 'graphify',
-      prompt: [
-        `KG incremental rebuild: ${newWrites} new memory writes detected.`,
-        'Run the following pipeline in order:',
-        `cd ${workdir}`,
-        '1. pnpm tsx scripts/kg-extract-chunks.ts --write',
-        '2. pnpm tsx scripts/kg-extract-entities.ts --write --limit 100',
-        '3. pnpm tsx scripts/kg-extract-edges.ts --write --limit 100',
-        '4. pnpm tsx scripts/kg-build-cooccurrence.ts --replace',
-        '5. pnpm tsx scripts/kg-build-frontmatter-edges.ts --write',
-        '6. pnpm tsx scripts/kg-detect-conflicts.ts --write',
-        '7. pnpm tsx scripts/kg-viz.ts',
-        'Report: entity count, edge count, new conflicts.',
-      ].join('\n'),
+      prompt: kgRebuildCmd,
       workdir,
-      acceptance: 'KG entities.jsonl and edges.jsonl updated with new data from recent memory writes; manifest.json last_incremental timestamp refreshed',
+      acceptance: `KG incremental rebuild (${newWrites} new writes): entities.jsonl and edges.jsonl updated; manifest.json last_incremental refreshed`,
     });
 
     markKGIngestTriggered();


### PR DESCRIPTION
## Summary

Patch (A) for agent-middleware#91. The `graphify` delegation type is wired to the **shell worker** (`delegation.ts` `CAPABILITY_TO_WORKER` + `rawPromptTypes`), so prompts flow verbatim into `/bin/bash -c`. The prior prose payload in `dispatchKGIngestIfNeeded` ("Run the following pipeline in order:", numbered list, "Report:" line) caused bash to fail with `line 0: KG incremental rebuild: ... command not found` — 156 cumulative silent `[worker:shell] FAIL` events in `agent-middleware/logs/server.log` since wire-up.

This PR replaces the prose with a single chained `cd && pnpm tsx ... && pnpm tsx ...` command and adds a warning comment so future editors don't reintroduce prose.

- **Loud framing** moves from `prompt` → `acceptance` (acceptance is metadata, not bash input).
- Behavior preserved: same 7 scripts, same order, same `cd ${workdir}`. The only difference is they now actually execute.

## Verification

- [x] `pnpm typecheck` — clean
- [x] `grep "Run the following pipeline" src/housekeeping.ts` → 0 lines
- [x] New cmd matches `cd <workdir> && pnpm tsx scripts/kg-extract-chunks.ts --write && ...` (verified via sed)
- [ ] Post-merge: monitor `agent-middleware/logs/server.log` for 5 housekeeping triggers — `grep "KG incremental rebuild" → 0`, and `manifest.json last_incremental` should refresh after a real ingest.

## Falsifier (KEPT/REFUTED window: 5 cycles after merge+deploy)

- After this lands: next 5 housekeeping triggers produce **0** `[worker:shell] FAIL ... KG incremental rebuild` lines in `agent-middleware/logs/server.log`.
- If the same FAIL persists → root cause is upstream of the prompt (e.g. `execShellWithProgress` mishandles long `&&` chains) — falsifier REFUTED, escalate to Patch (B) (validation at dispatch boundary).

Refs: agent-middleware#91

🤖 Generated with [Claude Code](https://claude.com/claude-code)