### PR TITLE
fix(agent): structured CLI_EXIT slog for silent_exit_void diagnosis

### DIFF
--- a/memory/handoffs/active.md
+++ b/memory/handoffs/active.md
@@ -91,3 +91,4 @@
 | github | kuro | PR #107 fix: unify default available actors | merged | 05-06 | 05-06 |
 | github | kuro | PR #104 fix: harden conflict governance and close internal review loop | merged | 05-06 | 05-06 |
 | github | kuro | PR #103 fix: add git conflict governance checks | merged | 05-06 | 05-06 |
+| github | akari | PR #120 fix(agent): structured CLI_EXIT slog for silent_exit_void diagnosis | changes-requested | 05-06 | - |

--- a/memory/handoffs/active.md
+++ b/memory/handoffs/active.md
@@ -52,27 +52,42 @@
 | github | kuro | #94 feat(correction-gate): respect documented hold reasons for local-commit-not-pushed | needs-triage | 05-06 | — |
 | github | kuro | #91 graphify delegation routes prose to shell worker → 156 cumulative bash FAILs | needs-triage | 05-06 | — |
 | github | kuro | #97 Auto-push hook for memory/auto-save chore commits (recurring drift, N=3) | needs-triage | 05-06 | — |
-| github | akari | PR #96 fix(housekeeping): emit shell-executable cmd for graphify KG rebuild (#91) | needs-review | 05-06 | - |
-| github | codex | PR #96 fix(housekeeping): emit shell-executable cmd for graphify KG rebuild (#91) | needs-review | 05-06 | - |
-| github | claude-code | PR #96 fix(housekeeping): emit shell-executable cmd for graphify KG rebuild (#91) | needs-review | 05-06 | - |
-| github | akari | PR #95 feat(correction-gate): respect documented hold reasons (agent-middleware#94) | needs-review | 05-06 | - |
-| github | codex | PR #95 feat(correction-gate): respect documented hold reasons (agent-middleware#94) | needs-review | 05-06 | - |
-| github | claude-code | PR #95 feat(correction-gate): respect documented hold reasons (agent-middleware#94) | needs-review | 05-06 | - |
-| github | akari | PR #93 chore(hooks): post-commit auto-rebuild to prevent stale-dist drift | needs-review | 05-06 | - |
-| github | codex | PR #93 chore(hooks): post-commit auto-rebuild to prevent stale-dist drift | needs-review | 05-06 | - |
-| github | claude-code | PR #93 chore(hooks): post-commit auto-rebuild to prevent stale-dist drift | needs-review | 05-06 | - |
-| github | akari | PR #92 feat(hooks): auto-rebuild dist after src/ commits | needs-review | 05-06 | - |
-| github | codex | PR #92 feat(hooks): auto-rebuild dist after src/ commits | needs-review | 05-06 | - |
-| github | claude-code | PR #92 feat(hooks): auto-rebuild dist after src/ commits | needs-review | 05-06 | - |
-| github | akari | PR #90 fix(feedback-loops): capture sampleMsg per error bucket → lastMessage | needs-review | 05-06 | - |
-| github | codex | PR #90 fix(feedback-loops): capture sampleMsg per error bucket → lastMessage | needs-review | 05-06 | - |
-| github | claude-code | PR #90 fix(feedback-loops): capture sampleMsg per error bucket → lastMessage | needs-review | 05-06 | - |
-| github | akari | PR #89 fix(loop): dump head bytes on hasMarker=false soft-gate skip (#88 followup) | needs-review | 05-06 | - |
+| github | akari | PR #96 fix(housekeeping): emit shell-executable cmd for graphify KG rebuild (#91) | merged | 05-06 | 05-06 |
+| github | codex | PR #96 fix(housekeeping): emit shell-executable cmd for graphify KG rebuild (#91) | merged | 05-06 | 05-06 |
+| github | claude-code | PR #96 fix(housekeeping): emit shell-executable cmd for graphify KG rebuild (#91) | merged | 05-06 | 05-06 |
+| github | akari | PR #95 feat(correction-gate): respect documented hold reasons (agent-middleware#94) | merged | 05-06 | 05-06 |
+| github | codex | PR #95 feat(correction-gate): respect documented hold reasons (agent-middleware#94) | merged | 05-06 | 05-06 |
+| github | claude-code | PR #95 feat(correction-gate): respect documented hold reasons (agent-middleware#94) | merged | 05-06 | 05-06 |
+| github | akari | PR #93 chore(hooks): post-commit auto-rebuild to prevent stale-dist drift | review-pending | 05-06 | - |
+| github | codex | PR #93 chore(hooks): post-commit auto-rebuild to prevent stale-dist drift | review-pending | 05-06 | - |
+| github | claude-code | PR #93 chore(hooks): post-commit auto-rebuild to prevent stale-dist drift | review-pending | 05-06 | - |
+| github | akari | PR #92 feat(hooks): auto-rebuild dist after src/ commits | merged | 05-06 | 05-06 |
+| github | codex | PR #92 feat(hooks): auto-rebuild dist after src/ commits | merged | 05-06 | 05-06 |
+| github | claude-code | PR #92 feat(hooks): auto-rebuild dist after src/ commits | merged | 05-06 | 05-06 |
+| github | akari | PR #90 fix(feedback-loops): capture sampleMsg per error bucket → lastMessage | review-approved | 05-06 | - |
+| github | codex | PR #90 fix(feedback-loops): capture sampleMsg per error bucket → lastMessage | review-approved | 05-06 | - |
+| github | claude-code | PR #90 fix(feedback-loops): capture sampleMsg per error bucket → lastMessage | review-approved | 05-06 | - |
+| github | akari | PR #89 fix(loop): dump head bytes on hasMarker=false soft-gate skip (#88 followup) | review-approved | 05-06 | - |
 | github | kuro | PR #98 fix: gate PR branch scope contamination | merged | 05-06 | 05-06 |
 | github | kuro | PR #86 fix(loop): instrument soft-gate try-entry (#81) | merged | 05-06 | 05-06 |
 | github | kuro | #99 correction-gate: low-output-quality OUTPUT_PATTERNS misses real deliverables (gh issue/pr create, file edits, commits) | needs-triage | 05-06 | — |
 | github | kuro | #100 post-commit hook: auto-allow scope-contamination for chore(memory):* commits | needs-triage | 05-06 | — |
