### PR TITLE
fix: queue autonomous maintenance for blocked debt

### DIFF
--- a/src/self-research-autopilot.ts
+++ b/src/self-research-autopilot.ts
@@ -6,7 +6,7 @@
  * scheduler and verification gate.
  */
 
-import { existsSync, readdirSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import path from 'node:path';
 import { eventBus } from './event-bus.js';
 import { createTask, queryMemoryIndexSync, type MemoryIndexEntry } from './memory-index.js';
@@ -24,6 +24,15 @@ export interface SelfResearchAutopilotResult {
   run?: SelfResearchRun;
   proposalPath?: string;
   task?: MemoryIndexEntry;
+  maintenance?: MaintenanceDebt;
+}
+
+export interface MaintenanceDebt {
+  kind: 'pr-conflict';
+  prNumber: number;
+  title: string;
+  action: 'needs-decomposition' | 'needs-verification';
+  reason: string;
 }
 
 export async function maybeQueueSelfResearch(
@@ -40,6 +49,13 @@ export async function maybeQueueSelfResearch(
     return { queued: false, reason: `suppressed-by-correction:${correction.reasons[0]?.type ?? 'unknown'}` };
   }
 
+  const openTasks = queryMemoryIndexSync(memoryDir, {
+    type: ['task'],
+    status: ['pending', 'in_progress', 'needs-decomposition', 'blocked', 'hold'],
+  });
+  const queuedMaintenance = await maybeQueueMaintenance(memoryDir, openTasks);
+  if (queuedMaintenance) return queuedMaintenance;
+
   const activeTasks = queryMemoryIndexSync(memoryDir, {
     type: ['task'],
     status: ['pending', 'in_progress', 'needs-decomposition', 'blocked'],
@@ -48,10 +64,7 @@ export async function maybeQueueSelfResearch(
     return { queued: false, reason: 'active-tasks-present' };
   }
 
-  const existing = queryMemoryIndexSync(memoryDir, {
-    type: ['task'],
-    status: ['pending', 'in_progress', 'needs-decomposition', 'blocked', 'hold'],
-  }).find(entry => (entry.summary ?? '').includes('execute self-research'));
+  const existing = openTasks.find(entry => (entry.summary ?? '').includes('execute self-research'));
   if (existing) {
     return { queued: false, reason: 'self-research-task-exists' };
   }
@@ -78,6 +91,99 @@ export async function maybeQueueSelfResearch(
   });
 
   return { queued: true, reason: 'queued', run, proposalPath, task };
+}
+
+async function maybeQueueMaintenance(
+  memoryDir: string,
+  openTasks: MemoryIndexEntry[],
+): Promise<SelfResearchAutopilotResult | null> {
+  const debt = findTopMaintenanceDebt(memoryDir);
+  if (!debt) return null;
+
+  const marker = `autonomous maintenance PR #${debt.prNumber}`;
+  if (openTasks.some(task => (task.summary ?? '').includes(marker))) {
+    return { queued: false, reason: 'maintenance-task-exists', maintenance: debt };
+  }
+
+  const activeNonMaintenance = openTasks.filter(task =>
+    ['pending', 'in_progress', 'needs-decomposition'].includes(String(task.status))
+    && !(task.summary ?? '').includes('autonomous maintenance'),
+  );
+  if (activeNonMaintenance.length > 0) return null;
+
+  const task = await createTask(memoryDir, {
+    title: `P1 ${marker}: ${maintenanceAction(debt)} for ${debt.title}`,
+    origin: 'scheduler',
+    priority: 1,
+    assignee: 'kuro',
+    verify_command: prConflictVerifyCommand(debt.prNumber),
+    acceptance_criteria: maintenanceAcceptance(debt),
+  });
+
+  eventBus.emit('action:task', {
+    event: 'autonomous-maintenance-queued',
+    taskId: task.id,
+    kind: debt.kind,
+    prNumber: debt.prNumber,
+    action: debt.action,
+  });
+
+  return { queued: true, reason: 'maintenance-queued', maintenance: debt, task };
+}
+
+function findTopMaintenanceDebt(memoryDir: string): MaintenanceDebt | null {
+  const activePath = path.join(memoryDir, 'handoffs', 'active.md');
+  if (!existsSync(activePath)) return null;
+
+  const debts = readFileSync(activePath, 'utf-8')
+    .split('\n')
+    .map(parseConflictDebtRow)
+    .filter((debt): debt is MaintenanceDebt => debt !== null);
+
+  return debts.sort((a, b) => maintenancePriority(b) - maintenancePriority(a))[0] ?? null;
+}
+
+function parseConflictDebtRow(line: string): MaintenanceDebt | null {
+  if (!line.includes('| blocked |') || !line.includes('conflict diagnostic')) return null;
+  const match = line.match(/PR #(\d+) conflict diagnostic:\s*(.*?)\s*\((needs-decomposition|needs-verification);\s*(.*?)\)\s*\|\s*blocked\s*\|/);
+  if (!match) return null;
+  return {
+    kind: 'pr-conflict',
+    prNumber: Number(match[1]),
+    title: unescapeTable(match[2].trim()),
+    action: match[3] as MaintenanceDebt['action'],
+    reason: unescapeTable(match[4].trim()),
+  };
+}
+
+function maintenancePriority(debt: MaintenanceDebt): number {
+  return debt.action === 'needs-decomposition' ? 2 : 1;
+}
+
+function maintenanceAction(debt: MaintenanceDebt): string {
+  return debt.action === 'needs-decomposition'
+    ? 'rebuild or split conflicting broad PR from current main'
+    : 'add completed verification evidence or close obsolete conflicting PR';
+}
+
+function maintenanceAcceptance(debt: MaintenanceDebt): string {
+  if (debt.action === 'needs-decomposition') {
+    return `Resolve PR #${debt.prNumber} debt by rebuilding/splitting from current main, or closing it as superseded with a replacement PR/issue. Do not merge broad conflicting scope directly. Reason: ${debt.reason}`;
+  }
+  return `Resolve PR #${debt.prNumber} debt by adding completed verification evidence and re-running review, or closing it as obsolete. Reason: ${debt.reason}`;
+}
+
+function prConflictVerifyCommand(prNumber: number): string {
+  return [
+    'test "$(',
+    `gh pr view ${prNumber} --repo miles990/mini-agent --json state,mergeable --jq `,
+    shellQuote('if .state == "MERGED" or .mergeable != "CONFLICTING" then "ok" else "blocked" end'),
+    ')" = ok',
+  ].join('');
+}
+
+function unescapeTable(value: string): string {
+  return value.replace(/\\\|/g, '|').replace(/\s+/g, ' ').trim();
 }
 
 function isIdleTrigger(trigger: string): boolean {

--- a/tests/self-research-autopilot.test.ts
+++ b/tests/self-research-autopilot.test.ts
@@ -65,6 +65,80 @@ describe('self research autopilot', () => {
     expect(result).toEqual({ queued: false, reason: 'active-tasks-present' });
   });
 
+  it('queues autonomous maintenance for blocked PR conflict debt before generic self-research', async () => {
+    mkdirSync(path.join(tmpDir, 'handoffs'), { recursive: true });
+    writeFileSync(
+      path.join(tmpDir, 'handoffs/active.md'),
+      [
+        '# Active Handoffs',
+        '',
+        '| From | To | Task | Status | Created | Done |',
+        '|------|----|------|--------|---------|------|',
+        '| github | kuro | PR #93 conflict diagnostic: hook rebuild (needs-verification; conflicting PR lacks completed verification evidence) | blocked | 05-06 | - |',
+        '| github | kuro | PR #90 conflict diagnostic: feedback loop patch (needs-decomposition; conflict spans broad scope (12 files)) | blocked | 05-06 | - |',
+      ].join('\n'),
+      'utf-8',
+    );
+
+    const result = await maybeQueueSelfResearch(tmpDir, {
+      triggerReason: 'heartbeat',
+      now: new Date('2026-05-05T00:00:00.000Z'),
+    });
+
+    expect(result.queued).toBe(true);
+    expect(result.reason).toBe('maintenance-queued');
+    expect(result.maintenance).toEqual(expect.objectContaining({
+      prNumber: 90,
+      action: 'needs-decomposition',
+    }));
+    expect(result.task).toEqual(expect.objectContaining({
+      status: 'pending',
+      summary: expect.stringContaining('P1 autonomous maintenance PR #90'),
+    }));
+    expect(result.task?.payload).toEqual(expect.objectContaining({
+      priority: 1,
+      assignee: 'kuro',
+      verify_command: expect.stringContaining('gh pr view 90'),
+    }));
+  });
+
+  it('does not duplicate an existing autonomous maintenance task', async () => {
+    mkdirSync(path.join(tmpDir, 'handoffs'), { recursive: true });
+    mkdirSync(path.join(tmpDir, 'state'), { recursive: true });
+    writeFileSync(
+      path.join(tmpDir, 'handoffs/active.md'),
+      [
+        '| From | To | Task | Status | Created | Done |',
+        '| github | kuro | PR #90 conflict diagnostic: feedback loop patch (needs-decomposition; conflict spans broad scope) | blocked | 05-06 | - |',
+      ].join('\n'),
+      'utf-8',
+    );
+    writeFileSync(
+      path.join(tmpDir, 'state/task-events.jsonl'),
+      JSON.stringify({
+        id: 'idx-maintenance',
+        ts: '2026-05-05T00:00:00.000Z',
+        type: 'task',
+        status: 'pending',
+        summary: 'P1 autonomous maintenance PR #90: rebuild or split conflicting broad PR from current main',
+        refs: [],
+        payload: { origin: 'scheduler', priority: 1 },
+      }) + '\n',
+      'utf-8',
+    );
+
+    const result = await maybeQueueSelfResearch(tmpDir, {
+      triggerReason: 'heartbeat',
+      now: new Date('2026-05-05T00:00:00.000Z'),
+    });
+
+    expect(result).toEqual({
+      queued: false,
+      reason: 'maintenance-task-exists',
+      maintenance: expect.objectContaining({ prNumber: 90 }),
+    });
+  });
+
   it('does not queue more than one proposal per day', async () => {
     const first = await maybeQueueSelfResearch(tmpDir, {
       triggerReason: 'heartbeat',


### PR DESCRIPTION
## Summary
- promote blocked PR conflict diagnostics into P1 autonomous maintenance tasks during idle cycles
- prioritize broad conflict decomposition before generic self-research or interest work
- avoid duplicate maintenance tasks and keep existing real work ahead of maintenance

## Verification
- [x] pnpm exec vitest run tests/self-research-autopilot.test.ts tests/self-research-loop.test.ts
- [x] pnpm typecheck
- [x] pnpm build