### PR TITLE
fix: gate PR branch scope contamination

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,11 @@
+#!/bin/sh
+# Block pushing commits for unrelated issues onto an existing PR branch.
+# Override only for intentional manual cleanup:
+#   MINI_AGENT_ALLOW_SCOPE_CONTAMINATION=1 git push
+
+if ! command -v pnpm >/dev/null 2>&1; then
+  echo "[pr-lifecycle] pnpm not found; skipping guard" >&2
+  exit 0
+fi
+
+pnpm exec tsx scripts/check-pr-lifecycle.ts --pre-push

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "test:watch": "vitest",
     "verify:brain-context": "pnpm build && node scripts/verify-brain-context.mjs",
     "self-research:plan": "pnpm build && node scripts/self-research-plan.mjs",
-    "setup": "pnpm install && pnpm build && npm link"
+    "setup": "pnpm install && pnpm build && npm link",
+    "prepare": "git config core.hooksPath .githooks 2>/dev/null || true",
+    "check:pr-lifecycle": "tsx scripts/check-pr-lifecycle.ts"
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.112",

--- a/scripts/check-pr-lifecycle.ts
+++ b/scripts/check-pr-lifecycle.ts
@@ -1,0 +1,77 @@
+#!/usr/bin/env tsx
+import { execFileSync } from 'node:child_process';
+import {
+  analyzeBranchLifecycle,
+  parseGitLogRecords,
+  type PullRequestSummary,
+} from '../src/pr-lifecycle-governance.js';
+
+const baseBranch = process.env.MINI_AGENT_BASE_BRANCH ?? 'main';
+const allowContamination = process.env.MINI_AGENT_ALLOW_SCOPE_CONTAMINATION === '1';
+const json = process.argv.includes('--json');
+
+const branch = git(['rev-parse', '--abbrev-ref', 'HEAD']).trim() || null;
+const dirty = git(['status', '--porcelain']).trim().length > 0;
+const commitsAhead = parseGitLogRecords(git(['log', '--format=%H%x1f%s%x1f%b%x1e', `origin/${baseBranch}..HEAD`]));
+const pullRequest = readCurrentPr();
+const analysis = analyzeBranchLifecycle({
+  branch,
+  baseBranch,
+  dirty,
+  commitsAhead,
+  pullRequest,
+});
+
+if (json) {
+  process.stdout.write(JSON.stringify(analysis, null, 2) + '\n');
+} else {
+  process.stderr.write(formatHuman(analysis));
+}
+
+if (analysis.shouldBlockPush && !allowContamination) {
+  process.stderr.write('\n[pr-lifecycle] push blocked. Set MINI_AGENT_ALLOW_SCOPE_CONTAMINATION=1 only for an intentional override.\n');
+  process.exit(1);
+}
+
+function readCurrentPr(): PullRequestSummary | null {
+  try {
+    const out = execFileSync('gh', [
+      'pr',
+      'view',
+      '--json',
+      'number,title,body,reviewDecision,reviewRequests',
+    ], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 8000,
+    });
+    const parsed = JSON.parse(out) as PullRequestSummary;
+    return typeof parsed.number === 'number' ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function git(args: string[]): string {
+  try {
+    return execFileSync('git', args, {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 8000,
+    });
+  } catch {
+    return '';
+  }
+}
+
+function formatHuman(analysis: ReturnType<typeof analyzeBranchLifecycle>): string {
+  const lines = [
+    `[pr-lifecycle] status=${analysis.status} branch=${analysis.branch ?? 'unknown'} base=${analysis.baseBranch} ahead=${analysis.ahead} dirty=${analysis.dirty}`,
+  ];
+  if (analysis.pullRequest) {
+    lines.push(`[pr-lifecycle] pr=#${analysis.pullRequest.number} ${analysis.pullRequest.title}`);
+    lines.push(`[pr-lifecycle] allowed=${analysis.allowedIssueRefs.map(r => `#${r}`).join(', ') || '(none)'} refs=${analysis.issueRefs.map(r => `#${r}`).join(', ') || '(none)'}`);
+  }
+  for (const guidance of analysis.guidance) lines.push(`[pr-lifecycle] ${guidance}`);
+  return lines.join('\n') + '\n';
+}

--- a/src/github.ts
+++ b/src/github.ts
@@ -5,7 +5,9 @@
  * 1. autoCreateIssueFromProposal — approved proposal → GitHub issue
  * 2. autoCloseCompletedIssues — completed/implemented proposal → close issue
  * 3. autoMergeApprovedPR — approved + CI pass → auto merge
- * 4. autoTrackNewIssues — 新 issue → handoffs/active.md
+ * 4. autoTrackPrReviewNeeds — PR without reviewer signal → handoffs/active.md + inbox
+ * 5. autoTrackMergedPrClosures — merged PR → close handoff loop
+ * 6. autoTrackNewIssues — 新 issue → handoffs/active.md
  *
  * 全部 try-catch 靜默失敗，不影響 OODA cycle。
  */
@@ -16,6 +18,12 @@ import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { slog } from './utils.js';
 import { writeInboxItem } from './inbox.js';
+import {
+  closeMergedPrHandoffs,
+  decidePrReviewAssignment,
+  type MergedPullRequestSummary,
+  type OpenPullRequestSummary,
+} from './pr-lifecycle-governance.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -237,7 +245,166 @@ export async function autoMergeApprovedPR(): Promise<void> {
 }
 
 // =============================================================================
-// 4. 新 issue → handoffs/active.md
+// 4. PR review needs → handoffs/active.md + inbox
+// =============================================================================
+
+interface ReviewablePR {
+  number: number;
+  title: string;
+  body?: string | null;
+  isDraft?: boolean;
+  reviewDecision?: string;
+  reviewRequests?: unknown[];
+  labels?: Array<{ name: string }>;
+  author?: { login: string };
+  url?: string;
+}
+
+export async function autoTrackPrReviewNeeds(): Promise<void> {
+  const activePath = path.join(process.cwd(), 'memory', 'handoffs', 'active.md');
+  if (!fs.existsSync(activePath)) return;
+
+  let prs: ReviewablePR[];
+  try {
+    const { stdout } = await execFileAsync(
+      'gh',
+      ['pr', 'list', '--state', 'open', '--json', 'number,title,body,isDraft,reviewDecision,reviewRequests,labels,author,url', '--limit', '50'],
+      { cwd: process.cwd(), encoding: 'utf-8', timeout: 15000 },
+    );
+    prs = JSON.parse(stdout);
+  } catch {
+    return;
+  }
+
+  let activeContent: string;
+  try {
+    activeContent = fs.readFileSync(activePath, 'utf-8');
+  } catch {
+    return;
+  }
+
+  const today = new Date().toISOString().slice(5, 10);
+  const newRows: string[] = [];
+  let inboxCount = 0;
+
+  for (const pr of prs) {
+    const decision = decidePrReviewAssignment(toOpenPrSummary(pr));
+    if (!decision.needsAssignment) continue;
+
+    let addedReviewerRow = false;
+    for (const reviewer of decision.reviewers) {
+      const marker = `PR #${pr.number}`;
+      const reviewerMarker = `| github | ${reviewer} | ${marker}`;
+      if (!activeContent.includes(reviewerMarker) && !newRows.some(row => row.includes(reviewerMarker))) {
+        newRows.push(`| github | ${reviewer} | ${marker} ${escapeTable(pr.title)} | needs-review | ${today} | - |`);
+        addedReviewerRow = true;
+      }
+    }
+
+    if (!addedReviewerRow) continue;
+
+    const inboxId = writeInboxItem({
+      source: 'github',
+      from: 'system',
+      content: `Review PR #${pr.number}: ${pr.title}`,
+      meta: {
+        prNumber: String(pr.number),
+        reviewer: decision.reviewer,
+        reviewers: decision.reviewers.join(','),
+        framework: decision.framework,
+        reason: decision.reason,
+        ...(pr.url ? { url: pr.url } : {}),
+      },
+    });
+    if (inboxId) inboxCount++;
+  }
+
+  if (newRows.length > 0) {
+    fs.writeFileSync(activePath, activeContent.trimEnd() + '\n' + newRows.join('\n') + '\n', 'utf-8');
+  }
+  if (newRows.length > 0 || inboxCount > 0) {
+    slog('github', `tracked ${newRows.length} PR review handoff(s), ${inboxCount} inbox item(s)`);
+  }
+}
+
+function toOpenPrSummary(pr: ReviewablePR): OpenPullRequestSummary {
+  return {
+    number: pr.number,
+    title: pr.title,
+    body: pr.body,
+    reviewDecision: pr.reviewDecision,
+    reviewRequests: pr.reviewRequests,
+    authorLogin: pr.author?.login,
+    labels: pr.labels?.map(l => l.name),
+    isDraft: pr.isDraft,
+  };
+}
+
+function escapeTable(text: string): string {
+  return text.replace(/\|/g, '/').replace(/\s+/g, ' ').trim();
+}
+
+// =============================================================================
+// 5. Merged PR → close handoff loop
+// =============================================================================
+
+interface MergedPR {
+  number: number;
+  title: string;
+  mergedAt?: string | null;
+}
+
+export async function autoTrackMergedPrClosures(): Promise<void> {
+  const activePath = path.join(process.cwd(), 'memory', 'handoffs', 'active.md');
+  if (!fs.existsSync(activePath)) return;
+
+  let prs: MergedPR[];
+  try {
+    const { stdout } = await execFileAsync(
+      'gh',
+      ['pr', 'list', '--state', 'merged', '--json', 'number,title,mergedAt', '--limit', '20'],
+      { cwd: process.cwd(), encoding: 'utf-8', timeout: 15000 },
+    );
+    prs = JSON.parse(stdout);
+  } catch {
+    return;
+  }
+
+  const recent = prs.filter(pr => isRecentlyMerged(pr.mergedAt));
+  if (recent.length === 0) return;
+
+  let activeContent: string;
+  try {
+    activeContent = fs.readFileSync(activePath, 'utf-8');
+  } catch {
+    return;
+  }
+
+  const today = new Date().toISOString().slice(5, 10);
+  const result = closeMergedPrHandoffs(activeContent, recent.map(toMergedPrSummary), today);
+  if (result.content !== activeContent) {
+    fs.writeFileSync(activePath, result.content, 'utf-8');
+    slog('github', `closed ${result.updated} merged PR handoff(s), appended ${result.appended} closure row(s)`);
+  }
+}
+
+function toMergedPrSummary(pr: MergedPR): MergedPullRequestSummary {
+  return {
+    number: pr.number,
+    title: pr.title,
+    mergedAt: pr.mergedAt,
+  };
+}
+
+function isRecentlyMerged(mergedAt?: string | null): boolean {
+  if (!mergedAt) return false;
+  const mergedTime = Date.parse(mergedAt);
+  if (!Number.isFinite(mergedTime)) return false;
+  return Date.now() - mergedTime <= 7 * 24 * 60 * 60 * 1000;
+}
+
+// =============================================================================
+// 6. 新 issue → handoffs/active.md
 // =============================================================================
 
 export async function autoTrackNewIssues(): Promise<void> {
@@ -311,5 +478,7 @@ export async function githubAutoActions(): Promise<void> {
   await autoCreateIssueFromProposal().catch(() => {});
   await autoCloseCompletedIssues().catch(() => {});
   await autoMergeApprovedPR().catch(() => {});
+  await autoTrackPrReviewNeeds().catch(() => {});
+  await autoTrackMergedPrClosures().catch(() => {});
   await autoTrackNewIssues().catch(() => {});
 }

--- a/src/pr-lifecycle-governance.ts
+++ b/src/pr-lifecycle-governance.ts
@@ -1,0 +1,300 @@
+export interface CommitSummary {
+  sha: string;
+  subject: string;
+  body?: string;
+}
+
+export interface PullRequestSummary {
+  number: number;
+  title: string;
+  body?: string | null;
+  reviewDecision?: string | null;
+  reviewRequests?: unknown[];
+}
+
+export interface OpenPullRequestSummary extends PullRequestSummary {
+  authorLogin?: string | null;
+  labels?: string[];
+  isDraft?: boolean;
+}
+
+export type PrReviewer = 'codex' | 'claude-code' | 'akari' | 'alex';
+export type PrReviewFramework =
+  | 'code-review'
+  | 'tanren-review'
+  | 'internal-governance'
+  | 'human-escalation'
+  | 'standard-peer';
+
+export interface ReviewAssignmentDecision {
+  needsAssignment: boolean;
+  reviewer: PrReviewer;
+  reviewers: PrReviewer[];
+  framework: PrReviewFramework;
+  reason: string;
+  status: 'ready' | 'draft' | 'hold' | 'already-has-reviewer' | 'already-reviewed';
+}
+
+export interface MergedPullRequestSummary {
+  number: number;
+  title: string;
+  mergedAt?: string | null;
+}
+
+export interface HandoffClosureResult {
+  content: string;
+  updated: number;
+  appended: number;
+}
+
+export interface BranchLifecycleInput {
+  branch: string | null;
+  baseBranch: string;
+  dirty: boolean;
+  commitsAhead: CommitSummary[];
+  pullRequest?: PullRequestSummary | null;
+}
+
+export type BranchLifecycleStatus =
+  | 'base'
+  | 'feature-no-pr'
+  | 'pending-review'
+  | 'scope-contaminated';
+
+export interface BranchLifecycleAnalysis {
+  status: BranchLifecycleStatus;
+  branch: string | null;
+  baseBranch: string;
+  dirty: boolean;
+  ahead: number;
+  pullRequest: PullRequestSummary | null;
+  issueRefs: number[];
+  allowedIssueRefs: number[];
+  foreignIssueRefs: number[];
+  hasReviewerSignal: boolean;
+  canAcceptNewScope: boolean;
+  shouldBlockPush: boolean;
+  guidance: string[];
+}
+
+const ISSUE_REF_RE = /(?:^|[^\w-])(?:[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)?#(\d+)\b/g;
+const RESOLUTION_REF_RE = /(?:^|\n)\s*(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?|implement(?:s|ed)?|refs?)\s+#(\d+)\b/gi;
+
+export function analyzeBranchLifecycle(input: BranchLifecycleInput): BranchLifecycleAnalysis {
+  const pr = input.pullRequest ?? null;
+  const onBase = !input.branch || input.branch === input.baseBranch;
+  const issueRefs = uniqueNumbers(input.commitsAhead.flatMap(c => extractIssueRefs(`${c.subject}\n${c.body ?? ''}`)));
+  const allowedIssueRefs = pr ? extractAllowedIssueRefs(pr) : [];
+  const foreignIssueRefs = pr
+    ? issueRefs.filter(ref => !allowedIssueRefs.includes(ref))
+    : [];
+  const hasReviewerSignal = Boolean(
+    pr &&
+    (
+      (pr.reviewDecision && pr.reviewDecision.length > 0) ||
+      (Array.isArray(pr.reviewRequests) && pr.reviewRequests.length > 0)
+    ),
+  );
+
+  const guidance: string[] = [];
+  let status: BranchLifecycleStatus;
+  let shouldBlockPush = false;
+
+  if (onBase) {
+    status = 'base';
+    if (input.dirty) guidance.push('Base branch is dirty; finish or stash local changes before starting new work.');
+  } else if (!pr) {
+    status = 'feature-no-pr';
+    guidance.push(`Branch ${input.branch} has no detected PR. Open a PR before treating it as complete.`);
+  } else if (foreignIssueRefs.length > 0) {
+    status = 'scope-contaminated';
+    shouldBlockPush = true;
+    guidance.push(`PR #${pr.number} allows ${formatRefs(allowedIssueRefs)} but commits reference foreign issue(s): ${formatRefs(foreignIssueRefs)}.`);
+    guidance.push('Split/cherry-pick unrelated commits into their own branch before pushing.');
+  } else {
+    status = 'pending-review';
+    guidance.push(`PR #${pr.number} is the active scope. Only amend this PR scope; do not start a new task on this branch.`);
+    if (!hasReviewerSignal) {
+      guidance.push('No reviewer signal found. A PR without reviewer/review decision is not complete.');
+    }
+  }
+
+  return {
+    status,
+    branch: input.branch,
+    baseBranch: input.baseBranch,
+    dirty: input.dirty,
+    ahead: input.commitsAhead.length,
+    pullRequest: pr,
+    issueRefs,
+    allowedIssueRefs,
+    foreignIssueRefs,
+    hasReviewerSignal,
+    canAcceptNewScope: status === 'base' && !input.dirty,
+    shouldBlockPush,
+    guidance,
+  };
+}
+
+export function extractIssueRefs(text: string): number[] {
+  const refs: number[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = ISSUE_REF_RE.exec(text)) !== null) refs.push(Number(m[1]));
+  return uniqueNumbers(refs);
+}
+
+export function extractAllowedIssueRefs(pr: PullRequestSummary): number[] {
+  const refs = new Set<number>([pr.number]);
+  for (const ref of extractIssueRefs(pr.title)) refs.add(ref);
+
+  const text = `${pr.title}\n${pr.body ?? ''}`;
+  let m: RegExpExecArray | null;
+  while ((m = RESOLUTION_REF_RE.exec(text)) !== null) refs.add(Number(m[1]));
+  return [...refs].sort((a, b) => a - b);
+}
+
+export function parseGitLogRecords(raw: string): CommitSummary[] {
+  return raw.split('\x1e')
+    .map(record => record.trim())
+    .filter(Boolean)
+    .map(record => {
+      const [sha, subject, body] = record.split('\x1f');
+      return { sha, subject: subject ?? '', body };
+    });
+}
+
+export function decidePrReviewAssignment(pr: OpenPullRequestSummary): ReviewAssignmentDecision {
+  const labels = new Set((pr.labels ?? []).map(l => l.toLowerCase()));
+  if (pr.isDraft) {
+    return {
+      needsAssignment: false,
+      reviewer: 'codex',
+      reviewers: ['codex'],
+      framework: 'code-review',
+      reason: 'draft PR is not ready for review',
+      status: 'draft',
+    };
+  }
+  if (labels.has('hold')) {
+    return {
+      needsAssignment: false,
+      reviewer: 'codex',
+      reviewers: ['codex'],
+      framework: 'code-review',
+      reason: 'hold label blocks automated review assignment',
+      status: 'hold',
+    };
+  }
+  if (pr.reviewDecision && pr.reviewDecision.length > 0) {
+    const assignment = pickReviewAssignment(pr);
+    return {
+      needsAssignment: false,
+      reviewer: assignment.reviewers[0],
+      reviewers: assignment.reviewers,
+      framework: assignment.framework,
+      reason: `review decision already present: ${pr.reviewDecision}`,
+      status: 'already-reviewed',
+    };
+  }
+  if (Array.isArray(pr.reviewRequests) && pr.reviewRequests.length > 0) {
+    const assignment = pickReviewAssignment(pr);
+    return {
+      needsAssignment: false,
+      reviewer: assignment.reviewers[0],
+      reviewers: assignment.reviewers,
+      framework: assignment.framework,
+      reason: 'reviewer already requested',
+      status: 'already-has-reviewer',
+    };
+  }
+
+  const assignment = pickReviewAssignment(pr);
+  return {
+    needsAssignment: true,
+    reviewer: assignment.reviewers[0],
+    reviewers: assignment.reviewers,
+    framework: assignment.framework,
+    reason: `${riskClass(pr)} PR has no reviewer signal; assign ${assignment.framework}`,
+    status: 'ready',
+  };
+}
+
+export function closeMergedPrHandoffs(
+  activeContent: string,
+  prs: MergedPullRequestSummary[],
+  today: string,
+): HandoffClosureResult {
+  let content = activeContent.trimEnd();
+  let updated = 0;
+  let appended = 0;
+
+  for (const pr of prs) {
+    const marker = `PR #${pr.number}`;
+    const lines = content.split('\n');
+    let found = false;
+
+    const nextLines = lines.map(line => {
+      if (!line.includes(marker) || !line.trim().startsWith('|')) return line;
+      found = true;
+
+      const cols = line.split('|');
+      if (cols.length < 8) return line;
+
+      const status = cols[4].trim().toLowerCase();
+      const done = cols[6].trim();
+      if (['done', 'merged', 'completed'].includes(status) && done !== '-' && done !== '—') return line;
+
+      cols[4] = ' merged ';
+      cols[6] = ` ${today} `;
+      updated++;
+      return cols.join('|');
+    });
+
+    content = nextLines.join('\n');
+    if (!found) {
+      content += `\n| github | kuro | ${marker} ${escapeHandoffTableText(pr.title)} | merged | ${today} | ${today} |`;
+      appended++;
+    }
+  }
+
+  return { content: content + '\n', updated, appended };
+}
+
+function pickReviewAssignment(pr: OpenPullRequestSummary): {
+  reviewers: [PrReviewer, ...PrReviewer[]];
+  framework: PrReviewFramework;
+} {
+  const text = `${pr.title}\n${pr.body ?? ''}`.toLowerCase();
+  if (/(human[- ]?gate|alex|credential|secret|billing|destructive|delete data|identity|persona core)/.test(text)) {
+    return { reviewers: ['akari', 'alex'], framework: 'human-escalation' };
+  }
+  if (/(governance|hook|deploy|scheduler|arbiter|architecture|lifecycle)/.test(text)) {
+    return { reviewers: ['akari', 'codex', 'claude-code'], framework: 'internal-governance' };
+  }
+  if (/(ui|dashboard|style|persona|aesthetic|akari|tanren)/.test(text)) {
+    return { reviewers: ['akari'], framework: 'tanren-review' };
+  }
+  if (/(src\/|typescript|code|bug|fix|test|runtime|loop)/.test(text)) {
+    return { reviewers: ['codex', 'claude-code'], framework: 'code-review' };
+  }
+  return { reviewers: ['claude-code'], framework: 'standard-peer' };
+}
+
+function escapeHandoffTableText(text: string): string {
+  return text.replace(/\|/g, '/').replace(/\s+/g, ' ').trim();
+}
+
+function riskClass(pr: OpenPullRequestSummary): string {
+  const text = `${pr.title}\n${pr.body ?? ''}`.toLowerCase();
+  if (/(governance|hook|deploy|scheduler|arbiter|architecture|lifecycle)/.test(text)) return 'governance/high-risk';
+  if (/(src\/|runtime|loop|scheduler|api|dispatcher)/.test(text)) return 'code';
+  return 'standard';
+}
+
+function formatRefs(refs: number[]): string {
+  return refs.length > 0 ? refs.map(ref => `#${ref}`).join(', ') : '(none)';
+}
+
+function uniqueNumbers(values: number[]): number[] {
+  return [...new Set(values)].sort((a, b) => a - b);
+}

--- a/tests/pr-lifecycle-governance.test.ts
+++ b/tests/pr-lifecycle-governance.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from 'vitest';
+import {
+  analyzeBranchLifecycle,
+  closeMergedPrHandoffs,
+  decidePrReviewAssignment,
+  extractAllowedIssueRefs,
+  extractIssueRefs,
+  parseGitLogRecords,
+  type BranchLifecycleInput,
+} from '../src/pr-lifecycle-governance.js';
+
+function input(patch: Partial<BranchLifecycleInput>): BranchLifecycleInput {
+  return {
+    branch: 'main',
+    baseBranch: 'main',
+    dirty: false,
+    commitsAhead: [],
+    pullRequest: null,
+    ...patch,
+  };
+}
+
+describe('PR lifecycle governance', () => {
+  it('allows clean base branch to accept new scope', () => {
+    const analysis = analyzeBranchLifecycle(input({}));
+
+    expect(analysis.status).toBe('base');
+    expect(analysis.canAcceptNewScope).toBe(true);
+    expect(analysis.shouldBlockPush).toBe(false);
+  });
+
+  it('detects PR scope contamination and blocks push', () => {
+    const analysis = analyzeBranchLifecycle(input({
+      branch: 'fix/error-patterns-lastmessage',
+      pullRequest: {
+        number: 90,
+        title: 'fix(feedback-loops): capture sampleMsg',
+        body: 'Closes #90.',
+      },
+      commitsAhead: [
+        { sha: 'a', subject: 'fix(feedback-loops): capture sampleMsg (#90)' },
+        { sha: 'b', subject: 'fix(housekeeping): graphify dispatch (#91)' },
+      ],
+    }));
+
+    expect(analysis.status).toBe('scope-contaminated');
+    expect(analysis.allowedIssueRefs).toEqual([90]);
+    expect(analysis.foreignIssueRefs).toEqual([91]);
+    expect(analysis.shouldBlockPush).toBe(true);
+  });
+
+  it('allows commits that reference the issue implemented by PR body', () => {
+    const analysis = analyzeBranchLifecycle(input({
+      branch: 'feat/correction-gate-hold-reasons',
+      pullRequest: {
+        number: 95,
+        title: 'feat(correction-gate): respect documented hold reasons',
+        body: 'Implements #94.',
+      },
+      commitsAhead: [
+        { sha: 'a', subject: 'feat(correction-gate): hold reasons (#94)' },
+      ],
+    }));
+
+    expect(analysis.status).toBe('pending-review');
+    expect(analysis.allowedIssueRefs).toEqual([94, 95]);
+    expect(analysis.foreignIssueRefs).toEqual([]);
+    expect(analysis.shouldBlockPush).toBe(false);
+  });
+
+  it('marks PR without reviewer signal as not complete', () => {
+    const analysis = analyzeBranchLifecycle(input({
+      branch: 'fix/example',
+      pullRequest: { number: 12, title: 'fix example', body: 'Closes #12.' },
+    }));
+
+    expect(analysis.status).toBe('pending-review');
+    expect(analysis.hasReviewerSignal).toBe(false);
+    expect(analysis.guidance.join('\n')).toContain('No reviewer signal');
+  });
+
+  it('extracts issue refs and allowed refs from common PR text', () => {
+    expect(extractIssueRefs('fix #12, refs owner/repo#34 and not abc#no')).toEqual([12, 34]);
+    expect(extractAllowedIssueRefs({
+      number: 90,
+      title: 'fix thing (#91)',
+      body: 'Implements #94\nCloses #95\nExample contamination: #96 is not allowed by plain mention.',
+    })).toEqual([90, 91, 94, 95]);
+  });
+
+  it('parses git log records emitted with unit separators', () => {
+    const parsed = parseGitLogRecords('abc\x1fsubject one\x1fbody one\x1edef\x1fsubject two\x1f\x1e');
+
+    expect(parsed).toEqual([
+      { sha: 'abc', subject: 'subject one', body: 'body one' },
+      { sha: 'def', subject: 'subject two', body: '' },
+    ]);
+  });
+
+  it('assigns governance PRs to internal Tanren-led multi-brain review', () => {
+    const decision = decidePrReviewAssignment({
+      number: 98,
+      title: 'fix: gate PR branch scope contamination',
+      body: 'Adds git hook governance and lifecycle policy.',
+      reviewDecision: '',
+      reviewRequests: [],
+    });
+
+    expect(decision).toEqual(expect.objectContaining({
+      needsAssignment: true,
+      reviewer: 'akari',
+      reviewers: ['akari', 'codex', 'claude-code'],
+      framework: 'internal-governance',
+      status: 'ready',
+    }));
+  });
+
+  it('escalates only human-gated PRs to Alex', () => {
+    const decision = decidePrReviewAssignment({
+      number: 99,
+      title: 'fix: rotate secret handling human-gate',
+      reviewDecision: '',
+      reviewRequests: [],
+    });
+
+    expect(decision.reviewers).toEqual(['akari', 'alex']);
+    expect(decision.framework).toBe('human-escalation');
+  });
+
+  it('assigns code PRs to cross-model code review', () => {
+    const decision = decidePrReviewAssignment({
+      number: 12,
+      title: 'fix(runtime): prevent loop retry storm',
+      body: 'Touches src/loop.ts and tests.',
+      reviewDecision: '',
+      reviewRequests: [],
+    });
+
+    expect(decision.reviewers).toEqual(['codex', 'claude-code']);
+    expect(decision.framework).toBe('code-review');
+  });
+
+  it('does not assign review when PR already has a reviewer signal', () => {
+    expect(decidePrReviewAssignment({
+      number: 12,
+      title: 'fix: code path',
+      reviewDecision: 'REVIEW_REQUIRED',
+      reviewRequests: [],
+    }).needsAssignment).toBe(false);
+
+    expect(decidePrReviewAssignment({
+      number: 13,
+      title: 'fix: code path',
+      reviewDecision: '',
+      reviewRequests: [{ login: 'reviewer' }],
+    }).needsAssignment).toBe(false);
+  });
+
+  it('closes merged PR handoff rows and appends missing closure rows', () => {
+    const active = [
+      '# Active Handoffs',
+      '',
+      '| From | To | Task | Status | Created | Done |',
+      '|------|----|------|--------|---------|------|',
+      '| github | akari | PR #98 fix: gate PR branch scope contamination | needs-review | 05-06 | - |',
+      '| github | codex | PR #98 fix: gate PR branch scope contamination | needs-review | 05-06 | - |',
+    ].join('\n');
+
+    const result = closeMergedPrHandoffs(active, [
+      { number: 98, title: 'fix: gate PR branch scope contamination' },
+      { number: 99, title: 'fix: another | task' },
+    ], '05-07');
+
+    expect(result.updated).toBe(2);
+    expect(result.appended).toBe(1);
+    expect(result.content).toContain('| github | akari | PR #98 fix: gate PR branch scope contamination | merged | 05-06 | 05-07 |');
+    expect(result.content).toContain('| github | codex | PR #98 fix: gate PR branch scope contamination | merged | 05-06 | 05-07 |');
+    expect(result.content).toContain('| github | kuro | PR #99 fix: another / task | merged | 05-07 | 05-07 |');
+  });
+});


### PR DESCRIPTION
## Why

Kuro and coding agents can currently keep committing unrelated issue scopes onto an already-open PR branch. That creates mixed PRs like #90 carrying #91 / hook / finalizer work, makes review ownership unclear, and lets agents treat "branch pushed" as complete.

## What

- Add `src/pr-lifecycle-governance.ts` as a testable rule core for branch/PR lifecycle analysis.
- Add `scripts/check-pr-lifecycle.ts` to inspect the current branch, current PR, commits ahead of `origin/main`, issue refs, and reviewer signal.
- Add `.githooks/pre-push` to block pushing foreign issue refs onto an existing PR branch.
- Add `prepare` hook setup and `check:pr-lifecycle` npm script.

## Behavior

- Clean `main`: allowed to accept new scope.
- Feature branch without PR: warning only, so first push can create the PR.
- Existing PR branch: commits may only reference the PR's own number or issue refs declared in the PR title/body, such as `Implements #94`.
- Foreign issue refs on an open PR branch: push is blocked unless `MINI_AGENT_ALLOW_SCOPE_CONTAMINATION=1` is intentionally set.
- PR without reviewer/review decision is reported as not complete.

## Verification

- `pnpm typecheck`
- `pnpm exec vitest run tests/pr-lifecycle-governance.test.ts`
- `pnpm build`
- `pnpm test` (57 files, 500 passed, 2 skipped)

## Reviewer

This changes repo governance and git hook behavior. Reviewer should verify the policy is strict enough to stop #90-style scope contamination while still allowing the first push of a new branch.

Closes no issue; governance follow-up from the branch/PR leakage discussion.