### PR TITLE
fix(pr-lifecycle): bypass scope-contaminated block for memory-chore HEAD

### DIFF
--- a/src/pr-lifecycle-governance.ts
+++ b/src/pr-lifecycle-governance.ts
@@ -107,6 +107,7 @@ export function analyzeBranchLifecycle(input: BranchLifecycleInput): BranchLifec
   const foreignIssueRefs = pr
     ? issueRefs.filter(ref => !allowedIssueRefs.includes(ref))
     : [];
+  const headIsMemoryChore = isMemoryScopedHead(input.commitsAhead[0]);
   const hasReviewerSignal = Boolean(
     pr &&
     (
@@ -127,9 +128,17 @@ export function analyzeBranchLifecycle(input: BranchLifecycleInput): BranchLifec
     guidance.push(`Branch ${input.branch} has no detected PR. Open a PR before treating it as complete.`);
   } else if (foreignIssueRefs.length > 0) {
     status = 'scope-contaminated';
-    shouldBlockPush = true;
-    guidance.push(`PR #${pr.number} allows ${formatRefs(allowedIssueRefs)} but commits reference foreign issue(s): ${formatRefs(foreignIssueRefs)}.`);
-    guidance.push('Split/cherry-pick unrelated commits into their own branch before pushing.');
+    if (headIsMemoryChore) {
+      // Issue #102: HEAD is a memory chore that makes no scope claim of its own.
+      // Branch contamination came from earlier commits; blocking the chore push doesn't fix it
+      // and forces manual override on every memory snapshot. Allow push, surface as warning.
+      shouldBlockPush = false;
+      guidance.push(`HEAD is a memory chore with no scope claim; push allowed despite branch contamination from ${formatRefs(foreignIssueRefs)} (PR #${pr.number} allows ${formatRefs(allowedIssueRefs)}).`);
+    } else {
+      shouldBlockPush = true;
+      guidance.push(`PR #${pr.number} allows ${formatRefs(allowedIssueRefs)} but commits reference foreign issue(s): ${formatRefs(foreignIssueRefs)}.`);
+      guidance.push('Split/cherry-pick unrelated commits into their own branch before pushing.');
+    }
   } else {
     status = 'pending-review';
     guidance.push(`PR #${pr.number} is the active scope. Only amend this PR scope; do not start a new task on this branch.`);
@@ -160,6 +169,12 @@ export function extractIssueRefs(text: string): number[] {
   let m: RegExpExecArray | null;
   while ((m = ISSUE_REF_RE.exec(text)) !== null) refs.push(Number(m[1]));
   return uniqueNumbers(refs);
+}
+
+function isMemoryScopedHead(head?: CommitSummary): boolean {
+  if (!head) return false;
+  // chore(memory): commits are auto-generated memory snapshots — no scope claim, no block.
+  return /^chore\(memory\)/.test(head.subject ?? '');
 }
 
 export function extractAllowedIssueRefs(pr: PullRequestSummary): number[] {

--- a/tests/pr-lifecycle-governance.test.ts
+++ b/tests/pr-lifecycle-governance.test.ts
@@ -69,6 +69,28 @@ describe('PR lifecycle governance', () => {
     expect(analysis.shouldBlockPush).toBe(false);
   });
 
+  it('downgrades scope-contaminated block when HEAD is a memory-only chore (Issue #102)', () => {
+    const analysis = analyzeBranchLifecycle(input({
+      branch: 'feat/correction-gate-hold-reasons',
+      pullRequest: {
+        number: 95,
+        title: 'feat(correction-gate): respect documented hold reasons',
+        body: 'Implements #94.',
+      },
+      commitsAhead: [
+        // HEAD first (newest first, mirrors `git log` default order)
+        { sha: 'c', subject: 'chore(memory): Added 19 lines of code in memory/handoffs/active.md' },
+        { sha: 'b', subject: 'fix(housekeeping): graphify dispatch (#91)' },
+        { sha: 'a', subject: 'feat(correction-gate): hold reasons (#94)' },
+      ],
+    }));
+
+    expect(analysis.status).toBe('scope-contaminated');
+    expect(analysis.foreignIssueRefs).toEqual([91]);
+    expect(analysis.shouldBlockPush).toBe(false);
+    expect(analysis.guidance.join('\n')).toContain('memory chore');
+  });
+
   it('marks PR without reviewer signal as not complete', () => {
     const analysis = analyzeBranchLifecycle(input({
       branch: 'fix/example',


### PR DESCRIPTION
## Summary
- Closes #102 — `chore(memory):*` HEAD commits no longer get blocked by branch-state contamination from earlier commits.
- Status remains `scope-contaminated` (so the underlying issue is still visible) but `shouldBlockPush=false` for memory-chore HEAD.
- Targeted fix: subject prefix match `^chore\(memory\)` only — does not weaken the guard for any other commit type.

## Mechanism
`analyzeBranchLifecycle` in `src/pr-lifecycle-governance.ts:122` previously set `shouldBlockPush=true` whenever `foreignIssueRefs.length > 0`. New branch:
- If `commitsAhead[0]` (HEAD, newest first per `git log` default) matches `^chore\(memory\)` → push allowed, guidance message explains the bypass.
- Else → existing block behavior preserved.

## Verification
- [x] New test `downgrades scope-contaminated block when HEAD is a memory-only chore (Issue #102)` in `tests/pr-lifecycle-governance.test.ts`
- [x] All 16 existing tests still pass (`npx vitest run tests/pr-lifecycle-governance.test.ts`)
- [ ] After merge, monitor `/tmp/post-commit-push-mini-agent.log` for ≥3 successful auto-pushes of `chore(memory):*` commits on contaminated branches with no manual `MINI_AGENT_ALLOW_SCOPE_CONTAMINATION` env var (Issue #102 falsifier)

🤖 Generated with [Claude Code](https://claude.com/claude-code)