### PR TITLE
fix: add autonomous PR conflict diagnostics

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -23,6 +23,7 @@ import { writeInboxItem } from './inbox.js';
 import {
   closeMergedPrHandoffs,
   decidePrReviewAssignment,
+  decidePrConflictAction,
   type MergedPullRequestSummary,
   type OpenPullRequestSummary,
 } from './pr-lifecycle-governance.js';
@@ -393,6 +394,7 @@ interface GhPrView {
   files?: Array<{ path: string }>;
   isDraft?: boolean;
   reviewDecision?: string;
+  mergeable?: string;
   url?: string;
 }
 
@@ -492,7 +494,7 @@ export async function autoRepairPrVerificationEvidence(): Promise<void> {
 
 async function viewPullRequest(prNumber: number): Promise<GhPrView | null> {
   try {
-    const { stdout } = await gh(['pr', 'view', String(prNumber), '--json', 'number,title,body,headRefOid,labels,files,isDraft,reviewDecision,url']);
+    const { stdout } = await gh(['pr', 'view', String(prNumber), '--json', 'number,title,body,headRefOid,labels,files,isDraft,reviewDecision,mergeable,url']);
     return JSON.parse(stdout) as GhPrView;
   } catch {
     return null;
@@ -582,6 +584,49 @@ export async function autoMergeInternallyApprovedPR(): Promise<void> {
   }
 }
 
+// =============================================================================
+// 7b. Conflicting PRs → update branch or explicit diagnostic
+// =============================================================================
+
+export async function autoHandleConflictingPRs(): Promise<void> {
+  let prs: Array<{ number: number; mergeable?: string; labels?: Array<{ name: string }> }>;
+  try {
+    const { stdout } = await gh(['pr', 'list', '--state', 'open', '--json', 'number,mergeable,labels', '--limit', '50']);
+    prs = JSON.parse(stdout);
+  } catch {
+    return;
+  }
+
+  for (const summary of prs.filter(pr => pr.mergeable === 'CONFLICTING')) {
+    try {
+      const pr = await viewPullRequest(summary.number);
+      if (!pr) continue;
+      const decision = decidePrConflictAction({
+        number: pr.number,
+        title: pr.title,
+        body: pr.body,
+        mergeable: pr.mergeable,
+        reviewDecision: pr.reviewDecision,
+        labels: pr.labels?.map(label => label.name),
+        isDraft: pr.isDraft,
+        changedFiles: pr.files?.map(file => file.path).filter(Boolean) ?? [],
+      });
+
+      if (decision.action === 'attempt-update-branch') {
+        await gh(['pr', 'update-branch', String(pr.number)], 30000);
+        slog('github', `requested conflict update-branch for PR #${pr.number}: ${decision.reason}`);
+        continue;
+      }
+
+      if (decision.action === 'needs-decomposition' || decision.action === 'needs-verification') {
+        await recordConflictDiagnostic(pr, decision);
+      }
+    } catch {
+      // Single PR conflict handling failure should not block the loop.
+    }
+  }
+}
+
 function internalApprovalBody(summary: string): string {
   return [
     'Internal multi-brain review consensus approved this PR.',
@@ -590,6 +635,56 @@ function internalApprovalBody(summary: string): string {
     '',
     'File-truth source: memory/index/pr-review-claims.jsonl',
   ].join('\n');
+}
+
+async function recordConflictDiagnostic(pr: GhPrView, decision: { action: string; reason: string; risk: string }): Promise<void> {
+  const marker = `mini-agent:conflict-diagnostic:${pr.number}:${pr.headRefOid ?? 'unknown'}`;
+  if (await prHasCommentMarker(pr.number, marker)) return;
+
+  appendConflictHandoff(pr, decision);
+  await addPrComment(pr.number, [
+    `<!-- ${marker} -->`,
+    `Conflict diagnostic: ${decision.action}`,
+    '',
+    `Reason: ${decision.reason}`,
+    `Risk: ${decision.risk}`,
+    '',
+    'Autonomous action: not auto-merging this PR until the conflict is resolved.',
+    'Next step: split/rebuild the PR from current main or add completed verification evidence, then the review loop will re-evaluate it.',
+  ].join('\n'));
+  slog('github', `recorded conflict diagnostic for PR #${pr.number}: ${decision.action}`);
+}
+
+async function prHasCommentMarker(prNumber: number, marker: string): Promise<boolean> {
+  try {
+    const { stdout } = await gh(['api', `repos/miles990/mini-agent/issues/${prNumber}/comments`, '--paginate']);
+    const comments = JSON.parse(stdout) as Array<{ body?: string }>;
+    return comments.some(comment => comment.body?.includes(marker));
+  } catch {
+    return false;
+  }
+}
+
+async function addPrComment(prNumber: number, body: string): Promise<void> {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mini-agent-pr-comment-'));
+  const file = path.join(dir, 'comment.json');
+  try {
+    fs.writeFileSync(file, JSON.stringify({ body }), 'utf-8');
+    await gh(['api', `repos/miles990/mini-agent/issues/${prNumber}/comments`, '-X', 'POST', '--input', file], 20000);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function appendConflictHandoff(pr: GhPrView, decision: { action: string; reason: string }): void {
+  const activePath = path.join(process.cwd(), 'memory', 'handoffs', 'active.md');
+  if (!fs.existsSync(activePath)) return;
+  const content = fs.readFileSync(activePath, 'utf-8');
+  const marker = `PR #${pr.number} conflict diagnostic`;
+  if (content.includes(marker)) return;
+  const today = new Date().toISOString().slice(5, 10);
+  const row = `| github | kuro | ${marker}: ${escapeTable(pr.title)} (${decision.action}; ${escapeTable(decision.reason)}) | blocked | ${today} | - |`;
+  fs.writeFileSync(activePath, content.trimEnd() + '\n' + row + '\n', 'utf-8');
 }
 
 function statusChecksAcceptable(
@@ -733,6 +828,7 @@ export async function githubAutoActions(): Promise<void> {
   await autoApplyInternalPrReviewConsensus().catch(() => {});
   await autoMergeApprovedPR().catch(() => {});
   await autoMergeInternallyApprovedPR().catch(() => {});
+  await autoHandleConflictingPRs().catch(() => {});
   await autoTrackMergedPrClosures().catch(() => {});
   await autoTrackNewIssues().catch(() => {});
 }

--- a/src/pr-lifecycle-governance.ts
+++ b/src/pr-lifecycle-governance.ts
@@ -47,6 +47,25 @@ export interface HandoffClosureResult {
   appended: number;
 }
 
+export type PrConflictAction = 'none' | 'attempt-update-branch' | 'needs-decomposition' | 'needs-verification';
+
+export interface PrConflictInput {
+  number: number;
+  title: string;
+  body?: string | null;
+  mergeable?: string | null;
+  reviewDecision?: string | null;
+  labels?: string[];
+  isDraft?: boolean;
+  changedFiles: string[];
+}
+
+export interface PrConflictDecision {
+  action: PrConflictAction;
+  reason: string;
+  risk: 'low' | 'medium' | 'high';
+}
+
 export interface BranchLifecycleInput {
   branch: string | null;
   baseBranch: string;
@@ -260,6 +279,32 @@ export function closeMergedPrHandoffs(
   return { content: content + '\n', updated, appended };
 }
 
+export function decidePrConflictAction(pr: PrConflictInput): PrConflictDecision {
+  const labels = new Set((pr.labels ?? []).map(l => l.toLowerCase()));
+  if (pr.mergeable !== 'CONFLICTING') {
+    return { action: 'none', risk: 'low', reason: 'PR is not currently marked conflicting' };
+  }
+  if (pr.isDraft || labels.has('hold')) {
+    return { action: 'none', risk: 'medium', reason: 'draft or hold PR should not be conflict-updated automatically' };
+  }
+
+  const files = uniqueStrings(pr.changedFiles);
+  if (!hasCompletedVerification(pr.body ?? '')) {
+    return { action: 'needs-verification', risk: 'medium', reason: 'conflicting PR lacks completed verification evidence' };
+  }
+  if (isScopeBroad(files)) {
+    return {
+      action: 'needs-decomposition',
+      risk: 'high',
+      reason: `conflict spans broad scope (${files.length} files) and should be split or rebuilt from main`,
+    };
+  }
+  if (pr.reviewDecision === 'APPROVED') {
+    return { action: 'attempt-update-branch', risk: 'medium', reason: 'approved conflicting PR has narrow verified scope' };
+  }
+  return { action: 'none', risk: 'medium', reason: 'conflicting PR is waiting for review approval before branch update' };
+}
+
 function pickReviewAssignment(pr: OpenPullRequestSummary): {
   reviewers: [PrReviewer, ...PrReviewer[]];
   framework: PrReviewFramework;
@@ -296,10 +341,48 @@ function riskClass(pr: OpenPullRequestSummary): string {
   return 'standard';
 }
 
+function hasCompletedVerification(text: string): boolean {
+  const section = extractMarkdownSection(text, /^##\s+Verification\b/im);
+  if (!section) return false;
+  return /(?:^|\n)\s*-\s*\[[xX]\]\s+/.test(section)
+    || /\b(?:passed|passes|clean|success|ok)\b/i.test(section);
+}
+
+function extractMarkdownSection(text: string, heading: RegExp): string | null {
+  const match = heading.exec(text);
+  if (!match) return null;
+  const start = match.index;
+  const rest = text.slice(start);
+  const next = rest.slice(match[0].length).search(/\n##\s+/);
+  return next >= 0 ? rest.slice(0, match[0].length + next) : rest;
+}
+
+function isScopeBroad(files: string[]): boolean {
+  if (files.length > 6) return true;
+  const domains = new Set(files.map(fileDomain));
+  if (domains.size > 3) return true;
+  return files.some(file => /^memory\/(?:handoffs|topics|MEMORY\.md)/.test(file))
+    && files.some(file => /^(src|tests|scripts|\.githooks|package\.json)/.test(file));
+}
+
+function fileDomain(file: string): string {
+  if (file === 'package.json' || file === 'pnpm-lock.yaml') return 'package';
+  if (file.startsWith('src/')) return `src/${file.split('/')[1] ?? ''}`;
+  if (file.startsWith('tests/')) return 'tests';
+  if (file.startsWith('memory/')) return 'memory';
+  if (file.startsWith('scripts/')) return 'scripts';
+  if (file.startsWith('.githooks/')) return 'hooks';
+  return file.split('/')[0] ?? file;
+}
+
 function formatRefs(refs: number[]): string {
   return refs.length > 0 ? refs.map(ref => `#${ref}`).join(', ') : '(none)';
 }
 
 function uniqueNumbers(values: number[]): number[] {
   return [...new Set(values)].sort((a, b) => a - b);
+}
+
+function uniqueStrings(values: string[]): string[] {
+  return [...new Set(values.filter(Boolean))].sort((a, b) => a.localeCompare(b));
 }

--- a/tests/pr-lifecycle-governance.test.ts
+++ b/tests/pr-lifecycle-governance.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   analyzeBranchLifecycle,
   closeMergedPrHandoffs,
+  decidePrConflictAction,
   decidePrReviewAssignment,
   extractAllowedIssueRefs,
   extractIssueRefs,
@@ -189,5 +190,56 @@ describe('PR lifecycle governance', () => {
     expect(result.content).toContain('| github | akari | PR #98 fix: gate PR branch scope contamination | merged | 05-06 | 05-07 |');
     expect(result.content).toContain('| github | codex | PR #98 fix: gate PR branch scope contamination | merged | 05-06 | 05-07 |');
     expect(result.content).toContain('| github | kuro | PR #99 fix: another / task | merged | 05-07 | 05-07 |');
+  });
+
+  it('attempts branch update for approved narrow verified conflicts', () => {
+    expect(decidePrConflictAction({
+      number: 12,
+      title: 'fix: narrow bug',
+      body: '## Verification\n- [x] `pnpm test` passed',
+      mergeable: 'CONFLICTING',
+      reviewDecision: 'APPROVED',
+      changedFiles: ['src/feedback-loops.ts', 'tests/feedback-loops.test.ts'],
+    })).toEqual(expect.objectContaining({
+      action: 'attempt-update-branch',
+      risk: 'medium',
+    }));
+  });
+
+  it('routes broad conflicting PRs to decomposition instead of blind branch update', () => {
+    expect(decidePrConflictAction({
+      number: 90,
+      title: 'fix(feedback-loops): capture sampleMsg',
+      body: '## Verification\n- [x] `npx tsc --noEmit` clean',
+      mergeable: 'CONFLICTING',
+      reviewDecision: 'APPROVED',
+      changedFiles: [
+        '.githooks/post-commit',
+        'memory/handoffs/active.md',
+        'package.json',
+        'src/dispatcher.ts',
+        'src/feedback-loops.ts',
+        'src/housekeeping.ts',
+        'src/loop.ts',
+        'src/workspace-finalizer.ts',
+        'tests/workspace-finalizer.test.ts',
+      ],
+    })).toEqual(expect.objectContaining({
+      action: 'needs-decomposition',
+      risk: 'high',
+    }));
+  });
+
+  it('requires verification before conflict update', () => {
+    expect(decidePrConflictAction({
+      number: 93,
+      title: 'chore(hooks): post-commit auto-rebuild',
+      body: '## Test plan\n- [ ] Verify later',
+      mergeable: 'CONFLICTING',
+      reviewDecision: '',
+      changedFiles: ['.githooks/post-commit', 'package.json'],
+    })).toEqual(expect.objectContaining({
+      action: 'needs-verification',
+    }));
   });
 });


### PR DESCRIPTION
## Problem

Approved PRs can still get stuck when GitHub reports `CONFLICTING`. The previous automation only retried merge and swallowed failures, so #90/#93 had no explicit conflict-resolution state.

## Solution

- Add `decidePrConflictAction()` to classify conflicting PRs.
- Narrow, verified, approved conflicts can request `gh pr update-branch` automatically.
- Broad scope-contaminated conflicts are not blindly merged; they get a REST PR comment and a `memory/handoffs/active.md` blocked diagnostic row.
- Verification-missing conflicts get an explicit diagnostic instead of repeating merge attempts.
- Wire `autoHandleConflictingPRs()` into `githubAutoActions()` after merge attempts.

## Verification

- `pnpm exec vitest run tests/pr-lifecycle-governance.test.ts tests/pr-review-runner.test.ts` passed: 29 tests
- `pnpm typecheck` passed
- `pnpm build` passed
- `pnpm test` passed: 61 files, 547 passed, 2 skipped
