### PR TITLE
fix(feedback-loops): capture sampleMsg per error bucket → lastMessage

### DIFF
--- a/src/feedback-loops.ts
+++ b/src/feedback-loops.ts
@@ -27,6 +27,7 @@ interface ErrorPatternState {
     count: number;
     taskCreated: boolean;
     lastSeen: string;
+    lastMessage?: string;
   };
 }
 
@@ -210,14 +211,19 @@ export async function detectErrorPatterns(): Promise<void> {
   const state = readState<ErrorPatternState>('error-patterns.json', {});
 
   // Group by (context + error code + subtype) — subtype splits polymorphic TIMEOUT/UNKNOWN buckets.
-  const groups = new Map<string, number>();
+  // sampleMsg captures first error string per bucket (240ch) — restores postmortem visibility for
+  // opaque buckets like silent_exit_void / no_diag where lastSeen+count alone gave zero diagnostic.
+  const groups = new Map<string, { count: number; sampleMsg: string }>();
   for (const err of errors) {
     const context = err.data.context ?? 'unknown';
     const errorMsg = err.data.error ?? '';
     const code = extractErrorCode(errorMsg);
     const subtype = extractErrorSubtype(errorMsg);
     const key = `${code}:${subtype}::${context}`;
-    groups.set(key, (groups.get(key) ?? 0) + 1);
+    const cur = groups.get(key) ?? { count: 0, sampleMsg: '' };
+    cur.count += 1;
+    if (!cur.sampleMsg && errorMsg) cur.sampleMsg = errorMsg.slice(0, 240);
+    groups.set(key, cur);
   }
 
   let changed = false;
@@ -233,20 +239,21 @@ export async function detectErrorPatterns(): Promise<void> {
     }
   }
 
-  for (const [key, count] of groups) {
+  for (const [key, { count, sampleMsg }] of groups) {
     if (count < 3) continue;
 
     const existing = state[key];
     if (existing) {
       existing.count = count;
       existing.lastSeen = today;
+      if (sampleMsg) existing.lastMessage = sampleMsg;
       changed = true;
       continue;
     }
 
     // Observation only — pulse.ts owns task creation via its own state.
     // taskCreated here is just a "seen" flag to prevent re-logging.
-    state[key] = { count, taskCreated: false, lastSeen: today };
+    state[key] = { count, taskCreated: false, lastSeen: today, lastMessage: sampleMsg };
     changed = true;
     slog('FEEDBACK', `Error pattern detected: ${key} (${count}×)`);
   }


### PR DESCRIPTION
## Summary

Rebuilds PR #90 cleanly from current main — scope stripped to the single stated fix.

- `ErrorPatternState` type gains optional `lastMessage?: string` field
- `detectErrorPatterns()` now captures first `errorMsg.slice(0, 240)` per `(code:subtype:context)` bucket as `sampleMsg`, and persists it on both new-entry and existing-entry branches
- Groups map changed from `Map<string, number>` to `Map<string, { count: number; sampleMsg: string }>` to carry the sample through accumulation

## Context

PR #90 (`fix/error-patterns-lastmessage`) was CONFLICTING and contained broad scope contamination (ship-truth-language-gate, workspace-finalizer, .githooks/post-commit, housekeeping graphify pipeline — all separate concerns). Several of those changes already landed on main via #92 and #96. This PR cherry-picks only commit `21a90fc3` which touches exclusively `src/feedback-loops.ts`.

Closes/supersedes #90.

## Verification

- [x] `npx tsc --noEmit` clean
- [ ] Post-merge: 7d window — `error-patterns.json` buckets with `count>=3` should show non-empty `lastMessage` for ≥80% of entries
- [ ] If `lastMessage` uniformly `處理訊息時發生錯誤` with no diagnostic suffix → `agent.ts` exit-1 message construction is also dropping signal; sibling fix needed

## Falsifier

`/Users/user/Workspace/mini-agent/memory/state/error-patterns.json` 7 days post-merge: `< 80%` of buckets with `count>=3` populate `lastMessage` → upstream message construction is the real gap, not aggregation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)