### PR TITLE
fix: surface dirty runtime workspace corrections

### DIFF
--- a/src/correction-gate.ts
+++ b/src/correction-gate.ts
@@ -16,7 +16,8 @@ export type CorrectionReasonType =
   | 'pending-pledge'
   | 'low-responsiveness'
   | 'low-output-quality'
-  | 'local-commit-not-pushed';
+  | 'local-commit-not-pushed'
+  | 'dirty-runtime-workspace';
 
 export interface CorrectionReason {
   type: CorrectionReasonType;
@@ -38,6 +39,7 @@ export interface ShipTruthState {
   ahead: number;
   behind: number;
   dirty: boolean;
+  dirtyPaths: string[];
   state: 'not-repo' | 'clean' | 'dirty' | 'pending-push' | 'behind' | 'diverged' | 'unknown';
 }
 
@@ -120,6 +122,25 @@ export function evaluateCorrectionGate(memoryDir: string, repoRoot = process.cwd
     } else {
       const message = `交付狀態未完成 — local branch ahead origin ${shipTruth.ahead} commit(s)，只能視為 committed-local/pending-push，不是 shipped。`;
       reasons.push({ type: 'local-commit-not-pushed', severity: 'high', message });
+      guidance.push(message);
+    }
+  }
+
+  if (shipTruth.state === 'dirty') {
+    const match = findActiveHold(holds, 'dirty-runtime-workspace', {
+      branch: shipTruth.branch,
+      sha: shipTruth.headSha,
+    }, { repoRoot });
+
+    if (match) {
+      acknowledgedHolds.push(match);
+      guidance.push(
+        `runtime workspace dirty 但有 active hold (${match.matchedBy}): ${match.hold.reason}`,
+      );
+    } else {
+      const paths = shipTruth.dirtyPaths.slice(0, 5).join(', ') || 'unknown paths';
+      const message = `runtime workspace 有未整理變更 — ${paths}。先提交、移出、或清理，不能把部署 checkout 當開發/產物工作區。`;
+      reasons.push({ type: 'dirty-runtime-workspace', severity: 'high', message });
       guidance.push(message);
     }
   }
@@ -287,7 +308,7 @@ function parseCorrectionReasonFromSummary(summary: string): string {
 
 function readShipTruth(repoRoot: string): ShipTruthState {
   if (!existsSync(path.join(repoRoot, '.git'))) {
-    return { repoPresent: false, branch: null, headSha: null, ahead: 0, behind: 0, dirty: false, state: 'not-repo' };
+    return { repoPresent: false, branch: null, headSha: null, ahead: 0, behind: 0, dirty: false, dirtyPaths: [], state: 'not-repo' };
   }
 
   try {
@@ -299,7 +320,7 @@ function readShipTruth(repoRoot: string): ShipTruthState {
     });
     return parseGitStatusPorcelainV2(status);
   } catch {
-    return { repoPresent: true, branch: null, headSha: null, ahead: 0, behind: 0, dirty: false, state: 'unknown' };
+    return { repoPresent: true, branch: null, headSha: null, ahead: 0, behind: 0, dirty: false, dirtyPaths: [], state: 'unknown' };
   }
 }
 
