### PR TITLE
fix: delete squash-merged local branches in janitor

### DIFF
--- a/scripts/workspace-janitor.ts
+++ b/scripts/workspace-janitor.ts
@@ -55,11 +55,15 @@ for (const branch of readLocalBranches()) {
   if (openPrBranches.has(branch)) continue;
   if (isBranchCheckedOut(branch, worktrees)) continue;
   if (mergedPrBranches.has(branch) || isMergedToBase(branch, base)) {
+    const githubMerged = mergedPrBranches.has(branch);
     actions.push({
       type: 'delete-local-branch',
       target: branch,
-      reason: mergedPrBranches.has(branch) ? 'PR already merged' : `already merged into ${base}`,
-      command: ['git', 'branch', '-d', branch],
+      reason: githubMerged ? 'PR already merged' : `already merged into ${base}`,
+      // Squash merges are not ancestors of main, so -d can reject branches that
+      // GitHub has already recorded as merged. Force is scoped to merged PR heads
+      // only; normal ancestor cleanup still uses -d.
+      command: ['git', 'branch', githubMerged ? '-D' : '-d', branch],
     });
   }
 }


### PR DESCRIPTION
## Summary
- Use git branch -D for local branches whose PR is already merged in GitHub
- Keep normal ancestor-based cleanup on git branch -d

## Verification
- pnpm typecheck
- pnpm build
- pnpm exec tsx scripts/workspace-janitor.ts --json