-| github | akari | PR #101 feat: add PR review claim consensus runner | needs-review | 05-06 | - |
-| github | codex | PR #101 feat: add PR review claim consensus runner | needs-review | 05-06 | - |
-| github | claude-code | PR #101 feat: add PR review claim consensus runner | needs-review | 05-06 | - |
+| github | akari | PR #101 feat: add PR review claim consensus runner | merged | 05-06 | 05-06 |
+| github | codex | PR #101 feat: add PR review claim consensus runner | merged | 05-06 | 05-06 |
+| github | claude-code | PR #101 feat: add PR review claim consensus runner | merged | 05-06 | 05-06 |
 | github | kuro | #102 pr-lifecycle scope-guard false-positive: chore(memory) commits blocked by branch-level ref aggregation | needs-triage | 05-06 | — |
+| github | kuro | PR #119 feat: sync GitHub issues into autonomous tasks | merged | 05-06 | 05-06 |
+| github | kuro | PR #118 fix(feedback-loops): capture sampleMsg per error bucket → lastMessage | merged | 05-06 | 05-06 |
+| github | kuro | PR #117 fix(pr-lifecycle): bypass scope-contaminated block for memory-chore HEAD | merged | 05-06 | 05-06 |
+| github | kuro | PR #116 fix: queue autonomous maintenance for blocked debt | merged | 05-06 | 05-06 |
+| github | kuro | PR #115 fix: consolidate autonomous workspace isolation | merged | 05-06 | 05-06 |
+| github | kuro | PR #114 fix: isolate autonomous workspace writes | merged | 05-06 | 05-06 |
+| github | kuro | PR #113 fix: add autonomous PR conflict diagnostics | merged | 05-06 | 05-06 |
+| github | kuro | PR #112 fix: version PR review input fingerprints | merged | 05-06 | 05-06 |
+| github | kuro | PR #111 fix: accept tsc PR verification evidence | merged | 05-06 | 05-06 |
+| github | kuro | PR #110 fix: update PR bodies through REST automation | merged | 05-06 | 05-06 |
+| github | kuro | PR #109 fix: auto-repair PR verification headings | merged | 05-06 | 05-06 |
+| github | kuro | PR #108 fix: retry PR review claims after input changes | merged | 05-06 | 05-06 |
+| github | kuro | PR #107 fix: unify default available actors | merged | 05-06 | 05-06 |
+| github | kuro | PR #104 fix: harden conflict governance and close internal review loop | merged | 05-06 | 05-06 |
+| github | kuro | PR #103 fix: add git conflict governance checks | merged | 05-06 | 05-06 |

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -1043,6 +1043,15 @@ async function execClaude(fullPrompt: string, opts?: ExecOptions): Promise<strin
         slog('CLAUDE', `Process terminated by signal ${signal} (not our timeout), elapsed=${(duration / 1000).toFixed(1)}s`);
       }
 