@@ -309,6 +330,7 @@ export function parseGitStatusPorcelainV2(status: string): ShipTruthState {
   let ahead = 0;
   let behind = 0;
   let dirty = false;
+  const dirtyPaths: string[] = [];
 
   for (const line of status.split('\n')) {
     if (line.startsWith('# branch.oid ')) {
@@ -322,7 +344,12 @@ export function parseGitStatusPorcelainV2(status: string): ShipTruthState {
       ahead = aheadMatch ? Number(aheadMatch[1]) : 0;
       behind = behindMatch ? Number(behindMatch[1]) : 0;
     }
-    if (line && !line.startsWith('#')) dirty = true;
+    if (line && !line.startsWith('#')) {
+      dirty = true;
+      const parts = line.split(' ');
+      const path = parts[parts.length - 1]?.trim();
+      if (path) dirtyPaths.push(path);
+    }
   }
 
   let state: ShipTruthState['state'] = 'clean';
@@ -331,5 +358,5 @@ export function parseGitStatusPorcelainV2(status: string): ShipTruthState {
   else if (behind > 0) state = 'behind';
   else if (dirty) state = 'dirty';
 
-  return { repoPresent: true, branch, headSha, ahead, behind, dirty, state };
+  return { repoPresent: true, branch, headSha, ahead, behind, dirty, dirtyPaths, state };
 }

--- a/src/workspace-isolation.ts
+++ b/src/workspace-isolation.ts
@@ -17,7 +17,7 @@ export interface WorkspaceIsolationDecision extends WorkspaceIsolationSnapshot {
 }
 
 const SAFE_RUNTIME_BRANCHES = new Set(['main', 'runtime/main']);
-const CODE_PATH_PATTERN = /^(src|tests|scripts|plugins|skills|tools|\.githooks|\.github)\//;
+const CODE_PATH_PATTERN = /^(src|tests|scripts|plugins|skills|tools|kuro-portfolio|knowledge-graph|\.githooks|\.github)\//;
 const CODE_FILE_PATTERN = /^(package\.json|pnpm-lock\.yaml|tsconfig\.json|agent-compose\.yaml)$/;
 
 export function evaluateWorkspaceIsolation(cwd = process.cwd(), protectedRoot = process.env.MINI_AGENT_RUNTIME_WORKSPACE): WorkspaceIsolationDecision {

--- a/tests/correction-gate.test.ts
+++ b/tests/correction-gate.test.ts
@@ -81,7 +81,26 @@ describe('correction gate', () => {
       ahead: 2,
       behind: 0,
       dirty: false,
+      dirtyPaths: [],
       state: 'pending-push',
+    }));
+  });
+
+  it('parses dirty runtime paths as dirty ship truth', () => {
+    const parsed = parseGitStatusPorcelainV2([
+      '# branch.oid abc123',
+      '# branch.head runtime/main',
+      '# branch.upstream origin/main',
+      '# branch.ab +0 -0',
+      '1 .M N... 100644 100644 100644 abc abc kuro-portfolio/ai-trend/index.html',
+      '? knowledge-graph/',
+      '',
+    ].join('\n'));
+
+    expect(parsed).toEqual(expect.objectContaining({
+      dirty: true,
+      dirtyPaths: ['kuro-portfolio/ai-trend/index.html', 'knowledge-graph/'],
+      state: 'dirty',
     }));
   });
 

--- a/tests/workspace-isolation.test.ts
+++ b/tests/workspace-isolation.test.ts
@@ -15,10 +15,12 @@ describe('workspace isolation guard', () => {
     ]);
   });
 
-  it('treats source and config paths as code dirt but allows memory dirt', () => {
+  it('treats source, config, and managed output paths as blocking dirt but allows memory dirt', () => {
     expect(isCodePath('src/auto-executor.ts')).toBe(true);
     expect(isCodePath('tests/auto-executor.test.ts')).toBe(true);
     expect(isCodePath('package.json')).toBe(true);
+    expect(isCodePath('kuro-portfolio/ai-trend/index.html')).toBe(true);
+    expect(isCodePath('knowledge-graph/')).toBe(true);
     expect(isCodePath('memory/inner-notes.md')).toBe(false);
     expect(isCodePath('papers/')).toBe(false);
   });


### PR DESCRIPTION
## Summary
- Treat dirty runtime checkout state as a first-class correction reason instead of silently passing it through.
- Include dirty paths in ship-truth parsing so the correction task is actionable.
- Classify managed output/cross-project paths (kuro-portfolio/, knowledge-graph/) as blocking protected-runtime dirt for autonomous delegation.
- Integrate the low-responsiveness correction hold behavior from PR #125 so correction-gate fixes land as one coherent change.

Refs #124. Supersedes #125.

## Verification
- pnpm typecheck
- pnpm test --run tests/correction-gate.test.ts tests/workspace-isolation.test.ts tests/auto-executor.test.ts
- pnpm build