### PR TITLE
fix(correction-gate): wire hold-check into low-responsiveness (#124 option C)

### DIFF
--- a/src/correction-gate.ts
+++ b/src/correction-gate.ts
@@ -77,6 +77,9 @@ export function evaluateCorrectionGate(memoryDir: string, repoRoot = process.cwd
   const quality = hasPulseHistory ? Math.min(outputRate * 1.5, 1) : 0.7;
   const score = Math.min(Math.round(fulfillment * 40 + responsiveness * 35 + quality * 25), 100);
 
+  const holds = loadCorrectionHolds(memoryDir);
+  const acknowledgedHolds: ActiveHoldMatch[] = [];
+
   const reasons: CorrectionReason[] = [];
   const guidance: string[] = [];
 
@@ -89,10 +92,17 @@ export function evaluateCorrectionGate(memoryDir: string, repoRoot = process.cwd
   }
 
   if (responsiveness < 0.5) {
-    const stalest = [...activeTasks].sort((a, b) => ((b.payload as Record<string, unknown>)?.ticksSinceLastProgress as number ?? 0) - ((a.payload as Record<string, unknown>)?.ticksSinceLastProgress as number ?? 0))[0];
-    const message = `響應力低 (${Math.round(responsiveness * 100)}%) — 平均 ${avgStaleness.toFixed(1)} cycles 沒進展${stalest ? `，最停滯: ${stalest.summary?.slice(0, 50)}` : ''}。推進它。`;
-    reasons.push({ type: 'low-responsiveness', severity: 'medium', message, taskId: stalest?.id });
-    guidance.push(message);
+    const respHold = findActiveHold(holds, 'low-responsiveness', {}, { repoRoot });
+    if (respHold) {
+      // Documented hold (e.g., signal-lag with verified-closed issues — see mini-agent#124)
+      acknowledgedHolds.push(respHold);
+      guidance.push(`響應力低 (${Math.round(responsiveness * 100)}%) 但有 active hold (${respHold.matchedBy}): ${respHold.hold.reason}`);
+    } else {
+      const stalest = [...activeTasks].sort((a, b) => ((b.payload as Record<string, unknown>)?.ticksSinceLastProgress as number ?? 0) - ((a.payload as Record<string, unknown>)?.ticksSinceLastProgress as number ?? 0))[0];
+      const message = `響應力低 (${Math.round(responsiveness * 100)}%) — 平均 ${avgStaleness.toFixed(1)} cycles 沒進展${stalest ? `，最停滯: ${stalest.summary?.slice(0, 50)}` : ''}。推進它。`;
+      reasons.push({ type: 'low-responsiveness', severity: 'medium', message, taskId: stalest?.id });
+      guidance.push(message);
+    }
   }
 
   if (hasPulseHistory && quality < 0.4) {
@@ -102,8 +112,6 @@ export function evaluateCorrectionGate(memoryDir: string, repoRoot = process.cwd
   }
 
   const shipTruth = readShipTruth(repoRoot);
-  const holds = loadCorrectionHolds(memoryDir);
-  const acknowledgedHolds: ActiveHoldMatch[] = [];
 
   if (shipTruth.state === 'pending-push' || shipTruth.state === 'diverged') {
     const match = findActiveHold(holds, 'local-commit-not-pushed', {


### PR DESCRIPTION
Closes part of #124.

## What

Adds hold-check to the `low-responsiveness` branch in `src/correction-gate.ts`, mirroring the existing pattern in the `local-commit-not-pushed` branch. Hoists `holds` + `acknowledgedHolds` declarations above the reasons block so both branches can share them.

## Why (#124 option C: hold-on-stale)

Three cycles of P0 `low-responsiveness` re-injection on the same trio (#77/#97/#100) — all verified resolved on disk — turned into one tracked issue (#124) with three patch options:

- **A. reconcile-on-read** — re-derive task status from `task-events.jsonl` latest event
- **B. auto-progress-on-commit** — update `ticksSinceLastProgress` on git activity
- **C. hold-on-stale** — let an operator (or auto-reconciler) suppress the signal via `CorrectionHold` records ← **this PR**

Option C is the lowest-risk, smallest-diff piece. It doesn't change scoring logic or task-progress derivation — it just makes the existing hold mechanism reachable from one more reason type.

## How to use the new escape hatch

Append to `memory/state/correction-holds.jsonl`:

```json
{"id":"hold-124-signal-lag","correction_reason_type":"low-responsiveness","reason":"signal-lag: stalest tasks all verified-closed on disk (#124)","unblock_when":{"kind":"timeout","until":"2026-05-13T00:00:00Z"},"created_at":"2026-05-06T08:30:00Z","created_by":"kuro"}
```

Next correction-gate eval: `acknowledgedHolds` populated, `low-responsiveness` reason **not** pushed, scheduler stops re-injecting.

## Falsifier

`memory/state/correction-holds.jsonl` written with `correction_reason_type=low-responsiveness` AND next correction-gate run produces `acknowledgedHolds.length >= 1` AND `reasons` does not contain `low-responsiveness` → patch works.

## Test

- `npx tsc --noEmit` passes
- Diff: 1 file, +14/-6
- Behavior identical when no matching hold exists (fall-through to original reason emit)

Follow-ups (#124 still open): A and B for the systemic fix.