### PR TITLE
feat: sync GitHub issues into autonomous tasks

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test:watch": "vitest",
     "verify:brain-context": "pnpm build && node scripts/verify-brain-context.mjs",
     "self-research:plan": "pnpm build && node scripts/self-research-plan.mjs",
+    "sync:github-issues": "pnpm build && node dist/issue-autopilot-cli.js",
     "setup": "pnpm install && pnpm build && npm link",
     "prepare": "git config core.hooksPath .githooks 2>/dev/null || true",
     "check:pr-lifecycle": "tsx scripts/check-pr-lifecycle.ts"

--- a/plugins/github-issues.sh
+++ b/plugins/github-issues.sh
@@ -6,6 +6,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 CACHE_FILE="${TMPDIR:-/tmp}/mini-agent-github-issues.cache"
 CACHE_TTL=60  # seconds
+mkdir -p "$(dirname "$CACHE_FILE")" 2>/dev/null || true
 
 # ─── gh CLI 可用性檢查 ───
 if ! command -v gh &>/dev/null; then
@@ -42,6 +43,23 @@ fi
 
 count=$(echo "$issues" | jq 'length')
 output="=== Open Issues: $count ==="
+
+# ─── Issue Autopilot：把 open issue 寫入 memory index，讓 scheduler 能接手 ───
+if [ "${MINI_AGENT_GITHUB_ISSUE_AUTOPILOT:-1}" != "0" ]; then
+  if [ -f "$PROJECT_DIR/dist/issue-autopilot-cli.js" ]; then
+    sync_output=$(MINI_AGENT_MEMORY_DIR="$PROJECT_DIR/memory" node "$PROJECT_DIR/dist/issue-autopilot-cli.js" --json --limit 50 2>/dev/null | sed -n '/^{/,$p')
+    if [ -n "$sync_output" ]; then
+      sync_summary=$(echo "$sync_output" | jq -r '"Issue Autopilot: scanned=\(.scanned) created=\(.created) updated=\(.updated) skipped=\(.skipped)"' 2>/dev/null)
+      if [ -n "$sync_summary" ]; then
+        output="$output
+$sync_summary"
+      fi
+    fi
+  else
+    output="$output
+Issue Autopilot: dist missing; run pnpm build"
+  fi
+fi
 
 # ─── Needs Triage（無 assignee）───
 needs_triage=$(echo "$issues" | jq -r '

--- a/src/issue-autopilot-cli.ts
+++ b/src/issue-autopilot-cli.ts
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { readOpenIssuesFromGitHub, syncGitHubIssuesToTasks } from './issue-autopilot.js';
+
+const args = new Set(process.argv.slice(2));
+const repo = readArg('--repo') ?? process.env.MINI_AGENT_GITHUB_REPO ?? detectRepo();
+const memoryDir = path.resolve(readArg('--memory') ?? process.env.MINI_AGENT_MEMORY_DIR ?? 'memory');
+const limit = Number(readArg('--limit') ?? process.env.MINI_AGENT_GITHUB_ISSUE_LIMIT ?? '50');
+const dryRun = args.has('--dry-run');
+const json = args.has('--json');
+
+if (!repo) {
+  process.stderr.write('[issue-autopilot] missing repo. Pass --repo owner/name or set MINI_AGENT_GITHUB_REPO.\n');
+  process.exit(2);
+}
+
+try {
+  const issues = readOpenIssuesFromGitHub(repo, limit);
+  const result = await syncGitHubIssuesToTasks(memoryDir, issues, { repo, dryRun });
+  if (json) {
+    process.stdout.write(JSON.stringify({
+      scanned: result.scanned,
+      created: result.created,
+      updated: result.updated,
+      skipped: result.skipped,
+      tasks: result.plans.map(plan => ({
+        id: plan.id,
+        issue: plan.issueNumber,
+        priority: plan.priority,
+        summary: plan.summary,
+      })),
+    }, null, 2) + '\n');
+  } else {
+    process.stdout.write(`[issue-autopilot] scanned=${result.scanned} created=${result.created} updated=${result.updated} skipped=${result.skipped}\n`);
+  }
+} catch (error) {
+  process.stderr.write(`[issue-autopilot] failed: ${error instanceof Error ? error.message : String(error)}\n`);
+  process.exit(1);
+}
+
+function readArg(name: string): string | undefined {
+  const argv = process.argv.slice(2);
+  const index = argv.indexOf(name);
+  if (index >= 0) return argv[index + 1];
+  const prefix = `${name}=`;
+  return argv.find(arg => arg.startsWith(prefix))?.slice(prefix.length);
+}
+
+function detectRepo(): string | undefined {
+  try {
+    const url = execFileSync('git', ['config', '--get', 'remote.origin.url'], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 5000,
+    }).trim();
+    const match = url.match(/github\.com[:/]([^/]+\/[^/.]+)(?:\.git)?$/);
+    return match?.[1];
+  } catch {
+    return undefined;
+  }
+}

