### PR TITLE
fix(post-commit): auto-allow scope-contamination for memory/handoff chores

### DIFF
--- a/.githooks/post-commit
+++ b/.githooks/post-commit
@@ -64,6 +64,14 @@ case "$SUBJECT" in
       (
         trap '' HUP
         cd "$REPO_ROOT" || exit 1
+        # Issue #100: memory/handoff chores are append-only state files; pr-lifecycle
+        # scope-contamination guard is correct for code commits but blocks these.
+        # Narrow override scoped to two prefixes only.
+        case "$SUBJECT" in
+          "chore(memory):"*|"chore(handoff):"*)
+            export MINI_AGENT_ALLOW_SCOPE_CONTAMINATION=1
+            ;;
+        esac
         if git push origin "$BRANCH" >>"$PUSH_LOG" 2>&1; then
           echo "[post-commit] ✓ auto-pushed $BRANCH at $(date '+%Y-%m-%d %H:%M:%S') ($SUBJECT)" >>"$PUSH_LOG"
         else


### PR DESCRIPTION
Closes #100.

## Summary
- `.githooks/post-commit` now sets `MINI_AGENT_ALLOW_SCOPE_CONTAMINATION=1` inside the auto-push subshell when the commit subject starts with `chore(memory):` or `chore(handoff):`
- Override is scoped narrowly: two prefixes only, inside the existing auto-save case branch — code commits / topic branches unaffected
- Implements the patch proposal in #100 verbatim (case statement on `\$SUBJECT`)

## Why
Memory/handoff chores are append-only state files. Their subjects naturally reference whatever issues were active that cycle, tripping pr-lifecycle's scope-contamination guard. Currently every such commit logs `✗ auto-push failed` and accumulates locally — same end-state as the original local-commit-not-pushed P0, one layer deeper.

## Test plan
- [ ] After merge: next `chore(memory):*` commit should log `[post-commit] ✓ auto-pushed` in `/tmp/post-commit-push-mini-agent.log`
- [ ] `git rev-list --count origin/<branch>..HEAD` returns 0 within 1h of a `chore(memory):` commit
- [ ] Code commit on a feature branch with cross-issue refs still gets blocked (override not too broad)

🤖 Generated with [Claude Code](https://claude.com/claude-code)