### PR TITLE
fix: isolate autonomous workspace writes

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -639,9 +639,9 @@ function internalApprovalBody(summary: string): string {
 
 async function recordConflictDiagnostic(pr: GhPrView, decision: { action: string; reason: string; risk: string }): Promise<void> {
   const marker = `mini-agent:conflict-diagnostic:${pr.number}:${pr.headRefOid ?? 'unknown'}`;
+  appendConflictHandoff(pr, decision);
   if (await prHasCommentMarker(pr.number, marker)) return;
 
-  appendConflictHandoff(pr, decision);
   await addPrComment(pr.number, [
     `<!-- ${marker} -->`,
     `Conflict diagnostic: ${decision.action}`,


### PR DESCRIPTION
## Summary
- keep conflict diagnostic handoff repair independent from PR comment dedupe
- route all workspace-writing autonomous delegations through forge worktrees, not only code tasks
- block protected service-checkout writes when forge allocation fails instead of falling back to the deploy workspace

## Verification
- [x] pnpm exec vitest run tests/delegation-arbiter.test.ts tests/pr-lifecycle-governance.test.ts tests/pr-review-runner.test.ts
- [x] pnpm typecheck
- [x] pnpm build