+      // Issue #77: structured exit log surfaces {code, signal, killed} for silent_exit_void
+      // (non-143 nonzero exit, no signal, no stderr). Without this, classifier sees only
+      // `exit undefined, stdout empty` and routes to hang_no_diag.
+      slog('CLI_EXIT', JSON.stringify({
+        cli: 'claude', source, code, signal: signal ?? null, killed: timedOut,
+        durationS: Math.round(duration / 1000), stderrLen: stderr.length,
+        stdoutLen: resultText.length, toolCalls: toolCallCount,
+      }));
+
       // Flush forensic entry — common to success and error paths. Fail-open.
       try {
         const now = Date.now();
@@ -1265,6 +1274,13 @@ async function execCodex(fullPrompt: string, opts?: ExecOptions): Promise<string
       if (toolCallCount > 0) {
         slog('AUDIT', `Codex CLI used ${toolCallCount} tool(s) this call`);
       }
+
+      // Issue #77: same structured exit log for codex lane (parity with claude handler).
+      slog('CLI_EXIT', JSON.stringify({
+        cli: 'codex', source, code, signal: signal ?? null, killed: timedOut,
+        durationS: Math.round(duration / 1000), stderrLen: stderr.length,
+        stdoutLen: resultText.length, toolCalls: toolCallCount,
+      }));
 
       if (code !== 0 && !resultText) {
         reject(Object.assign(new Error(`Codex CLI exited with code ${code}`), { stderr, stdout: resultText, status: code, killed: timedOut, signal, duration, timeoutMs: TIMEOUT_MS }));


### PR DESCRIPTION
## Summary
- Adds `slog('CLI_EXIT', JSON.stringify({code, signal, killed, durationS, stderrLen, stdoutLen, toolCalls}))` in both `child.on('close')` handlers in `src/agent.ts` (Claude lane line ~1042, Codex lane line ~1267).
- Before: only `EXIT143` and signal-termination got structured logs. The silent_exit_void mode (non-143 nonzero exit, no signal, empty stderr after 8–20 min) had zero structured trace.
- After: every CLI exit emits the full `{signal, killed, exitCode}` triple plus duration + IO lengths.

## Why
Issue #77 documents 12 silent_exit_void events over 5 days where the classifier saw only \`exit undefined, stdout empty\` and bucketed as `hang_no_diag`. My earlier comment narrowed the hypothesis tree to suggestion (A) — instrument first, theorize later. This PR is suggestion (A).

## Verification
- [x] `pnpm tsc --noEmit` clean
- [ ] After merge: wait for ≥5 silent_exit_void events, grep `server.log` for `CLI_EXIT` entries with `signal=null killed=false code≠143`, verify the triple gives a distinguishable signature vs. legitimate timeouts (`killed=true`).
- [ ] If `code` is consistently `null` post-patch → real cause is mid-flight kill from outside our process tree (OOM, system pressure, parent watchdog).
- [ ] If `code` is consistently a specific nonzero value → CLI itself is exiting; check stderrLen and stdoutLen pattern.

Closes #77 (instrumentation milestone — diagnostic follow-up tracked in the issue).