### PR TITLE
fix: version PR review input fingerprints

### DIFF
--- a/src/pr-review-runner.ts
+++ b/src/pr-review-runner.ts
@@ -59,6 +59,7 @@ export interface InternalPrReviewClaimResult {
 const PR_REVIEW_CLAIMS_FILE = 'pr-review-claims.jsonl';
 const PR_HANDOFF_RE = /^\|\s*github\s*\|\s*(\S+)\s*\|\s*PR #(\d+)\s+(.+?)\s*\|\s*([^|]+?)\s*\|/;
 const REVIEW_STATUSES = ['needs-review', 'review-pending', 'review-approved', 'changes-requested'];
+const REVIEW_INPUT_POLICY_VERSION = 2;
 
 export function getPrReviewClaimsPath(memoryDir: string): string {
   return path.join(memoryDir, 'index', PR_REVIEW_CLAIMS_FILE);
@@ -78,6 +79,7 @@ export function computePrReviewInputHash(candidate: InternalPrReviewCandidate): 
   const changedFiles = uniqueStrings(candidate.changedFiles);
   return createHash('sha256')
     .update(JSON.stringify({
+      policyVersion: REVIEW_INPUT_POLICY_VERSION,
       prNumber: candidate.prNumber,
       title: candidate.title,
       body: candidate.body ?? '',

--- a/tests/pr-review-runner.test.ts
+++ b/tests/pr-review-runner.test.ts
@@ -287,4 +287,18 @@ describe('PR review runner', () => {
     expect(computePrReviewInputHash({ ...candidate, changedFiles: [...candidate.changedFiles].reverse(), headSha: 'abc123' }))
       .toBe(computePrReviewInputHash({ ...candidate, headSha: 'abc123' }));
   });
+
+  it('uses the current review policy version in the input fingerprint', () => {
+    const hash = computePrReviewInputHash({
+      prNumber: 89,
+      title: 'fix(loop): dump head bytes on hasMarker=false soft-gate skip',
+      body: '## Verification\n- [x] `tsc --noEmit` passes',
+      headSha: 'a08d45898b3049b027c7b18a0d612e300b604333',
+      reviewer: 'akari',
+      framework: 'tanren-review',
+      changedFiles: ['src/loop.ts'],
+    });
+
+    expect(hash).not.toBe('888b5ec0d453625c');
+  });
 });


### PR DESCRIPTION
## Problem

After #111, the review rule accepts `tsc --noEmit passes`, but #89 still has an older request-changes claim for the same PR body/head hash. The input fingerprint only included PR input, not the review policy version, so policy improvements could not trigger a fresh internal review.

## Solution

- Add `REVIEW_INPUT_POLICY_VERSION` to the PR review input fingerprint payload.
- Bump the policy version to force re-review after the verification detector changed.
- Add regression coverage that the #89-style fingerprint no longer matches the old hash.

## Verification

- `pnpm exec vitest run tests/pr-review-runner.test.ts` passed: 14 tests
- `pnpm typecheck` passed
- `pnpm build` passed
