### PR TITLE
fix: accept tsc PR verification evidence

### DIFF
--- a/src/pr-review-runner.ts
+++ b/src/pr-review-runner.ts
@@ -227,7 +227,7 @@ export function createInternalPrReviewClaim(candidate: InternalPrReviewCandidate
   const changedFiles = uniqueStrings(candidate.changedFiles);
   const touchesCode = changedFiles.some(file => /^(src|tests|scripts|plugins|\.githooks)\//.test(file) || file === 'package.json');
   const hasVerification = /(^|\n)##\s+Verification\b/i.test(text)
-    && /\b(pnpm|vitest|test|typecheck|build|passed|smoke)\b/i.test(text);
+    && /\b(pnpm|npm|npx|vitest|tsc|test|typecheck|build|passed|passes|clean|smoke)\b/i.test(text);
 
   if (changedFiles.length === 0) {
     return createPrReviewClaim({

--- a/tests/pr-review-runner.test.ts
+++ b/tests/pr-review-runner.test.ts
@@ -196,6 +196,24 @@ describe('PR review runner', () => {
     }));
   });
 
+  it('accepts tsc verification evidence in PR bodies', () => {
+    const claim = createInternalPrReviewClaim({
+      prNumber: 89,
+      title: 'fix(loop): dump head bytes on hasMarker=false soft-gate skip',
+      body: '## Verification\n- [x] `tsc --noEmit` passes',
+      headSha: 'abc123',
+      reviewer: 'akari',
+      framework: 'tanren-review',
+      changedFiles: ['src/loop.ts'],
+    }, new Date('2026-05-06T00:00:00Z'));
+
+    expect(claim).toEqual(expect.objectContaining({
+      prNumber: 89,
+      reviewer: 'akari',
+      verdict: 'approve',
+    }));
+  });
+
   it('does not create internal claims for Alex review rows', () => {
     expect(createInternalPrReviewClaim({
       prNumber: 104,


### PR DESCRIPTION
## Problem

#89 was auto-repaired from `## Test plan` to `## Verification`, but the internal review rule still rejected its evidence because the accepted keyword list did not include `tsc` or `passes`.

## Solution

- Align internal PR review verification detection with the autorepair evidence detector.
- Accept common TypeScript verification terms: `npm`, `npx`, `tsc`, `passes`, and `clean`.
- Add regression coverage for `## Verification\n- [x] \`tsc --noEmit\` passes`.

## Verification

- `pnpm exec vitest run tests/pr-review-runner.test.ts tests/github-verification-autorepair.test.ts` passed: 17 tests
- `pnpm typecheck` passed
- `pnpm build` passed
