### PR TITLE
fix: unify default available actors

### DIFF
--- a/src/actor-selection-policy.ts
+++ b/src/actor-selection-policy.ts
@@ -7,7 +7,7 @@
  */
 
 import type { ActorId, WorkIntent, WorkItem, WorkRisk } from './brain-types.js';
-import { getActorProfile, type ActorProfile, type ActorRoleTendency } from './actor-registry.js';
+import { getActorProfile, getDefaultDispatchableActors, type ActorProfile, type ActorRoleTendency } from './actor-registry.js';
 import type { ActorOutcomeStats } from './actor-outcome-stats.js';
 
 export type SelectionRole = 'primary' | 'reviewer' | 'advisor' | 'executor';
@@ -23,8 +23,6 @@ export interface SelectionOptions {
   availableActors?: ActorId[];
   actorStats?: ActorOutcomeStats;
 }
-
-const DEFAULT_AVAILABLE: ActorId[] = ['claude', 'codex', 'local', 'shell', 'akari', 'human'];
 
 const INTENT_CAPABILITY_HINTS: Record<WorkIntent, string[]> = {
   chat: ['low-cost-reasoning', 'writing'],
@@ -46,7 +44,7 @@ export function rankActorsForRole(
   role: SelectionRole,
   opts: SelectionOptions = {},
 ): ActorScore[] {
-  const available = opts.availableActors ?? DEFAULT_AVAILABLE;
+  const available = opts.availableActors ?? getDefaultDispatchableActors();
   return available
     .map(actor => scoreActor(item, actor, role, opts))
     .filter((score): score is ActorScore => score !== null)

--- a/src/brain-health.ts
+++ b/src/brain-health.ts
@@ -8,6 +8,7 @@
 
 import type { ActorId, BrainProvider, PeerAgentId, ProviderHealth, ProviderId } from './brain-types.js';
 import type { PeerAgent } from './peer-agent.js';
+import { getActorProfile, getDefaultDispatchableActors } from './actor-registry.js';
 
 export interface BrainActorHealth {
   actor: ActorId;
@@ -24,7 +25,6 @@ export interface BrainHealthSnapshot {
 }
 
 const BUILT_INS: ActorId[] = ['kuro', 'human'];
-const DEFAULT_AVAILABLE: ActorId[] = ['claude', 'codex', 'local', 'shell', 'akari', 'tanren'];
 
 let cachedSnapshot: BrainHealthSnapshot | null = null;
 
@@ -60,16 +60,17 @@ export async function refreshBrainHealth(
 export function getCachedBrainHealthSnapshot(): BrainHealthSnapshot {
   if (cachedSnapshot) return cachedSnapshot;
   const checkedAt = new Date(0).toISOString();
+  const availableActors = getDefaultDispatchableActors();
   return {
     checkedAt,
-    actors: DEFAULT_AVAILABLE.map(actor => ({
+    actors: availableActors.map(actor => ({
       actor,
-      kind: isPeer(actor) ? 'peer' : 'provider',
+      kind: actorHealthKind(actor),
       available: true,
       checkedAt,
       detail: 'optimistic default before first health refresh',
     })),
-    availableActors: DEFAULT_AVAILABLE,
+    availableActors,
   };
 }
 
@@ -110,4 +111,10 @@ async function actorHealth(
 
 function isPeer(actor: ActorId): boolean {
   return actor === 'akari' || actor === 'tanren';
+}
+
+function actorHealthKind(actor: ActorId): BrainActorHealth['kind'] {
+  const profile = getActorProfile(actor);
+  if (profile?.kind === 'human' || profile?.kind === 'host-agent') return 'built-in';
+  return isPeer(actor) ? 'peer' : 'provider';
 }

--- a/src/github.ts
+++ b/src/github.ts
@@ -291,9 +291,7 @@ interface ReviewablePR {
   body?: string | null;
   isDraft?: boolean;
   reviewDecision?: string;
-  reviewRequests?: unknown[];
   labels?: Array<{ name: string }>;
-  author?: { login: string };
   url?: string;
 }
 
@@ -303,7 +301,7 @@ export async function autoTrackPrReviewNeeds(): Promise<void> {
 
   let prs: ReviewablePR[];
   try {
-    const { stdout } = await gh(['pr', 'list', '--state', 'open', '--json', 'number,title,body,isDraft,reviewDecision,reviewRequests,labels,author,url', '--limit', '50']);
+    const { stdout } = await gh(['pr', 'list', '--state', 'open', '--json', 'number,title,body,isDraft,reviewDecision,labels,url', '--limit', '50']);
     prs = JSON.parse(stdout);
   } catch {
     return;
@@ -371,8 +369,7 @@ function toOpenPrSummary(pr: ReviewablePR): OpenPullRequestSummary {
     title: pr.title,
     body: pr.body,
     reviewDecision: pr.reviewDecision,
-    reviewRequests: pr.reviewRequests,
-    authorLogin: pr.author?.login,
+    reviewRequests: [],
     labels: pr.labels?.map(l => l.name),
     isDraft: pr.isDraft,
   };
@@ -394,8 +391,6 @@ interface GhPrView {
   files?: Array<{ path: string }>;
   isDraft?: boolean;
   reviewDecision?: string;
-  reviewRequests?: unknown[];
-  author?: { login: string };
   url?: string;
 }
 
@@ -441,7 +436,7 @@ export async function autoProduceInternalPrReviewClaims(): Promise<void> {
 
 async function viewPullRequest(prNumber: number): Promise<GhPrView | null> {
   try {
-    const { stdout } = await gh(['pr', 'view', String(prNumber), '--json', 'number,title,body,labels,files,isDraft,reviewDecision,reviewRequests,author,url']);
+    const { stdout } = await gh(['pr', 'view', String(prNumber), '--json', 'number,title,body,labels,files,isDraft,reviewDecision,url']);
     return JSON.parse(stdout) as GhPrView;
   } catch {
     return null;

--- a/tests/actor-registry.test.ts
+++ b/tests/actor-registry.test.ts
@@ -44,6 +44,10 @@ describe('actor registry', () => {
     expect(getPeerCritiqueActors()).not.toContain('tanren');
   });
 
+  it('provides the canonical default dispatch actor set', () => {
+    expect(getDefaultDispatchableActors()).toEqual(['claude', 'codex', 'local', 'shell', 'akari', 'human']);
+  });
+
   it('keeps executors, memory, and sensors distinct from brains', () => {
     expect(getActorProfile('shell')).toEqual(expect.objectContaining({
       kind: 'executor',

--- a/tests/brain-health.test.ts
+++ b/tests/brain-health.test.ts
@@ -5,6 +5,7 @@ import {
   isBrainRuntimeDelegationEnabled,
   refreshBrainHealth,
 } from '../src/brain-health.js';
+import { getDefaultDispatchableActors } from '../src/actor-registry.js';
 import type { BrainProvider, ProviderId } from '../src/brain-types.js';
 
 const originalFlag = process.env.MINI_AGENT_DELEGATION_RUNTIME;
@@ -35,7 +36,12 @@ function provider(id: ProviderId, available: boolean): BrainProvider {
 describe('brain health registry', () => {
   it('starts with an optimistic cached actor set before refresh', () => {
     expect(getCachedBrainHealthSnapshot().checkedAt).toBe('1970-01-01T00:00:00.000Z');
-    expect(getCachedAvailableBrainActors()).toEqual(expect.arrayContaining(['claude', 'codex', 'shell']));
+    expect(getCachedAvailableBrainActors()).toEqual(getDefaultDispatchableActors());
+    expect(getCachedAvailableBrainActors()).not.toContain('kuro');
+    expect(getCachedAvailableBrainActors()).not.toContain('tanren');
+    expect(getCachedBrainHealthSnapshot().actors).toEqual(expect.arrayContaining([
+      expect.objectContaining({ actor: 'human', kind: 'built-in' }),
+    ]));
   });
 
   it('refreshes provider health and keeps built-in actors available', async () => {


### PR DESCRIPTION
## Summary
- Remove duplicated `DEFAULT_AVAILABLE` declarations from actor selection and brain health.
- Use `getDefaultDispatchableActors()` from `actor-registry.ts` as the single source of truth.
- Keep Kuro as a non-dispatchable built-in coordinator while excluding Tanren framework from default dispatch targets.
- Avoid requesting GitHub `author`/`reviewRequests` fields in PR automation because Kuro's token can manage PRs without `read:org`.
- Add regression coverage for the canonical default dispatch set and brain-health optimistic cache.

Closes #105.
Closes #106.

## Verification
- `rg "DEFAULT_AVAILABLE" src tests -n` → no matches
- Kuro-token PR list without `read:org` fields can read PR #107
- `pnpm exec vitest run tests/actor-registry.test.ts tests/actor-selection-policy.test.ts tests/brain-health.test.ts tests/brain-arbiter.test.ts` → 21 passed
- `pnpm exec vitest run tests/pr-review-runner.test.ts tests/pr-lifecycle-governance.test.ts tests/actor-registry.test.ts tests/brain-health.test.ts` → 30 passed
- `pnpm typecheck` → passed
- `pnpm build` → passed
- `pnpm test` → 59 files passed, 524 passed, 2 skipped