### PR TITLE
fix: update PR bodies through REST automation

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -14,6 +14,7 @@
  */
 
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
@@ -481,7 +482,7 @@ export async function autoRepairPrVerificationEvidence(): Promise<void> {
       if (pr.labels?.some(label => label.name === 'hold')) continue;
       const fix = autofixPrVerificationSection(pr.body);
       if (!fix.changed) continue;
-      await gh(['pr', 'edit', String(consensus.prNumber), '--body', fix.body], 20000);
+      await updatePullRequestBody(consensus.prNumber, fix.body);
       slog('github', `auto-repaired PR #${consensus.prNumber} verification evidence: ${fix.reason}`);
     } catch {
       // Single PR repair failure should not block the loop.
@@ -495,6 +496,17 @@ async function viewPullRequest(prNumber: number): Promise<GhPrView | null> {
     return JSON.parse(stdout) as GhPrView;
   } catch {
     return null;
+  }
+}
+
+async function updatePullRequestBody(prNumber: number, body: string): Promise<void> {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mini-agent-pr-body-'));
+  const file = path.join(dir, 'body.json');
+  try {
+    fs.writeFileSync(file, JSON.stringify({ body }), 'utf-8');
+    await gh(['api', `repos/miles990/mini-agent/pulls/${prNumber}`, '-X', 'PATCH', '--input', file], 20000);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
   }
 }
 


### PR DESCRIPTION
## Problem

#109 added PR verification heading autorepair, but `gh pr edit --body` uses a GraphQL path that requests `login`. The Kuro token intentionally does not have `read:org`, so the repair can silently fail even with `repo` scope.

## Solution

- Replace `gh pr edit --body` with REST `gh api repos/miles990/mini-agent/pulls/{number} -X PATCH --input <json>`.
- Write the body update through a temporary JSON file so long PR bodies do not depend on argv limits or GraphQL fields.
- Keep cleanup in a `finally` block.

## Verification

- `pnpm exec vitest run tests/github-verification-autorepair.test.ts tests/pr-review-runner.test.ts` passed: 16 tests
- `pnpm typecheck` passed
- `pnpm build` passed
- `pnpm test` passed: 60 files, 530 passed, 2 skipped