--- a/src/issue-autopilot.ts
+++ b/src/issue-autopilot.ts
@@ -1,0 +1,218 @@
+import { execFileSync } from 'node:child_process';
+import { appendMemoryIndexEntry, queryMemoryIndexSync, updateMemoryIndexEntry, type MemoryIndexEntry } from './memory-index.js';
+import { slog } from './utils.js';
+
+export interface GitHubIssueSummary {
+  number: number;
+  title: string;
+  url?: string;
+  body?: string;
+  labels?: Array<{ name: string } | string>;
+  assignees?: Array<{ login: string } | string>;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface IssueAutopilotSyncOptions {
+  repo: string;
+  now?: Date;
+  dryRun?: boolean;
+}
+
+export interface IssueTaskPlan {
+  id: string;
+  repo: string;
+  issueNumber: number;
+  title: string;
+  priority: number;
+  summary: string;
+  labels: string[];
+  verifyCommand: string;
+  url: string;
+}
+
+export interface IssueAutopilotSyncResult {
+  scanned: number;
+  created: number;
+  updated: number;
+  skipped: number;
+  plans: IssueTaskPlan[];
+}
+
+const TERMINAL_TASK_STATUSES = new Set(['completed', 'done', 'deleted']);
+
+export function issueTaskId(repo: string, issueNumber: number): string {
+  return `idx-github-issue-${repo.replace(/[^a-zA-Z0-9]+/g, '-')}-${issueNumber}`;
+}
+
+export function planIssueTask(issue: GitHubIssueSummary, options: IssueAutopilotSyncOptions): IssueTaskPlan {
+  const labels = normalizeLabels(issue.labels);
+  const priority = classifyIssuePriority(issue, labels);
+  const repo = options.repo;
+  const title = issue.title.trim();
+  const url = issue.url ?? `https://github.com/${repo}/issues/${issue.number}`;
+
+  return {
+    id: issueTaskId(repo, issue.number),
+    repo,
+    issueNumber: issue.number,
+    title,
+    priority,
+    labels,
+    url,
+    summary: `P${priority} GitHub issue #${issue.number}: ${title}`,
+    verifyCommand: [
+      `gh issue view ${issue.number} --repo ${repo} --json state,title,labels`,
+      'pnpm typecheck',
+      'pnpm test',
+    ].join(' && '),
+  };
+}
+
+export async function syncGitHubIssuesToTasks(
+  memoryDir: string,
+  issues: GitHubIssueSummary[],
+  options: IssueAutopilotSyncOptions,
+): Promise<IssueAutopilotSyncResult> {
+  const plans = issues
+    .filter(issue => Number.isInteger(issue.number) && issue.number > 0 && issue.title.trim().length > 0)
+    .map(issue => planIssueTask(issue, options));
+
+  let created = 0;
+  let updated = 0;
+  let skipped = 0;
+
+  for (const plan of plans) {
+    const existing = queryMemoryIndexSync(memoryDir, { id: plan.id, limit: 1 })[0];
+    if (existing && TERMINAL_TASK_STATUSES.has(String(existing.status))) {
+      skipped++;
+      continue;
+    }
+
+    if (options.dryRun) {
+      if (existing) updated++;
+      else created++;
+      continue;
+    }
+
+    const payload = buildPayload(plan, options.now ?? new Date());
+    if (existing) {
+      const changed = await updateExistingIssueTask(memoryDir, existing, plan, payload);
+      if (changed) updated++;
+      else skipped++;
+      continue;
+    }
+
+    await appendMemoryIndexEntry(memoryDir, {
+      id: plan.id,
+      type: 'task',
+      status: 'pending',
+      source: 'github-issue',
+      summary: plan.summary,
+      refs: [plan.url],
+      tags: ['github', 'issue', `issue:${plan.issueNumber}`, `P${plan.priority}`, ...plan.labels.map(l => `label:${l}`)],
+      payload,
+    });
+    created++;
+  }
+
+  const result = { scanned: issues.length, created, updated, skipped, plans };
+  slog('ISSUE-AUTOPILOT', `scanned=${result.scanned} created=${created} updated=${updated} skipped=${skipped}`);
+  return result;
+}
+
+export function readOpenIssuesFromGitHub(repo: string, limit = 50): GitHubIssueSummary[] {
+  const output = execFileSync('gh', [
+    'issue',
+    'list',
+    '--repo',
+    repo,
+    '--state',
+    'open',
+    '--limit',
+    String(limit),
+    '--json',
+    'number,title,url,labels,assignees,createdAt,updatedAt',
+  ], {
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    timeout: 15_000,
+  });
+  return JSON.parse(output) as GitHubIssueSummary[];
+}
+
+function normalizeLabels(labels: GitHubIssueSummary['labels']): string[] {
+  return (labels ?? [])
+    .map(label => typeof label === 'string' ? label : label.name)
+    .filter((label): label is string => Boolean(label))
+    .map(label => label.toLowerCase().trim())
+    .filter(Boolean);
+}
+
+function classifyIssuePriority(issue: GitHubIssueSummary, labels: string[]): number {
+  const haystack = `${issue.title}\n${issue.body ?? ''}\n${labels.join(' ')}`.toLowerCase();
+  if (
+    labels.some(label => /(^|\b)(p0|critical|security)(\b|$)/.test(label)) ||
+    /\b(p0|critical|security|credential|token leak|deploy failed|ci failed|production down)\b/.test(haystack)
+  ) {
+    return 0;
+  }
+  if (
+    labels.some(label => /(^|\b)(p1|bug|fix|regression)(\b|$)/.test(label)) ||
+    /\b(bug|fail(?:ed|ure|ures|s)?|regression|broken|conflict|merge|review|autonomous|self[- ]?heal|silent|unresolved|stuck|blocked|expired|backlog|clogging)\b/.test(haystack)
+  ) {
+    return 1;
+  }
+  return 2;
+}
+
+function buildPayload(plan: IssueTaskPlan, now: Date): Record<string, unknown> {
+  return {
+    origin: 'github-issue',
+    priority: plan.priority,
+    assignee: 'kuro',
+    repo: plan.repo,
+    issue_number: plan.issueNumber,
+    issue_url: plan.url,
+    issue_labels: plan.labels,
+    verify_command: plan.verifyCommand,
+    acceptance_criteria: [
+      `Issue #${plan.issueNumber} is addressed with code/docs/tests as appropriate.`,
+      'Verification evidence is attached to the PR or task report.',
+      'Issue is closed only after the fix is merged or explicitly marked obsolete.',
+    ].join(' '),
+    synced_at: now.toISOString(),
+  };
+}
+
+async function updateExistingIssueTask(
+  memoryDir: string,
+  existing: MemoryIndexEntry,
+  plan: IssueTaskPlan,
+  payload: Record<string, unknown>,
+): Promise<boolean> {
+  const existingPayload = (existing.payload ?? {}) as Record<string, unknown>;
+  const nextPayload = {
+    ...existingPayload,
+    ...payload,
+    first_seen_at: existingPayload.first_seen_at ?? existing.ts,
+  };
+  const needsUpdate =
+    existing.summary !== plan.summary ||
+    existing.status === 'abandoned' ||
+    existingPayload.priority !== plan.priority ||
+    existingPayload.issue_url !== plan.url ||
+    JSON.stringify(existingPayload.issue_labels ?? []) !== JSON.stringify(plan.labels);
+
+  if (!needsUpdate) return false;
+
+  await updateMemoryIndexEntry(memoryDir, existing.id, {
+    status: existing.status === 'abandoned' ? 'pending' : existing.status,
+    source: 'github-issue',
+    summary: plan.summary,
+    refs: [plan.url],
+    tags: ['github', 'issue', `issue:${plan.issueNumber}`, `P${plan.priority}`, ...plan.labels.map(l => `label:${l}`)],
+    payload: nextPayload,
+  });
+  return true;
+}

--- a/tests/issue-autopilot.test.ts
+++ b/tests/issue-autopilot.test.ts
@@ -1,0 +1,118 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { issueTaskId, planIssueTask, syncGitHubIssuesToTasks } from '../src/issue-autopilot.js';
+import { appendMemoryIndexEntry, queryMemoryIndexSync } from '../src/memory-index.js';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(path.join(os.tmpdir(), 'mini-agent-issue-autopilot-'));
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('issue autopilot', () => {
+  it('plans stable priority tasks from GitHub issues', () => {
+    const plan = planIssueTask({
+      number: 100,
+      title: 'Fix autonomous review loop failure',
+      labels: [{ name: 'bug' }],
+    }, { repo: 'miles990/mini-agent' });
+
+    expect(plan).toEqual(expect.objectContaining({
+      id: 'idx-github-issue-miles990-mini-agent-100',
+      priority: 1,
+      summary: 'P1 GitHub issue #100: Fix autonomous review loop failure',
+      url: 'https://github.com/miles990/mini-agent/issues/100',
+    }));
+    expect(plan.verifyCommand).toContain('gh issue view 100 --repo miles990/mini-agent');
+  });
+
+  it('treats autonomous runtime failure language as P1 work', () => {
+    const plan = planIssueTask({
+      number: 91,
+      title: 'graphify delegation routes prose to shell worker -> 156 cumulative bash FAILs',
+      labels: [],
+    }, { repo: 'miles990/mini-agent' });
+
+    expect(plan.priority).toBe(1);
+    expect(plan.summary).toBe('P1 GitHub issue #91: graphify delegation routes prose to shell worker -> 156 cumulative bash FAILs');
+  });
+
+  it('creates one scheduler-visible task per open issue and does not duplicate on resync', async () => {
+    const issues = [
+      { number: 100, title: 'Deploy failed after merge', labels: ['bug'] },
+      { number: 101, title: 'Document dashboard controls', labels: ['docs'] },
+    ];
+
+    const first = await syncGitHubIssuesToTasks(tmpDir, issues, {
+      repo: 'miles990/mini-agent',
+      now: new Date('2026-05-06T00:00:00.000Z'),
+    });
+    const second = await syncGitHubIssuesToTasks(tmpDir, issues, {
+      repo: 'miles990/mini-agent',
+      now: new Date('2026-05-06T00:01:00.000Z'),
+    });
+
+    expect(first).toEqual(expect.objectContaining({ scanned: 2, created: 2, updated: 0, skipped: 0 }));
+    expect(second).toEqual(expect.objectContaining({ scanned: 2, created: 0, updated: 0, skipped: 2 }));
+
+    const tasks = queryMemoryIndexSync(tmpDir, { type: ['task'], status: ['pending'] });
+    expect(tasks).toHaveLength(2);
+    expect(tasks.map(t => t.summary).sort()).toEqual([
+      'P0 GitHub issue #100: Deploy failed after merge',
+      'P2 GitHub issue #101: Document dashboard controls',
+    ]);
+    expect(tasks[0].payload).toEqual(expect.objectContaining({
+      origin: 'github-issue',
+      assignee: 'kuro',
+      repo: 'miles990/mini-agent',
+      verify_command: expect.stringContaining('pnpm test'),
+    }));
+  });
+
+  it('updates abandoned issue tasks back to pending when the issue is still open', async () => {
+    await appendMemoryIndexEntry(tmpDir, {
+      id: issueTaskId('miles990/mini-agent', 88),
+      type: 'task',
+      status: 'abandoned',
+      source: 'github-issue',
+      summary: 'P2 GitHub issue #88: old title',
+      refs: [],
+    });
+
+    const result = await syncGitHubIssuesToTasks(tmpDir, [
+      { number: 88, title: 'Self-healing conflict guard is stuck', labels: ['bug'] },
+    ], { repo: 'miles990/mini-agent' });
+
+    expect(result).toEqual(expect.objectContaining({ created: 0, updated: 1, skipped: 0 }));
+    const task = queryMemoryIndexSync(tmpDir, { id: issueTaskId('miles990/mini-agent', 88) })[0];
+    expect(task).toEqual(expect.objectContaining({
+      status: 'pending',
+      summary: 'P1 GitHub issue #88: Self-healing conflict guard is stuck',
+    }));
+  });
+
+  it('does not reopen completed tasks without an explicit lifecycle diagnosis', async () => {
+    await appendMemoryIndexEntry(tmpDir, {
+      id: issueTaskId('miles990/mini-agent', 77),
+      type: 'task',
+      status: 'completed',
+      source: 'github-issue',
+      summary: 'P1 GitHub issue #77: done',
+      refs: [],
+    });
+
+    const result = await syncGitHubIssuesToTasks(tmpDir, [
+      { number: 77, title: 'Still open but task completed', labels: ['bug'] },
+    ], { repo: 'miles990/mini-agent' });
+
+    expect(result).toEqual(expect.objectContaining({ created: 0, updated: 0, skipped: 1 }));
+    expect(queryMemoryIndexSync(tmpDir, { id: issueTaskId('miles990/mini-agent', 77) })[0].status).toBe('completed');
+  });
+});


### PR DESCRIPTION
## Summary
- Add Issue Autopilot sync that turns open GitHub issues into stable memory-index tasks
- Wire github-issues perception to run the sync and report scanned/created/updated/skipped counts
- Add CLI entrypoint and tests for priority classification, dedupe, abandoned-task revival, and completed-task preservation

## Verification
- pnpm typecheck
- pnpm test --run tests/issue-autopilot.test.ts
- pnpm build
- node dist/issue-autopilot-cli.js --repo miles990/mini-agent --memory memory --json --dry-run --limit 10

## Runtime impact
- Open GitHub issues become scheduler-visible tasks instead of passive perception text
- Set MINI_AGENT_GITHUB_ISSUE_AUTOPILOT=0 to disable the side effect in plugins/github-issues.sh