### PR TITLE
fix: consolidate autonomous workspace isolation

### DIFF
--- a/src/delegation.ts
+++ b/src/delegation.ts
@@ -23,7 +23,7 @@ import type { DelegationTaskType, Provider } from './types.js';
 import { writeActivity } from './activity-journal.js';
 import { createTask, updateTask } from './memory-index.js';
 import { middleware, type PlanStepSpec, type PlanStatus } from './middleware-client.js';
-import { forgeCreate, forgeYolo, forgeCleanup } from './forge.js';
+import { finalizeForgeWorkspace, prepareForgeWorkspace, type ForgeOutcome } from './forge.js';
 import { extractDelegationSummary, buildRecentDelegationSummary, persistDelegationResult, writeLaneOutput } from './delegation-summary.js';
 import { decideArbitration } from './brain-arbiter.js';
 import type { ArbitrationDecision, WorkIntent, WorkItem, WorkPriority, WorkRisk } from './brain-types.js';
@@ -69,13 +69,6 @@ export interface VerifyResult {
   cmd: string;
   passed: boolean;
   output: string;
-}
-
-export interface ForgeOutcome {
-  worktree: string;
-  created: boolean;
-  merged: boolean;
-  cleaned: boolean;
 }
 
 export interface TaskResult {
@@ -257,14 +250,17 @@ export function spawnDelegation(task: DelegationTask): string {
     slog('DELEGATION', `Capacity reached (${activeTasks.size}/${MAX_CONCURRENT}) — middleware will queue ${taskId}`);
   }
 
-  // Forge (§Q2): allocate isolated worktrees for all workspace-writing work
-  // before submitting the plan. The main service checkout is deploy/runtime
-  // truth; autonomous edits must not fall back to mutating it directly.
+  // Forge (§Q2): workspace isolation is a single adapter decision. Delegation
+  // only consumes the prepared cwd; forge owns worktree allocation policy.
   const needsWorkspaceIsolation = workItem.risk === 'workspace_write';
-  const forgeWorktree = task.forgeWorktree ?? (needsWorkspaceIsolation
-    ? forgeCreate(taskId, workdir, taskType) ?? undefined
-    : undefined);
-  const cwd = forgeWorktree ?? workdir;
+  const preparedWorkspace = prepareForgeWorkspace({
+    taskId,
+    workdir,
+    taskType,
+    requiresIsolation: needsWorkspaceIsolation,
+    explicitWorktree: task.forgeWorktree,
+  });
+  const cwd = preparedWorkspace.cwd;
 
   const result: TaskResult = {
     id: taskId,
@@ -276,13 +272,13 @@ export function spawnDelegation(task: DelegationTask): string {
 
   // Synchronously reserve the slot so callers see the task via listTasks/getActiveDelegationSummaries.
   // planId gets filled in once /plan returns (or cleared on failure).
-  const entry: ActiveEntry = { planId: '', result, task, forgeWorktree, arbitration };
+  const entry: ActiveEntry = { planId: '', result, task, forgeWorktree: preparedWorkspace.worktree, arbitration };
   activeTasks.set(taskId, entry);
 
-  if (needsWorkspaceIsolation && !forgeWorktree && isProtectedServiceWorkspace(workdir)) {
+  if (preparedWorkspace.blockedReason) {
     finalizeTask(entry, {
       status: 'failed',
-      output: `blocked by workspace isolation policy: forge worktree allocation failed for protected service workspace ${workdir}`,
+      output: preparedWorkspace.blockedReason,
     });
     return taskId;
   }
@@ -682,10 +678,6 @@ function riskForDelegationType(type: DelegationTaskType, task: DelegationTask): 
   return 'read_only';
 }
 
-function isProtectedServiceWorkspace(workdir: string): boolean {
-  return path.resolve(workdir) === path.resolve(process.cwd());
-}
-
 function priorityForDelegation(task: DelegationTask): WorkPriority {
   if (/\b(P0|urgent|ASAP|緊急|馬上)\b/i.test(task.prompt)) return 'P0';
   if (/\b(P2|low priority|低優先)\b/i.test(task.prompt)) return 'P2';
@@ -742,21 +734,14 @@ function finalizeTask(
 
   // Forge merge/cleanup on completion
   if (forgeWorktree) {
-    const forgeOutcome: ForgeOutcome = { worktree: forgeWorktree, created: true, merged: false, cleaned: false };
-    if (result.status === 'completed') {
-      const merged = forgeYolo(forgeWorktree, task.workdir, task.prompt.slice(0, 80));
-      forgeOutcome.merged = merged;
-      if (!merged) {
-        result.output += '\n[forge] merge skipped (verify failed or no changes)';
-        forgeCleanup(forgeWorktree, task.workdir);
-        forgeOutcome.cleaned = true;
-      }
-    } else {
-      slog('FORGE', `Cleaning up failed worktree ${forgeWorktree} (status=${result.status})`);
-      forgeCleanup(forgeWorktree, task.workdir);
-      forgeOutcome.cleaned = true;
-    }
-    result.forge = forgeOutcome;
+    const finalized = finalizeForgeWorkspace({
+      worktree: forgeWorktree,
+      mainDir: task.workdir,
+      status: result.status,
+      message: task.prompt.slice(0, 80),
+    });
+    if (finalized.outputSuffix) result.output += finalized.outputSuffix;
+    result.forge = finalized.outcome;
   }
 
   slog('DELEGATION', `Finished ${result.id}: ${result.status} in ${Math.round((result.duration ?? 0) / 1000)}s`);

--- a/src/delegation.ts
+++ b/src/delegation.ts
@@ -257,8 +257,11 @@ export function spawnDelegation(task: DelegationTask): string {
     slog('DELEGATION', `Capacity reached (${activeTasks.size}/${MAX_CONCURRENT}) — middleware will queue ${taskId}`);
   }
 
-  // Forge (§Q2): allocate worktree for code workers here, before submitting plan.
-  const forgeWorktree = task.forgeWorktree ?? (taskType === 'code'
+  // Forge (§Q2): allocate isolated worktrees for all workspace-writing work
+  // before submitting the plan. The main service checkout is deploy/runtime
+  // truth; autonomous edits must not fall back to mutating it directly.
+  const needsWorkspaceIsolation = workItem.risk === 'workspace_write';
+  const forgeWorktree = task.forgeWorktree ?? (needsWorkspaceIsolation
     ? forgeCreate(taskId, workdir, taskType) ?? undefined
     : undefined);
   const cwd = forgeWorktree ?? workdir;
@@ -275,6 +278,14 @@ export function spawnDelegation(task: DelegationTask): string {
   // planId gets filled in once /plan returns (or cleared on failure).
   const entry: ActiveEntry = { planId: '', result, task, forgeWorktree, arbitration };
   activeTasks.set(taskId, entry);
+
+  if (needsWorkspaceIsolation && !forgeWorktree && isProtectedServiceWorkspace(workdir)) {
+    finalizeTask(entry, {
+      status: 'failed',
+      output: `blocked by workspace isolation policy: forge worktree allocation failed for protected service workspace ${workdir}`,
+    });
+    return taskId;
+  }
 
   writeActivity({
     lane: 'background',
@@ -669,6 +680,10 @@ function riskForDelegationType(type: DelegationTaskType, task: DelegationTask): 
     return 'workspace_write';
   }
   return 'read_only';
+}
+
+function isProtectedServiceWorkspace(workdir: string): boolean {
+  return path.resolve(workdir) === path.resolve(process.cwd());
 }
 
 function priorityForDelegation(task: DelegationTask): WorkPriority {

--- a/src/forge.ts
+++ b/src/forge.ts
@@ -19,6 +19,19 @@ export interface ForgeSlotStatus {
   source: 'plugin' | 'bundled';
 }
 
+export interface ForgeOutcome {
+  worktree: string;
+  created: boolean;
+  merged: boolean;
+  cleaned: boolean;
+}
+
+export interface PreparedForgeWorkspace {
+  cwd: string;
+  worktree?: string;
+  blockedReason?: string;
+}
+
 // Task types that don't need dependency installation (pure docs/review work)
 const NO_INSTALL_TYPES: Set<DelegationTaskType> = new Set(['create', 'review', 'learn', 'research', 'plan', 'debug']);
 
@@ -47,6 +60,25 @@ export function forgeCreate(taskId: string, workdir: string, taskType?: Delegati
   }
 }
 
+export function prepareForgeWorkspace(opts: {
+  taskId: string;
+  workdir: string;
+  taskType?: DelegationTaskType;
+  requiresIsolation: boolean;
+  explicitWorktree?: string;
+}): PreparedForgeWorkspace {
+  if (!opts.requiresIsolation) return { cwd: opts.workdir };
+  if (opts.explicitWorktree) return { cwd: opts.explicitWorktree, worktree: opts.explicitWorktree };
+
+  const worktree = forgeCreate(opts.taskId, opts.workdir, opts.taskType) ?? undefined;
+  if (worktree) return { cwd: worktree, worktree };
+
+  return {
+    cwd: opts.workdir,
+    blockedReason: `blocked by workspace isolation policy: forge worktree allocation failed for ${opts.workdir}`,
+  };
+}
+
 export function forgeYolo(worktreePath: string, mainDir: string, message: string): boolean {
   try {
     forgeExec(`yolo "${worktreePath}" "${message}"`, mainDir, 120_000);
@@ -59,6 +91,29 @@ export function forgeYolo(worktreePath: string, mainDir: string, message: string
 /** @DANGEROUS _reason: deletes the worktree — only call after yolo failed or task aborted */
 export function forgeCleanup(worktreePath: string, mainDir: string): void {
   try { forgeExec(`cleanup "${worktreePath}"`, mainDir); } catch { /* best effort */ }
+}
+
+export function finalizeForgeWorkspace(opts: {
+  worktree: string;
+  mainDir: string;
+  status: 'completed' | 'failed' | 'timeout';
+  message: string;
+}): { outcome: ForgeOutcome; outputSuffix?: string } {
+  const outcome: ForgeOutcome = { worktree: opts.worktree, created: true, merged: false, cleaned: false };
+  if (opts.status === 'completed') {
+    outcome.merged = forgeYolo(opts.worktree, opts.mainDir, opts.message);
+    if (!outcome.merged) {
+      forgeCleanup(opts.worktree, opts.mainDir);
+      outcome.cleaned = true;
+      return { outcome, outputSuffix: '\n[forge] merge skipped (verify failed or no changes)' };
+    }
+    return { outcome };
+  }
+
+  slog('FORGE', `Cleaning up failed worktree ${opts.worktree} (status=${opts.status})`);
+  forgeCleanup(opts.worktree, opts.mainDir);
+  outcome.cleaned = true;
+  return { outcome };
 }
 
 export function forgeRecover(workdir: string): void {

--- a/tests/delegation-arbiter.test.ts
+++ b/tests/delegation-arbiter.test.ts
@@ -30,9 +30,14 @@ vi.mock('../src/middleware-client.js', () => ({
 }));
 
 vi.mock('../src/forge.js', () => ({
-  forgeCreate: vi.fn(() => null),
-  forgeYolo: vi.fn(() => false),
-  forgeCleanup: vi.fn(),
+  prepareForgeWorkspace: vi.fn((opts: { workdir: string; requiresIsolation: boolean }) => ({
+    cwd: opts.requiresIsolation ? '/repo-forge/default' : opts.workdir,
+    ...(opts.requiresIsolation ? { worktree: '/repo-forge/default' } : {}),
+  })),
+  finalizeForgeWorkspace: vi.fn((opts: { worktree: string }) => ({
+    outcome: { worktree: opts.worktree, created: true, merged: false, cleaned: true },
+    outputSuffix: '\n[forge] merge skipped (verify failed or no changes)',
+  })),
 }));
 
 vi.mock('../src/delegation-summary.js', () => ({
@@ -58,12 +63,15 @@ import {
   killAllDelegations,
   spawnDelegation,
 } from '../src/delegation.js';
-import { forgeCreate } from '../src/forge.js';
+import { prepareForgeWorkspace } from '../src/forge.js';
 
 beforeEach(() => {
   delete process.env.MINI_AGENT_DELEGATION_RUNTIME;
-  vi.mocked(forgeCreate).mockReset();
-  vi.mocked(forgeCreate).mockReturnValue(null);
+  vi.mocked(prepareForgeWorkspace).mockReset();
+  vi.mocked(prepareForgeWorkspace).mockImplementation((opts: { workdir: string; requiresIsolation: boolean }) => ({
+    cwd: opts.requiresIsolation ? '/repo-forge/default' : opts.workdir,
+    ...(opts.requiresIsolation ? { worktree: '/repo-forge/default' } : {}),
+  }));
   killAllDelegations();
 });
 
@@ -134,7 +142,7 @@ describe('delegation arbitration mapping', () => {
   });
 
   it('allocates forge worktrees for create delegations that can write workspace files', () => {
-    vi.mocked(forgeCreate).mockReturnValueOnce('/repo-forge/create-1');
+    vi.mocked(prepareForgeWorkspace).mockReturnValueOnce({ cwd: '/repo-forge/create-1', worktree: '/repo-forge/create-1' });
 
     const id = spawnDelegation({
       prompt: 'Create docs/guide.md',
@@ -143,11 +151,19 @@ describe('delegation arbitration mapping', () => {
     });
 
     expect(getTaskResult(id)?.status).toBe('running');
-    expect(forgeCreate).toHaveBeenCalledWith(id, '/repo', 'create');
+    expect(prepareForgeWorkspace).toHaveBeenCalledWith(expect.objectContaining({
+      taskId: id,
+      workdir: '/repo',
+      taskType: 'create',
+      requiresIsolation: true,
+    }));
   });
 
-  it('blocks protected service workspace writes when forge allocation fails', () => {
-    vi.mocked(forgeCreate).mockReturnValueOnce(null);
+  it('blocks workspace writes when forge allocation fails', () => {
+    vi.mocked(prepareForgeWorkspace).mockReturnValueOnce({
+      cwd: process.cwd(),
+      blockedReason: 'blocked by workspace isolation policy: forge worktree allocation failed for repo',
+    });
 
     const id = spawnDelegation({
       prompt: 'Update src/agent.ts',

--- a/tests/delegation-arbiter.test.ts
+++ b/tests/delegation-arbiter.test.ts
@@ -58,9 +58,12 @@ import {
   killAllDelegations,
   spawnDelegation,
 } from '../src/delegation.js';
+import { forgeCreate } from '../src/forge.js';
 
 beforeEach(() => {
   delete process.env.MINI_AGENT_DELEGATION_RUNTIME;
+  vi.mocked(forgeCreate).mockReset();
+  vi.mocked(forgeCreate).mockReturnValue(null);
   killAllDelegations();
 });
 
@@ -128,6 +131,33 @@ describe('delegation arbitration mapping', () => {
         fileScopes: ['src/agent.ts'],
       }),
     ]);
+  });
+
+  it('allocates forge worktrees for create delegations that can write workspace files', () => {
+    vi.mocked(forgeCreate).mockReturnValueOnce('/repo-forge/create-1');
+
+    const id = spawnDelegation({
+      prompt: 'Create docs/guide.md',
+      workdir: '/repo',
+      type: 'create',
+    });
+
+    expect(getTaskResult(id)?.status).toBe('running');
+    expect(forgeCreate).toHaveBeenCalledWith(id, '/repo', 'create');
+  });
+
+  it('blocks protected service workspace writes when forge allocation fails', () => {
+    vi.mocked(forgeCreate).mockReturnValueOnce(null);
+
+    const id = spawnDelegation({
+      prompt: 'Update src/agent.ts',
+      workdir: process.cwd(),
+      type: 'code',
+    });
+
+    expect(getTaskResult(id)?.status).toBe('failed');
+    expect(getTaskResult(id)?.output).toContain('workspace isolation policy');
+    expect(getActiveWriteLeases()).toHaveLength(0);
   });
 
   it('blocks overlapping write scopes instead of dispatching them', () => {


### PR DESCRIPTION
## Summary
- make forge the high-level autonomous workspace adapter, not only a low-level shell wrapper
- route workspace-write delegations through one prepare/finalize interface
- block workspace-write tasks when forge cannot allocate an isolated worktree instead of falling back to direct repo mutation
- keep delegation focused on arbitration, leases, dispatch, and result recording

## Verification
- [x] pnpm exec vitest run tests/delegation-arbiter.test.ts tests/pr-lifecycle-governance.test.ts tests/pr-review-runner.test.ts
- [x] pnpm typecheck
- [x] pnpm build