### PR TITLE
fix: add git conflict governance checks

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -8,4 +8,5 @@ if ! command -v pnpm >/dev/null 2>&1; then
   exit 0
 fi
 
+pnpm exec tsx scripts/check-conflicts.ts || exit $?
 pnpm exec tsx scripts/check-pr-lifecycle.ts --pre-push

--- a/scripts/check-conflicts.ts
+++ b/scripts/check-conflicts.ts
@@ -1,0 +1,69 @@
+#!/usr/bin/env tsx
+import { execFileSync } from 'node:child_process';
+import { existsSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { mkdirSync } from 'node:fs';
+import { assessConflicts, mergeAppendOnlyText } from '../src/conflict-governance.js';
+
+const args = new Set(process.argv.slice(2));
+const shouldResolve = args.has('--resolve-append-only');
+const json = args.has('--json');
+
+function git(args: string[]): string {
+  return execFileSync('git', args, { encoding: 'utf-8' }).trimEnd();
+}
+
+function conflictedPaths(): string[] {
+  const out = git(['diff', '--name-only', '--diff-filter=U']);
+  return out ? out.split('\n').filter(Boolean) : [];
+}
+
+function stageContent(stage: 2 | 3, file: string): string {
+  try {
+    return execFileSync('git', ['show', `:${stage}:${file}`], { encoding: 'utf-8' });
+  } catch {
+    return '';
+  }
+}
+
+function resolveAppendOnly(paths: string[]): string[] {
+  const resolved: string[] = [];
+  for (const file of paths) {
+    const ours = stageContent(2, file);
+    const theirs = stageContent(3, file);
+    if (!ours && !theirs) continue;
+    const merged = mergeAppendOnlyText(ours, theirs);
+    mkdirSync(dirname(file), { recursive: true });
+    writeFileSync(file, merged, 'utf-8');
+    execFileSync('git', ['add', file], { stdio: 'ignore' });
+    resolved.push(file);
+  }
+  return resolved;
+}
+
+const paths = conflictedPaths();
+let assessment = assessConflicts(paths);
+let resolved: string[] = [];
+
+if (shouldResolve && assessment.autoResolvable.length > 0) {
+  resolved = resolveAppendOnly(assessment.autoResolvable.map(f => f.path));
+  assessment = assessConflicts(conflictedPaths());
+}
+
+if (json) {
+  console.log(JSON.stringify({ ...assessment, resolved }, null, 2));
+} else {
+  for (const line of assessment.guidance) console.error(`[conflict-governance] ${line}`);
+  for (const file of assessment.conflicted) {
+    console.error(`[conflict-governance] ${file.path}: ${file.resolution} (${file.reason})`);
+  }
+  if (resolved.length > 0) {
+    console.error(`[conflict-governance] resolved append-only: ${resolved.join(', ')}`);
+  }
+}
+
+if (assessment.shouldBlock) process.exit(1);
+if (!existsSync('.git')) {
+  // Kept only to make this script explicit about requiring a git worktree.
+  process.exit(1);
+}

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -20,7 +20,16 @@ log "Starting deployment..."
 # ── Phase 1: Pull + Install + Build (Kuro still running) ──
 
 log "Pulling latest code..."
-git pull origin main 2>/dev/null || true
+if ! git pull origin main; then
+    log "git pull failed; aborting deploy before build/stop"
+    exit 1
+fi
+
+if ! pnpm exec tsx scripts/check-conflicts.ts; then
+    log "Unresolved git conflicts detected; aborting deploy before build/stop"
+    log "For append-only memory conflicts, run: pnpm exec tsx scripts/check-conflicts.ts --resolve-append-only"
+    exit 1
+fi
 
 log "Installing dependencies..."
 pnpm install --frozen-lockfile 2>/dev/null || pnpm install

--- a/src/conflict-governance.ts
+++ b/src/conflict-governance.ts
@@ -1,0 +1,111 @@
+export type ConflictClass = 'append-only-memory' | 'generated' | 'code' | 'config' | 'unknown';
+
+export interface ConflictFile {
+  path: string;
+  class: ConflictClass;
+  autoResolvable: boolean;
+  resolution: 'append-union' | 'regenerate' | 'manual-review';
+  reason: string;
+}
+
+export interface ConflictAssessment {
+  conflicted: ConflictFile[];
+  autoResolvable: ConflictFile[];
+  manual: ConflictFile[];
+  shouldBlock: boolean;
+  guidance: string[];
+}
+
+const APPEND_ONLY_MEMORY_RE = /^memory\/(?:inner-notes\.md|handoffs\/active\.md|topics\/.+\.md|threads\/.+\.md|research\/.+\.md)$/;
+const GENERATED_RE = /^(?:dist\/|memory\/topics\/\.summaries\/|memory\/index\/.+\.jsonl$)/;
+const CODE_RE = /^(?:src\/|tests\/|scripts\/|plugins\/|\.githooks\/).+/;
+const CONFIG_RE = /^(?:package\.json|pnpm-lock\.yaml|tsconfig\.json|agent-compose\.yaml|\.env(?:\..*)?)$/;
+
+export function assessConflicts(paths: string[]): ConflictAssessment {
+  const conflicted = unique(paths).map(classifyConflictPath);
+  const autoResolvable = conflicted.filter(f => f.autoResolvable);
+  const manual = conflicted.filter(f => !f.autoResolvable);
+  const guidance: string[] = [];
+
+  if (conflicted.length === 0) {
+    guidance.push('No unresolved git conflicts detected.');
+  } else {
+    guidance.push(`Detected ${conflicted.length} unresolved conflict(s).`);
+  }
+  if (autoResolvable.length > 0) {
+    guidance.push(`Auto-resolvable append-only memory files: ${autoResolvable.map(f => f.path).join(', ')}.`);
+  }
+  if (manual.length > 0) {
+    guidance.push(`Manual review required: ${manual.map(f => `${f.path} (${f.class})`).join(', ')}.`);
+  }
+
+  return {
+    conflicted,
+    autoResolvable,
+    manual,
+    shouldBlock: conflicted.length > 0,
+    guidance,
+  };
+}
+
+export function classifyConflictPath(path: string): ConflictFile {
+  if (APPEND_ONLY_MEMORY_RE.test(path)) {
+    return {
+      path,
+      class: 'append-only-memory',
+      autoResolvable: true,
+      resolution: 'append-union',
+      reason: 'memory markdown is append-oriented; preserve both sides and deduplicate exact lines',
+    };
+  }
+  if (GENERATED_RE.test(path)) {
+    return {
+      path,
+      class: 'generated',
+      autoResolvable: false,
+      resolution: 'regenerate',
+      reason: 'generated files should be rebuilt from source instead of hand-merged',
+    };
+  }
+  if (CODE_RE.test(path)) {
+    return {
+      path,
+      class: 'code',
+      autoResolvable: false,
+      resolution: 'manual-review',
+      reason: 'code conflicts need semantic review and tests',
+    };
+  }
+  if (CONFIG_RE.test(path)) {
+    return {
+      path,
+      class: 'config',
+      autoResolvable: false,
+      resolution: 'manual-review',
+      reason: 'configuration conflicts can change runtime behavior and require explicit review',
+    };
+  }
+  return {
+    path,
+    class: 'unknown',
+    autoResolvable: false,
+    resolution: 'manual-review',
+    reason: 'unknown file type defaults to manual review',
+  };
+}
+
+export function mergeAppendOnlyText(ours: string, theirs: string): string {
+  const lines: string[] = [];
+  const seen = new Set<string>();
+  for (const line of [...ours.split('\n'), ...theirs.split('\n')]) {
+    if (!line.trim()) continue;
+    if (seen.has(line)) continue;
+    seen.add(line);
+    lines.push(line);
+  }
+  return lines.join('\n') + (lines.length > 0 ? '\n' : '');
+}
+
+function unique(values: string[]): string[] {
+  return [...new Set(values.filter(Boolean))].sort((a, b) => a.localeCompare(b));
+}

--- a/tests/conflict-governance.test.ts
+++ b/tests/conflict-governance.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import {
+  assessConflicts,
+  classifyConflictPath,
+  mergeAppendOnlyText,
+} from '../src/conflict-governance.js';
+
+describe('conflict governance', () => {
+  it('allows append-only memory conflicts to use append-union resolution', () => {
+    expect(classifyConflictPath('memory/inner-notes.md')).toEqual(expect.objectContaining({
+      class: 'append-only-memory',
+      autoResolvable: true,
+      resolution: 'append-union',
+    }));
+    expect(classifyConflictPath('memory/topics/kuro.md')).toEqual(expect.objectContaining({
+      class: 'append-only-memory',
+      autoResolvable: true,
+    }));
+  });
+
+  it('requires manual review for code and config conflicts', () => {
+    expect(classifyConflictPath('src/github.ts')).toEqual(expect.objectContaining({
+      class: 'code',
+      autoResolvable: false,
+      resolution: 'manual-review',
+    }));
+    expect(classifyConflictPath('agent-compose.yaml')).toEqual(expect.objectContaining({
+      class: 'config',
+      autoResolvable: false,
+    }));
+  });
+
+  it('classifies generated conflicts as regenerate, not auto merge', () => {
+    expect(classifyConflictPath('dist/github.js')).toEqual(expect.objectContaining({
+      class: 'generated',
+      autoResolvable: false,
+      resolution: 'regenerate',
+    }));
+  });
+
+  it('blocks whenever unresolved conflicts exist and separates auto/manual sets', () => {
+    const assessment = assessConflicts([
+      'memory/inner-notes.md',
+      'src/github.ts',
+    ]);
+
+    expect(assessment.shouldBlock).toBe(true);
+    expect(assessment.autoResolvable.map(f => f.path)).toEqual(['memory/inner-notes.md']);
+    expect(assessment.manual.map(f => f.path)).toEqual(['src/github.ts']);
+  });
+
+  it('merges append-only text by preserving both sides and deduplicating exact lines', () => {
+    expect(mergeAppendOnlyText('a\nb\n', 'b\nc\n')).toBe('a\nb\nc\n');
+  });
+});


### PR DESCRIPTION
## Summary

Adds a conflict prevention and resolution workflow for mini-agent's file-truth/git-based runtime.

What this changes:
- Adds `src/conflict-governance.ts` to classify unresolved conflicts.
- Adds `scripts/check-conflicts.ts` for machine-checkable conflict status.
- Allows append-only memory markdown conflicts to be resolved by append-union with `--resolve-append-only`.
- Requires manual review for code/config/generated conflicts.
- Runs conflict checks in `.githooks/pre-push` before PR lifecycle checks.
- Makes `scripts/deploy.sh` fail closed if `git pull` fails or unresolved conflicts exist, before build/stop.

This specifically prevents the earlier bad pattern where deploy continued after `git pull origin main || true` while the worktree still had unresolved memory conflicts.

## Verification

- `pnpm exec vitest run tests/conflict-governance.test.ts` passed: 5 tests.
- `pnpm exec tsx scripts/check-conflicts.ts --json` passed on clean worktree.
- `pnpm typecheck` passed.
- `pnpm build` passed.
- `pnpm test` passed: 59 files, 516 passed, 2 skipped.