### PR TITLE
fix: enforce autonomous workspace isolation

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "verify:brain-context": "pnpm build && node scripts/verify-brain-context.mjs",
     "self-research:plan": "pnpm build && node scripts/self-research-plan.mjs",
     "sync:github-issues": "pnpm build && node dist/issue-autopilot-cli.js",
+    "janitor:workspaces": "tsx scripts/workspace-janitor.ts",
     "setup": "pnpm install && pnpm build && npm link",
     "prepare": "git config core.hooksPath .githooks 2>/dev/null || true",
     "check:pr-lifecycle": "tsx scripts/check-pr-lifecycle.ts"

--- a/scripts/workspace-janitor.ts
+++ b/scripts/workspace-janitor.ts
@@ -1,0 +1,217 @@
+#!/usr/bin/env tsx
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+
+interface WorktreeRecord {
+  path: string;
+  head: string;
+  branch: string | null;
+}
+
+interface JanitorAction {
+  type: 'remove-worktree' | 'delete-local-branch' | 'delete-remote-branch' | 'warn-runtime-branch';
+  target: string;
+  reason: string;
+  command?: string[];
+}
+
+const apply = process.argv.includes('--apply');
+const json = process.argv.includes('--json');
+const repo = readArg('--repo') ?? process.env.MINI_AGENT_GITHUB_REPO ?? 'miles990/mini-agent';
+const base = readArg('--base') ?? process.env.MINI_AGENT_BASE_BRANCH ?? 'main';
+const root = git(['rev-parse', '--show-toplevel']) || process.cwd();
+const currentBranch = git(['rev-parse', '--abbrev-ref', 'HEAD']) || 'unknown';
+const mergedPrBranches = new Set(readMergedPrBranches(repo));
+const openPrBranches = new Set(readOpenPrBranches(repo));
+const worktrees = readWorktrees();
+const protectedRoot = path.resolve(process.env.MINI_AGENT_RUNTIME_WORKSPACE ?? inferRuntimeWorkspace(root));
+
+const actions: JanitorAction[] = [];
+
+if (path.resolve(root) === protectedRoot && !['main', 'runtime/main'].includes(currentBranch)) {
+  actions.push({
+    type: 'warn-runtime-branch',
+    target: currentBranch,
+    reason: `protected runtime workspace is on ${currentBranch}; switch it back to runtime/main after preserving local work`,
+  });
+}
+
+for (const wt of worktrees) {
+  if (!wt.branch) continue;
+  if (path.resolve(wt.path) === protectedRoot) continue;
+  if (openPrBranches.has(wt.branch)) continue;
+  if (mergedPrBranches.has(wt.branch) && isWorktreeClean(wt.path)) {
+    actions.push({
+      type: 'remove-worktree',
+      target: wt.path,
+      reason: `branch ${wt.branch} was merged and worktree is clean`,
+      command: ['git', 'worktree', 'remove', wt.path],
+    });
+  }
+}
+
+for (const branch of readLocalBranches()) {
+  if (['main', 'runtime/main'].includes(branch)) continue;
+  if (openPrBranches.has(branch)) continue;
+  if (isBranchCheckedOut(branch, worktrees)) continue;
+  if (mergedPrBranches.has(branch) || isMergedToBase(branch, base)) {
+    actions.push({
+      type: 'delete-local-branch',
+      target: branch,
+      reason: mergedPrBranches.has(branch) ? 'PR already merged' : `already merged into ${base}`,
+      command: ['git', 'branch', '-d', branch],
+    });
+  }
+}
+
+for (const branch of readRemoteBranches()) {
+  if (openPrBranches.has(branch)) continue;
+  if (mergedPrBranches.has(branch)) {
+    actions.push({
+      type: 'delete-remote-branch',
+      target: branch,
+      reason: 'PR already merged and no open PR uses this head',
+      command: ['git', 'push', 'origin', '--delete', branch],
+    });
+  }
+}
+
+if (apply) {
+  for (const action of actions) {
+    if (!action.command) continue;
+    try {
+      execFileSync(action.command[0], action.command.slice(1), {
+        cwd: root,
+        encoding: 'utf-8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+        timeout: 30_000,
+      });
+    } catch (error) {
+      action.reason += `; apply failed: ${error instanceof Error ? error.message.split('\n')[0] : String(error)}`;
+    }
+  }
+  git(['worktree', 'prune']);
+}
+
+if (json) {
+  process.stdout.write(JSON.stringify({ apply, root, currentBranch, actions }, null, 2) + '\n');
+} else {
+  process.stdout.write(`[workspace-janitor] mode=${apply ? 'apply' : 'dry-run'} actions=${actions.length}\n`);
+  for (const action of actions) {
+    process.stdout.write(`- ${action.type}: ${action.target} — ${action.reason}\n`);
+  }
+}
+
+function readArg(name: string): string | undefined {
+  const argv = process.argv.slice(2);
+  const index = argv.indexOf(name);
+  if (index >= 0) return argv[index + 1];
+  const prefix = `${name}=`;
+  return argv.find(arg => arg.startsWith(prefix))?.slice(prefix.length);
+}
+
+function inferRuntimeWorkspace(repoRoot: string): string {
+  const baseName = path.basename(repoRoot);
+  if (baseName === 'mini-agent') return repoRoot;
+  if (baseName.startsWith('mini-agent-')) return path.join(path.dirname(repoRoot), 'mini-agent');
+  return repoRoot;
+}
+
+function readMergedPrBranches(repoName: string): string[] {
+  try {
+    const out = execFileSync('gh', [
+      'pr', 'list',
+      '--repo', repoName,
+      '--state', 'merged',
+      '--limit', '100',
+      '--json', 'headRefName',
+    ], { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'], timeout: 15_000 });
+    return (JSON.parse(out) as Array<{ headRefName: string }>).map(pr => pr.headRefName).filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+function readOpenPrBranches(repoName: string): string[] {
+  try {
+    const out = execFileSync('gh', [
+      'pr', 'list',
+      '--repo', repoName,
+      '--state', 'open',
+      '--limit', '100',
+      '--json', 'headRefName',
+    ], { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'], timeout: 15_000 });
+    return (JSON.parse(out) as Array<{ headRefName: string }>).map(pr => pr.headRefName).filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+function readWorktrees(): WorktreeRecord[] {
+  const out = git(['worktree', 'list', '--porcelain']) ?? '';
+  const records: WorktreeRecord[] = [];
+  let current: Partial<WorktreeRecord> = {};
+  for (const line of out.split('\n')) {
+    if (line.startsWith('worktree ')) {
+      if (current.path) records.push({ path: current.path, head: current.head ?? '', branch: current.branch ?? null });
+      current = { path: line.slice('worktree '.length) };
+    } else if (line.startsWith('HEAD ')) {
+      current.head = line.slice('HEAD '.length);
+    } else if (line.startsWith('branch refs/heads/')) {
+      current.branch = line.slice('branch refs/heads/'.length);
+    } else if (line === 'detached') {
+      current.branch = null;
+    }
+  }
+  if (current.path) records.push({ path: current.path, head: current.head ?? '', branch: current.branch ?? null });
+  return records;
+}
+
+function readLocalBranches(): string[] {
+  return (git(['for-each-ref', '--format=%(refname:short)', 'refs/heads']) ?? '')
+    .split('\n')
+    .map(s => s.trim())
+    .filter(Boolean);
+}
+
+function readRemoteBranches(): string[] {
+  return (git(['for-each-ref', '--format=%(refname:short)', 'refs/remotes/origin']) ?? '')
+    .split('\n')
+    .map(s => s.trim())
+    .filter(s => s && s !== 'origin/HEAD')
+    .map(s => s.replace(/^origin\//, ''));
+}
+
+function isWorktreeClean(worktreePath: string): boolean {
+  return (git(['-C', worktreePath, 'status', '--porcelain']) ?? '').trim().length === 0;
+}
+
+function isBranchCheckedOut(branch: string, records: WorktreeRecord[]): boolean {
+  return records.some(wt => wt.branch === branch);
+}
+
+function isMergedToBase(branch: string, baseBranch: string): boolean {
+  try {
+    execFileSync('git', ['merge-base', '--is-ancestor', branch, `origin/${baseBranch}`], {
+      cwd: root,
+      stdio: 'ignore',
+      timeout: 5000,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function git(args: string[]): string | null {
+  try {
+    return execFileSync('git', args, {
+      cwd: root,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 10_000,
+    }).trim();
+  } catch {
+    return null;
+  }
+}

--- a/src/auto-executor.ts
+++ b/src/auto-executor.ts
@@ -15,6 +15,7 @@ import { eventBus } from './event-bus.js';
 import { slog } from './utils.js';
 import { spawnSync } from 'node:child_process';
 import path from 'node:path';
+import { evaluateWorkspaceIsolation } from './workspace-isolation.js';
 
 // =============================================================================
 // Config
@@ -22,6 +23,7 @@ import path from 'node:path';
 
 const COOLDOWN_MS = 3 * 60_000;
 const MAX_FAILURES_PER_TASK = 3;
+const ISSUE_AUTOPILOT_ORIGIN = 'github-issue';
 const TIMEOUT_BY_COMPLEXITY: Record<TaskComplexity, number> = {
   simple: 300_000,   // 5 min
   medium: 600_000,   // 10 min
@@ -64,6 +66,65 @@ export function classifyComplexity(verifyCommand: string): TaskComplexity {
   if (hasMultiDir) return 'complex';
 
   return 'medium';
+}
+
+export function isIssueAutopilotTask(entry: MemoryIndexEntry): boolean {
+  const payload = (entry.payload ?? {}) as Record<string, unknown>;
+  return entry.source === ISSUE_AUTOPILOT_ORIGIN || payload.origin === ISSUE_AUTOPILOT_ORIGIN;
+}
+
+export function canAutoDispatchTask(entry: MemoryIndexEntry, complexity: TaskComplexity): boolean {
+  if (complexity !== 'complex') return true;
+  return isIssueAutopilotTask(entry);
+}
+
+export function buildAutoDelegation(top: MemoryIndexEntry, complexity: TaskComplexity, now = Date.now()): DelegationTask {
+  const topPayload = (top.payload ?? {}) as Record<string, unknown>;
+  const verifyCommand = topPayload.verify_command as string;
+  const acceptance = (topPayload.acceptance_criteria as string) ?? `Task completed: ${top.summary}`;
+  const issueNumber = topPayload.issue_number as number | undefined;
+  const repo = topPayload.repo as string | undefined;
+  const issueContext = isIssueAutopilotTask(top)
+    ? [
+        '',
+        '## GitHub Issue Lifecycle',
+        repo && issueNumber ? `Source issue: ${repo}#${issueNumber}` : 'Source issue: recorded in task payload.',
+        '- Work in the isolated forge worktree allocated for this delegation.',
+        '- Keep the patch scoped to the issue.',
+        '- Run the verification commands and include evidence in the result.',
+        '- Do not close the GitHub issue unless the fix is merged or explicitly obsolete.',
+      ]
+    : [];
+
+  const prompt = [
+    `## Task: ${top.summary}`,
+    '',
+    `Task ID: ${top.id}`,
+    ...issueContext,
+    '',
+    '## Instructions',
+    'Complete this task by writing code. The task is verified by running:',
+    '```',
+    verifyCommand,
+    '```',
+    '',
+    'Write the minimum code needed to make the verify command pass.',
+    'After writing code, run the verify command to confirm it passes.',
+  ].join('\n');
+
+  const verify = verifyCommand.split('&&').map(v => v.trim());
+  const delegationId = `auto-${top.id.slice(0, 16)}-${now}`;
+
+  return {
+    id: delegationId,
+    type: 'code',
+    originTask: top.id,
+    prompt,
+    workdir: process.cwd(),
+    verify,
+    acceptance,
+    timeoutMs: TIMEOUT_BY_COMPLEXITY[complexity],
+  };
 }
 
 // =============================================================================
@@ -145,6 +206,20 @@ function ensureListener(): void {
       failCounts.set(taskId, count);
       if (count >= MAX_FAILURES_PER_TASK) {
         dispatchedSet.add(taskId);
+        const memoryDir = path.join(process.cwd(), 'memory');
+        const current = queryMemoryIndexSync(memoryDir, { id: taskId, limit: 1 })[0];
+        const payload = (current?.payload ?? {}) as Record<string, unknown>;
+        updateMemoryIndexEntry(memoryDir, taskId, {
+          status: 'hold',
+          payload: {
+            ...payload,
+            holdCondition: {
+              type: 'manual',
+              value: `auto-executor exhausted retries (${count}/${MAX_FAILURES_PER_TASK})`,
+            },
+            auto_executor_failures: count,
+          },
+        }).catch(() => {});
         slog('AUTO-EXEC', `task ${taskId.slice(0, 16)} exhausted retries (${count}/${MAX_FAILURES_PER_TASK}) — marking blocked`);
       } else {
         slog('AUTO-EXEC', `task ${taskId.slice(0, 16)} failed (${count}/${MAX_FAILURES_PER_TASK})`);
@@ -167,6 +242,11 @@ export interface AutoExecuteResult {
 
 export function checkAndDispatch(memoryDir: string): AutoExecuteResult {
   ensureListener();
+
+  const isolation = evaluateWorkspaceIsolation(process.cwd());
+  if (!isolation.ok) {
+    return { fired: false, reason: `workspace isolation guard: ${isolation.reason}` };
+  }
 
   if (activeAutoTaskId) {
     return { fired: false, reason: `previous auto-dispatch still active: ${activeAutoTaskId}` };
@@ -202,43 +282,15 @@ export function checkAndDispatch(memoryDir: string): AutoExecuteResult {
   const top = actionable[0];
   const topPayload = (top.payload ?? {}) as Record<string, unknown>;
   const verifyCommand = topPayload.verify_command as string;
-  const acceptance = (topPayload.acceptance_criteria as string) ?? `Task completed: ${top.summary}`;
 
   // M3: complexity routing
   const complexity = classifyComplexity(verifyCommand);
-  if (complexity === 'complex') {
+  if (!canAutoDispatchTask(top, complexity)) {
     return { fired: false, reason: `task too complex for auto-dispatch: ${(top.summary ?? '').slice(0, 60)}`, complexity };
   }
 
-  const workdir = process.cwd();
-
-  const prompt = [
-    `## Task: ${top.summary}`,
-    '',
-    `Task ID: ${top.id}`,
-    '',
-    '## Instructions',
-    'Complete this task by writing code. The task is verified by running:',
-    '```',
-    verifyCommand,
-    '```',
-    '',
-    'Write the minimum code needed to make the verify command pass.',
-    'After writing code, run the verify command to confirm it passes.',
-  ].join('\n');
-
-  const verify = verifyCommand.split('&&').map(v => v.trim());
-  const delegationId = `auto-${top.id.slice(0, 16)}-${Date.now()}`;
-
-  const delegation: DelegationTask = {
-    id: delegationId,
-    type: 'code',
-    prompt,
-    workdir,
-    verify,
-    acceptance,
-    timeoutMs: TIMEOUT_BY_COMPLEXITY[complexity],
-  };
+  const delegation = buildAutoDelegation(top, complexity);
+  const delegationId = delegation.id!;
 
   try {
     spawnDelegation(delegation);

--- a/src/workspace-isolation.ts
+++ b/src/workspace-isolation.ts
@@ -1,0 +1,120 @@
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+
+export interface WorkspaceIsolationSnapshot {
+  cwd: string;
+  repoRoot: string | null;
+  branch: string | null;
+  protectedRuntimeWorkspace: boolean;
+  dirtyPaths: string[];
+  codeDirtyPaths: string[];
+}
+
+export interface WorkspaceIsolationDecision extends WorkspaceIsolationSnapshot {
+  ok: boolean;
+  reason: string;
+  warnings: string[];
+}
+
+const SAFE_RUNTIME_BRANCHES = new Set(['main', 'runtime/main']);
+const CODE_PATH_PATTERN = /^(src|tests|scripts|plugins|skills|tools|\.githooks|\.github)\//;
+const CODE_FILE_PATTERN = /^(package\.json|pnpm-lock\.yaml|tsconfig\.json|agent-compose\.yaml)$/;
+
+export function evaluateWorkspaceIsolation(cwd = process.cwd(), protectedRoot = process.env.MINI_AGENT_RUNTIME_WORKSPACE): WorkspaceIsolationDecision {
+  const repoRoot = git(cwd, ['rev-parse', '--show-toplevel']) || null;
+  const branch = git(cwd, ['rev-parse', '--abbrev-ref', 'HEAD']) || null;
+  const dirtyPaths = parseDirtyPaths(git(cwd, ['status', '--porcelain']) ?? '');
+  const codeDirtyPaths = dirtyPaths.filter(isCodePath);
+  const protectedRuntimeWorkspace = isProtectedRuntimeWorkspace(cwd, repoRoot, protectedRoot);
+  const warnings: string[] = [];
+
+  if (!protectedRuntimeWorkspace) {
+    return {
+      cwd,
+      repoRoot,
+      branch,
+      protectedRuntimeWorkspace,
+      dirtyPaths,
+      codeDirtyPaths,
+      ok: true,
+      reason: 'isolated worktree',
+      warnings,
+    };
+  }
+
+  if (!branch || !SAFE_RUNTIME_BRANCHES.has(branch)) {
+    return {
+      cwd,
+      repoRoot,
+      branch,
+      protectedRuntimeWorkspace,
+      dirtyPaths,
+      codeDirtyPaths,
+      ok: false,
+      reason: `protected runtime workspace is on branch ${branch ?? 'unknown'}; expected main or runtime/main`,
+      warnings,
+    };
+  }
+
+  if (codeDirtyPaths.length > 0) {
+    return {
+      cwd,
+      repoRoot,
+      branch,
+      protectedRuntimeWorkspace,
+      dirtyPaths,
+      codeDirtyPaths,
+      ok: false,
+      reason: `protected runtime workspace has code/config dirt: ${codeDirtyPaths.slice(0, 5).join(', ')}`,
+      warnings,
+    };
+  }
+
+  if (dirtyPaths.length > 0) {
+    warnings.push(`runtime workspace has non-code dirt: ${dirtyPaths.slice(0, 5).join(', ')}`);
+  }
+
+  return {
+    cwd,
+    repoRoot,
+    branch,
+    protectedRuntimeWorkspace,
+    dirtyPaths,
+    codeDirtyPaths,
+    ok: true,
+    reason: 'protected runtime workspace is safe for isolated delegation',
+    warnings,
+  };
+}
+
+export function parseDirtyPaths(porcelain: string): string[] {
+  return porcelain
+    .split('\n')
+    .map(line => line.trimEnd())
+    .filter(Boolean)
+    .map(line => line.slice(3).trim())
+    .filter(Boolean);
+}
+
+export function isCodePath(filePath: string): boolean {
+  return CODE_PATH_PATTERN.test(filePath) || CODE_FILE_PATTERN.test(filePath);
+}
+
+function isProtectedRuntimeWorkspace(cwd: string, repoRoot: string | null, protectedRoot?: string): boolean {
+  const root = repoRoot ? path.resolve(repoRoot) : path.resolve(cwd);
+  if (protectedRoot) return root === path.resolve(protectedRoot);
+  return path.basename(root) === 'mini-agent';
+}
+
+function git(cwd: string, args: string[]): string | null {
+  try {
+    return execFileSync('git', args, {
+      cwd,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 5000,
+    }).trim();
+  } catch {
+    return null;
+  }
+}

--- a/tests/auto-executor.test.ts
+++ b/tests/auto-executor.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildAutoDelegation,
+  canAutoDispatchTask,
+  classifyComplexity,
+  isIssueAutopilotTask,
+} from '../src/auto-executor.js';
+import type { MemoryIndexEntry } from '../src/memory-index.js';
+
+describe('auto executor task routing', () => {
+  it('keeps generic three-step verification out of automatic dispatch', () => {
+    const task = taskEntry({
+      id: 'idx-generic',
+      source: 'scheduler',
+      payload: {
+        origin: 'scheduler',
+        verify_command: 'pnpm typecheck && pnpm test && pnpm build',
+      },
+    });
+    const complexity = classifyComplexity(task.payload!.verify_command as string);
+
+    expect(complexity).toBe('complex');
+    expect(canAutoDispatchTask(task, complexity)).toBe(false);
+  });
+
+  it('allows GitHub issue tasks through the complex gate because they are first-class work', () => {
+    const task = githubIssueTask();
+    const complexity = classifyComplexity(task.payload!.verify_command as string);
+
+    expect(isIssueAutopilotTask(task)).toBe(true);
+    expect(complexity).toBe('complex');
+    expect(canAutoDispatchTask(task, complexity)).toBe(true);
+  });
+
+  it('builds delegations that can close the original issue task lifecycle', () => {
+    const task = githubIssueTask();
+    const delegation = buildAutoDelegation(task, 'complex', 1778058000000);
+
+    expect(delegation).toEqual(expect.objectContaining({
+      id: 'auto-idx-github-issue-1778058000000',
+      type: 'code',
+      originTask: task.id,
+      verify: [
+        'gh issue view 83 --repo miles990/mini-agent --json state,title,labels',
+        'pnpm typecheck',
+        'pnpm test',
+      ],
+      timeoutMs: 1_500_000,
+    }));
+    expect(delegation.prompt).toContain('GitHub Issue Lifecycle');
+    expect(delegation.prompt).toContain('Source issue: miles990/mini-agent#83');
+    expect(delegation.prompt).toContain('isolated forge worktree');
+  });
+});
+
+function githubIssueTask(): MemoryIndexEntry {
+  return taskEntry({
+    id: 'idx-github-issue-miles990-mini-agent-83',
+    source: 'github-issue',
+    summary: 'P1 GitHub issue #83: review-backlog clogs prompt',
+    payload: {
+      origin: 'github-issue',
+      repo: 'miles990/mini-agent',
+      issue_number: 83,
+      priority: 1,
+      verify_command: 'gh issue view 83 --repo miles990/mini-agent --json state,title,labels && pnpm typecheck && pnpm test',
+      acceptance_criteria: 'Issue #83 is addressed with verification evidence.',
+    },
+  });
+}
+
+function taskEntry(overrides: Partial<MemoryIndexEntry>): MemoryIndexEntry {
+  return {
+    id: 'idx-task',
+    ts: '2026-05-06T00:00:00.000Z',
+    type: 'task',
+    status: 'pending',
+    summary: 'test task',
+    refs: [],
+    ...overrides,
+  };
+}

--- a/tests/workspace-isolation.test.ts
+++ b/tests/workspace-isolation.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+import { isCodePath, parseDirtyPaths } from '../src/workspace-isolation.js';
+
+describe('workspace isolation guard', () => {
+  it('parses porcelain paths without losing renamed or untracked paths', () => {
+    expect(parseDirtyPaths([
+      ' M memory/inner-notes.md',
+      '?? papers/',
+      'A  src/workspace-isolation.ts',
+    ].join('\n'))).toEqual([
+      'memory/inner-notes.md',
+      'papers/',
+      'src/workspace-isolation.ts',
+    ]);
+  });
+
+  it('treats source and config paths as code dirt but allows memory dirt', () => {
+    expect(isCodePath('src/auto-executor.ts')).toBe(true);
+    expect(isCodePath('tests/auto-executor.test.ts')).toBe(true);
+    expect(isCodePath('package.json')).toBe(true);
+    expect(isCodePath('memory/inner-notes.md')).toBe(false);
+    expect(isCodePath('papers/')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Add a workspace isolation guard that blocks auto-executor writes when the protected runtime checkout is on a feature branch or has code/config dirt
- Let GitHub issue tasks pass the complex verify gate and carry originTask so delegation completion updates the original task lifecycle
- Add workspace janitor dry-run/apply script for merged worktrees and stale merged branches

## Verification
- pnpm typecheck
- pnpm test --run tests/auto-executor.test.ts tests/issue-autopilot.test.ts tests/workspace-isolation.test.ts
- pnpm build
- pnpm exec tsx scripts/workspace-janitor.ts --json