### PR TITLE
fix: complete scheduler-bound tasks by id fallback

### DIFF
--- a/src/loop.ts
+++ b/src/loop.ts
@@ -2986,6 +2986,21 @@ export class AgentLoop {
           // the agent said it's done, so release the scheduler binding.
           const schedState = getSchedulerState();
           if (schedState.currentTaskId) {
+            if (markedCount === 0) {
+              try {
+                const { markTaskDoneById } = await import('./memory-index.js');
+                const markedCurrent = await markTaskDoneById(
+                  path.join(process.cwd(), 'memory'),
+                  schedState.currentTaskId,
+                  'current-task done fallback',
+                );
+                if (markedCurrent) {
+                  slog('DONE', `Marked scheduler current task by id fallback: ${schedState.currentTaskId.slice(0, 16)}`);
+                }
+              } catch (err) {
+                slog('DONE', `⚠️ current task fallback failed: ${err instanceof Error ? err.message : String(err)}`);
+              }
+            }
             schedulerTaskDone(schedState.currentTaskId);
             completeProcess(schedState.currentTaskId);
           }

--- a/src/memory-index.ts
+++ b/src/memory-index.ts
@@ -1613,6 +1613,36 @@ export async function markTaskDoneByDescription(
   return totalMarked;
 }
 
+export async function markTaskDoneById(
+  memoryDir: string,
+  taskId: string,
+  reason = 'scheduler binding done',
+): Promise<boolean> {
+  const task = queryMemoryIndexSync(memoryDir, {
+    id: taskId,
+    type: ['task', 'goal'],
+    status: ['pending', 'in_progress'],
+    limit: 1,
+  })[0];
+  if (!task) return false;
+
+  const payload = {
+    ...((task.payload ?? {}) as Record<string, unknown>),
+    completed_by: reason,
+    completed_at: new Date().toISOString(),
+  };
+  const updated = await updateMemoryIndexEntry(memoryDir, task.id, {
+    status: 'completed',
+    payload,
+  });
+  if (!updated) return false;
+
+  eventBus.emit('action:task', { content: updated.summary, entry: updated });
+  if (updated.summary) await resolveActiveCommitments(memoryDir, updated.summary);
+  slog('DONE', `Marked scheduler-bound task done: ${updated.summary?.slice(0, 60)}`);
+  return true;
+}
+
 /**
  * Auto-complete reply tasks by roomMsgId.
  * Called when inbox processing confirms a message was replied/addressed.

--- a/tests/scheduler-completion-fallback.test.ts
+++ b/tests/scheduler-completion-fallback.test.ts
@@ -1,0 +1,61 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  appendMemoryIndexEntry,
+  markTaskDoneById,
+  queryMemoryIndexSync,
+} from '../src/memory-index.js';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(path.join(os.tmpdir(), 'mini-agent-scheduler-completion-'));
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('scheduler completion fallback', () => {
+  it('writes completed status to task-events when the current scheduler task is done by id', async () => {
+    const task = await appendMemoryIndexEntry(tmpDir, {
+      id: 'idx-current',
+      type: 'task',
+      status: 'pending',
+      summary: 'P1 current scheduler task',
+      refs: [],
+      payload: { priority: 1 },
+    });
+
+    const marked = await markTaskDoneById(tmpDir, task.id, 'test fallback');
+
+    expect(marked).toBe(true);
+    expect(queryMemoryIndexSync(tmpDir, { id: task.id })[0]).toEqual(expect.objectContaining({
+      status: 'completed',
+      payload: expect.objectContaining({
+        completed_by: 'test fallback',
+        completed_at: expect.any(String),
+      }),
+    }));
+    expect(queryMemoryIndexSync(tmpDir, {
+      type: ['task'],
+      status: ['pending', 'in_progress'],
+    }).map(t => t.id)).not.toContain(task.id);
+  });
+
+  it('is a no-op when the task is already terminal', async () => {
+    const task = await appendMemoryIndexEntry(tmpDir, {
+      id: 'idx-completed',
+      type: 'task',
+      status: 'completed',
+      summary: 'P1 already completed task',
+      refs: [],
+    });
+
+    await expect(markTaskDoneById(tmpDir, task.id)).resolves.toBe(false);
+    expect(queryMemoryIndexSync(tmpDir, { id: task.id })[0].status).toBe('completed');
+  });
+});


### PR DESCRIPTION
Closes #75.

## Summary
- Add markTaskDoneById so scheduler-bound tasks can be completed by stable task id
- When <kuro:done> descriptions do not fuzzy-match any pending task, complete the current scheduler task in memory-index before releasing the scheduler/process binding
- Add regression tests proving the fallback removes the task from pending/in_progress queries

## Verification
- pnpm typecheck
- pnpm test --run tests/scheduler-completion-fallback.test.ts tests/process-table.test.ts tests/memory-index-buckets.test.ts
- pnpm build