### PR TITLE
fix: retry PR review claims after input changes

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -387,6 +387,7 @@ interface GhPrView {
   number: number;
   title: string;
   body?: string | null;
+  headRefOid?: string;
   labels?: Array<{ name: string }>;
   files?: Array<{ path: string }>;
   isDraft?: boolean;
@@ -400,7 +401,7 @@ export async function autoProduceInternalPrReviewClaims(): Promise<void> {
   if (!fs.existsSync(activePath)) return;
 
   let handoffs = parsePrReviewHandoffs(fs.readFileSync(activePath, 'utf-8'));
-  handoffs = handoffs.filter(h => h.reviewer !== 'alex' && ['needs-review', 'review-pending'].includes(h.status));
+  handoffs = handoffs.filter(h => h.reviewer !== 'alex' && ['needs-review', 'review-pending', 'changes-requested'].includes(h.status));
   if (handoffs.length === 0) return;
 
   const byPr = new Map<number, typeof handoffs>();
@@ -421,6 +422,7 @@ export async function autoProduceInternalPrReviewClaims(): Promise<void> {
         prNumber,
         title: pr.title,
         body: pr.body,
+        headSha: pr.headRefOid,
         reviewer: row.reviewer,
         framework: assignment.framework,
         changedFiles: pr.files?.map(f => f.path).filter(Boolean) ?? [],
@@ -436,7 +438,7 @@ export async function autoProduceInternalPrReviewClaims(): Promise<void> {
 
 async function viewPullRequest(prNumber: number): Promise<GhPrView | null> {
   try {
-    const { stdout } = await gh(['pr', 'view', String(prNumber), '--json', 'number,title,body,labels,files,isDraft,reviewDecision,url']);
+    const { stdout } = await gh(['pr', 'view', String(prNumber), '--json', 'number,title,body,headRefOid,labels,files,isDraft,reviewDecision,url']);
     return JSON.parse(stdout) as GhPrView;
   } catch {
     return null;

--- a/src/pr-review-runner.ts
+++ b/src/pr-review-runner.ts
@@ -1,6 +1,6 @@
 import { appendFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
-import { randomUUID } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import { requiresHumanPrReview, type PrReviewFramework, type PrReviewer } from './pr-lifecycle-governance.js';
 
 export type PrReviewVerdict = 'approve' | 'request_changes' | 'comment';
@@ -14,6 +14,8 @@ export interface PrReviewClaimInput {
   risk: 'low' | 'medium' | 'high';
   summary: string;
   evidence: string[];
+  reviewInputHash?: string;
+  headSha?: string;
 }
 
 export interface PrReviewClaim extends PrReviewClaimInput {
@@ -43,6 +45,7 @@ export interface InternalPrReviewCandidate {
   prNumber: number;
   title: string;
   body?: string | null;
+  headSha?: string | null;
   reviewer: PrReviewer;
   framework: PrReviewFramework;
   changedFiles: string[];
@@ -69,6 +72,20 @@ export function createPrReviewClaim(input: PrReviewClaimInput, now = new Date())
     id: randomUUID(),
     createdAt: now.toISOString(),
   };
+}
+
+export function computePrReviewInputHash(candidate: InternalPrReviewCandidate): string {
+  const changedFiles = uniqueStrings(candidate.changedFiles);
+  return createHash('sha256')
+    .update(JSON.stringify({
+      prNumber: candidate.prNumber,
+      title: candidate.title,
+      body: candidate.body ?? '',
+      headSha: candidate.headSha ?? '',
+      changedFiles,
+    }))
+    .digest('hex')
+    .slice(0, 16);
 }
 
 export function appendPrReviewClaim(memoryDir: string, claim: PrReviewClaim): PrReviewClaim {
@@ -221,6 +238,8 @@ export function createInternalPrReviewClaim(candidate: InternalPrReviewCandidate
       risk: 'medium',
       summary: 'Internal review could not inspect changed-file evidence yet.',
       evidence: ['missing changed-file list'],
+      reviewInputHash: computePrReviewInputHash(candidate),
+      headSha: candidate.headSha ?? undefined,
     }, now);
   }
 
@@ -233,6 +252,8 @@ export function createInternalPrReviewClaim(candidate: InternalPrReviewCandidate
       risk: 'medium',
       summary: 'Code-affecting PR is missing verification evidence in the PR body.',
       evidence: changedFiles.slice(0, 8),
+      reviewInputHash: computePrReviewInputHash(candidate),
+      headSha: candidate.headSha ?? undefined,
     }, now);
   }
 
@@ -247,6 +268,8 @@ export function createInternalPrReviewClaim(candidate: InternalPrReviewCandidate
       ...changedFiles.slice(0, 8),
       ...(hasVerification ? ['PR body includes verification evidence'] : []),
     ],
+    reviewInputHash: computePrReviewInputHash(candidate),
+    headSha: candidate.headSha ?? undefined,
   }, now);
 }
 
@@ -256,14 +279,14 @@ export function appendMissingInternalPrReviewClaims(
   now = new Date(),
 ): InternalPrReviewClaimResult {
   const existing = readPrReviewClaimsSync(memoryDir);
-  const seen = new Set(existing.map(claim => `${claim.prNumber}:${claim.reviewer}`));
+  const seen = new Set(existing.map(reviewClaimKey));
   const created: PrReviewClaim[] = [];
   const skipped: InternalPrReviewClaimResult['skipped'] = [];
 
   for (const candidate of candidates) {
-    const key = `${candidate.prNumber}:${candidate.reviewer}`;
+    const key = `${candidate.prNumber}:${candidate.reviewer}:${computePrReviewInputHash(candidate)}`;
     if (seen.has(key)) {
-      skipped.push({ prNumber: candidate.prNumber, reviewer: candidate.reviewer, reason: 'claim already exists' });
+      skipped.push({ prNumber: candidate.prNumber, reviewer: candidate.reviewer, reason: 'claim already exists for this PR input' });
       continue;
     }
     const claim = createInternalPrReviewClaim(candidate, now);
@@ -298,6 +321,8 @@ function claimToRecord(claim: PrReviewClaim): Record<string, unknown> {
     risk: claim.risk,
     summary: claim.summary,
     evidence: claim.evidence,
+    review_input_hash: claim.reviewInputHash,
+    head_sha: claim.headSha,
     created_at: claim.createdAt,
   };
 }
@@ -314,16 +339,22 @@ function parseClaim(line: string): PrReviewClaim | null {
     const id = stringField(raw.id);
     const summary = stringField(raw.summary);
     const createdAt = stringField(raw.created_at ?? raw.createdAt);
+    const reviewInputHash = stringField(raw.review_input_hash ?? raw.reviewInputHash) || undefined;
+    const headSha = stringField(raw.head_sha ?? raw.headSha) || undefined;
     if (!id || !reviewer || !framework || !['approve', 'request_changes', 'comment'].includes(verdict)) return null;
     if (!['low', 'medium', 'high'].includes(risk)) return null;
     if (!Number.isInteger(prNumber) || prNumber <= 0 || !summary || !createdAt) return null;
     const evidence = Array.isArray(raw.evidence)
       ? raw.evidence.filter((item): item is string => typeof item === 'string')
       : [];
-    return { id, prNumber, reviewer, framework, verdict, risk, summary, evidence, createdAt };
+    return { id, prNumber, reviewer, framework, verdict, risk, summary, evidence, reviewInputHash, headSha, createdAt };
   } catch {
     return null;
   }
+}
+
+function reviewClaimKey(claim: PrReviewClaim): string {
+  return `${claim.prNumber}:${claim.reviewer}:${claim.reviewInputHash ?? 'legacy'}`;
 }
 
 function normalizeReviewer(value: string): PrReviewer | null {

--- a/tests/pr-review-runner.test.ts
+++ b/tests/pr-review-runner.test.ts
@@ -6,6 +6,7 @@ import {
   appendMissingInternalPrReviewClaims,
   appendPrReviewClaim,
   applyPrReviewConsensusToHandoffs,
+  computePrReviewInputHash,
   createPrReviewClaim,
   createInternalPrReviewClaim,
   evaluatePrReviewConsensus,
@@ -179,6 +180,7 @@ describe('PR review runner', () => {
       prNumber: 104,
       title: 'fix: harden conflict governance and Kuro actor semantics',
       body: '## Verification\n- `pnpm typecheck` passed\n- `pnpm test` passed',
+      headSha: 'abc123',
       reviewer: 'codex',
       framework: 'internal-governance',
       changedFiles: ['src/actor-registry.ts', 'tests/actor-registry.test.ts'],
@@ -189,6 +191,8 @@ describe('PR review runner', () => {
       reviewer: 'codex',
       verdict: 'approve',
       risk: 'medium',
+      headSha: 'abc123',
+      reviewInputHash: expect.any(String),
     }));
   });
 
@@ -207,6 +211,7 @@ describe('PR review runner', () => {
       prNumber: 104,
       title: 'fix: harden conflict governance',
       body: '## Verification\n- `pnpm test` passed',
+      headSha: 'abc123',
       reviewer,
       framework: 'internal-governance' as const,
       changedFiles: ['src/conflict-governance.ts', 'tests/conflict-governance.test.ts'],
@@ -218,5 +223,50 @@ describe('PR review runner', () => {
     expect(first.created).toHaveLength(3);
     expect(second.created).toHaveLength(0);
     expect(readPrReviewClaimsSync(tmpDir, 104)).toHaveLength(3);
+  });
+
+  it('creates a new review claim when the PR input changes after requested changes', () => {
+    const baseCandidate = {
+      prNumber: 104,
+      title: 'fix: harden conflict governance',
+      body: 'Missing verification section',
+      headSha: 'abc123',
+      reviewer: 'codex' as const,
+      framework: 'internal-governance' as const,
+      changedFiles: ['src/conflict-governance.ts'],
+    };
+    const fixedCandidate = {
+      ...baseCandidate,
+      body: '## Verification\n- `pnpm test` passed',
+    };
+
+    const first = appendMissingInternalPrReviewClaims(tmpDir, [baseCandidate], new Date('2026-05-06T00:00:00Z'));
+    const duplicate = appendMissingInternalPrReviewClaims(tmpDir, [baseCandidate], new Date('2026-05-06T00:01:00Z'));
+    const fixed = appendMissingInternalPrReviewClaims(tmpDir, [fixedCandidate], new Date('2026-05-06T00:02:00Z'));
+    const claims = readPrReviewClaimsSync(tmpDir, 104);
+
+    expect(first.created).toHaveLength(1);
+    expect(first.created[0].verdict).toBe('request_changes');
+    expect(duplicate.created).toHaveLength(0);
+    expect(fixed.created).toHaveLength(1);
+    expect(fixed.created[0].verdict).toBe('approve');
+    expect(claims).toHaveLength(2);
+    expect(new Set(claims.map(c => c.reviewInputHash)).size).toBe(2);
+  });
+
+  it('changes the review input fingerprint when the head sha changes', () => {
+    const candidate = {
+      prNumber: 104,
+      title: 'fix: harden conflict governance',
+      body: '## Verification\n- `pnpm test` passed',
+      reviewer: 'codex' as const,
+      framework: 'internal-governance' as const,
+      changedFiles: ['tests/conflict-governance.test.ts', 'src/conflict-governance.ts'],
+    };
+
+    expect(computePrReviewInputHash({ ...candidate, headSha: 'abc123' }))
+      .not.toBe(computePrReviewInputHash({ ...candidate, headSha: 'def456' }));
+    expect(computePrReviewInputHash({ ...candidate, changedFiles: [...candidate.changedFiles].reverse(), headSha: 'abc123' }))
+      .toBe(computePrReviewInputHash({ ...candidate, headSha: 'abc123' }));
   });
 });


### PR DESCRIPTION
## Problem

Internal PR review claims were deduplicated by `prNumber + reviewer` only. Once a reviewer requested changes for a PR, later edits to the PR body or head commit could not produce a fresh claim, so `changes-requested` handoffs could stay stuck forever.

## Solution

- Add a stable PR review input fingerprint based on PR number, title, body, head sha, and changed files.
- Persist `review_input_hash` and `head_sha` in `memory/index/pr-review-claims.jsonl` records.
- Deduplicate internal review claims by `prNumber + reviewer + reviewInputHash`.
- Allow `changes-requested` handoffs to be reconsidered by `autoProduceInternalPrReviewClaims`.
- Include `headRefOid` in `gh pr view` so updated commits generate a new review input.

## Verification

- `pnpm exec vitest run tests/pr-review-runner.test.ts tests/pr-lifecycle-governance.test.ts` passed: 24 tests
- `pnpm typecheck` passed
- `pnpm build` passed
- `pnpm test` passed: 59 files, 526 passed, 2 skipped
