### PR TITLE
fix: resolve grep falsifier commitments

### DIFF
--- a/src/commitment-ledger.ts
+++ b/src/commitment-ledger.ts
@@ -42,7 +42,7 @@ export type Counterparty =
 // `manual` is the escape hatch for predictions that truly need human judgment.
 export type FalsifierQuery =
   | { kind: 'kg_count';    query: string; op: '<=' | '>=' | '=='; threshold: number }
-  | { kind: 'log_grep';    pattern: string; since_iso: string; op: '<=' | '>=' | '=='; threshold: number }
+  | { kind: 'log_grep';    path: string; pattern: string; since_iso: string; op: '<=' | '>=' | '=='; threshold: number }
   | { kind: 'file_exists'; path: string; must: boolean }
   | { kind: 'metric';      metric: string; op: '<=' | '>=' | '=='; threshold: number }
   | { kind: 'manual';      description: string };
@@ -266,8 +266,8 @@ export function auditCommitments(currentCycleId: number): CommitmentAudit {
 // =============================================================================
 
 // Cheap, synchronous query runners. Network-bound kinds (kg_count) and
-// higher-cost scans (log_grep, metric) return inconclusive for now —
-// they'll be wired in follow-up patches once the plumbing is proven.
+// runtime metric checks return inconclusive for now; file-local checks execute
+// inline so ledger commitments can resolve without delegation.
 
 /**
  * Parse a falsifier string for explicit FalsifierQuery DSL markers.
@@ -277,6 +277,9 @@ export function auditCommitments(currentCycleId: number): CommitmentAudit {
  * Supported DSL markers (opt-in, write anywhere in the falsifier text):
  *   file_exists:/abs/path      -> { kind:'file_exists', path, must:true }
  *   file_not_exists:/abs/path  -> { kind:'file_exists', path, must:false }
+ *   grep:/abs/path "pattern" [since:ISO] >=N
+ *   grep:/abs/path "pattern" [since:ISO] <=N
+ *   grep:/abs/path "pattern" [since:ISO] ==N
  *
  * Closes the cycle 80 STRUCTURAL gap: dispatcher.ts:1024 + loop.ts:2659
  * writeCommitment calls now auto-populate falsifier_query so
@@ -290,6 +293,20 @@ export function parseFalsifierToQuery(falsifier: string): FalsifierQuery | undef
   if (neg) return { kind: 'file_exists', path: neg[1], must: false };
   const pos = falsifier.match(new RegExp(String.raw`\bfile_exists:(\/\S+?)` + stop));
   if (pos) return { kind: 'file_exists', path: pos[1], must: true };
+
+  const grep = falsifier.match(
+    /\bgrep:(\/\S+?)\s+"((?:[^"\\]|\\.)*)"(?:\s+since:(\S+?))?\s+(>=|<=|==)\s*(\d+)/,
+  );
+  if (grep) {
+    return {
+      kind: 'log_grep',
+      path: grep[1],
+      pattern: unescapeQuotedPattern(grep[2]),
+      since_iso: grep[3] ?? new Date().toISOString(),
+      op: grep[4] as '<=' | '>=' | '==',
+      threshold: Number.parseInt(grep[5], 10),
+    };
+  }
   return undefined;
 }
 
@@ -315,14 +332,70 @@ function runQuery(q: FalsifierQuery): QueryResult {
         conclusive: false,
         evidence: `manual: ${q.description} (awaiting manual resolution)`,
       };
-    case 'kg_count':
     case 'log_grep':
+      return runLogGrepQuery(q);
+    case 'kg_count':
     case 'metric':
       return {
         conclusive: false,
         evidence: `kind=${q.kind} executor not yet implemented (Phase 1.5 stub)`,
       };
   }
+}
+
+function runLogGrepQuery(q: Extract<FalsifierQuery, { kind: 'log_grep' }>): QueryResult {
+  if (!existsSync(q.path)) {
+    return {
+      conclusive: true,
+      verdict: 'refuted',
+      evidence: `log_grep: file ${q.path} does not exist`,
+    };
+  }
+
+  let re: RegExp;
+  try {
+    re = new RegExp(q.pattern);
+  } catch (err) {
+    return {
+      conclusive: false,
+      evidence: `log_grep: invalid regex /${q.pattern}/: ${(err as Error).message}`,
+    };
+  }
+
+  const sinceMs = Date.parse(q.since_iso);
+  const useSince = !Number.isNaN(sinceMs);
+  const content = readFileSync(q.path, 'utf-8');
+  let count = 0;
+
+  for (const line of content.split('\n')) {
+    if (!re.test(line)) continue;
+    if (!useSince) {
+      count++;
+      continue;
+    }
+
+    const tsMatch = line.match(/\b\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z?\b/);
+    if (!tsMatch) {
+      count++;
+      continue;
+    }
+    if (Date.parse(tsMatch[0]) >= sinceMs) count++;
+  }
+
+  const kept =
+    q.op === '>=' ? count >= q.threshold :
+    q.op === '<=' ? count <= q.threshold :
+    count === q.threshold;
+
+  return {
+    conclusive: true,
+    verdict: kept ? 'kept' : 'refuted',
+    evidence: `log_grep ${q.path} /${q.pattern}/ since ${q.since_iso} -> count=${count} ${q.op}${q.threshold} -> ${kept ? 'kept' : 'refuted'}`,
+  };
+}
+
+function unescapeQuotedPattern(pattern: string): string {
+  return pattern.replace(/\\(["\\])/g, '$1');
 }
 
 export function resolveReadyCommitments(
@@ -413,7 +486,7 @@ export function buildLedgerSection(currentCycleId: number): string {
         const q = e.falsifier_query;
         const qDesc =
           q.kind === 'kg_count'    ? `kg_count(${q.query}) ${q.op} ${q.threshold}` :
-          q.kind === 'log_grep'    ? `log_grep(${q.pattern}) ${q.op} ${q.threshold} since ${q.since_iso}` :
+          q.kind === 'log_grep'    ? `log_grep(${q.path} /${q.pattern}/) ${q.op} ${q.threshold} since ${q.since_iso}` :
           q.kind === 'file_exists' ? `file_exists(${q.path}) must=${q.must}` :
           q.kind === 'metric'      ? `metric(${q.metric}) ${q.op} ${q.threshold}` :
           /* manual */               `manual: ${q.description}`;

--- a/tests/commitment-ledger.test.ts
+++ b/tests/commitment-ledger.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { mkdtempSync, rmSync, readFileSync } from 'node:fs';
+import { mkdtempSync, rmSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
@@ -23,6 +23,8 @@ import {
   expireOverdueCommitments,
   auditCommitments,
   readPendingCommitments,
+  parseFalsifierToQuery,
+  resolveReadyCommitments,
 } from '../src/commitment-ledger.js';
 
 describe('commitment-ledger trust-layer branching', () => {
@@ -175,5 +177,114 @@ describe('commitment-ledger trust-layer branching', () => {
     expect(audit.abandoned).toBe(1);
     expect(audit.expired).toBe(1);
     expect(audit.pending).toBe(1);
+  });
+
+  it('parses grep falsifier DSL into log_grep query', () => {
+    const parsed = parseFalsifierToQuery('next cycle grep:/tmp/x.log "foo.*bar" >=3');
+
+    expect(parsed).toEqual(expect.objectContaining({
+      kind: 'log_grep',
+      path: '/tmp/x.log',
+      pattern: 'foo.*bar',
+      op: '>=',
+      threshold: 3,
+    }));
+    expect(parsed && parsed.kind === 'log_grep' ? parsed.since_iso : '').toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('parses grep falsifier DSL with explicit since timestamp', () => {
+    const parsed = parseFalsifierToQuery('grep:/tmp/x.log "bar" since:2026-05-01T00:00:00Z ==0');
+
+    expect(parsed).toEqual({
+      kind: 'log_grep',
+      path: '/tmp/x.log',
+      pattern: 'bar',
+      since_iso: '2026-05-01T00:00:00Z',
+      op: '==',
+      threshold: 0,
+    });
+  });
+
+  it('auto-populates log_grep query and resolves kept when count meets threshold', () => {
+    const logPath = path.join(tmpStateDir, 'server.log');
+    writeFileSync(logPath, [
+      '2026-05-06T00:00:00Z alpha',
+      '2026-05-06T00:01:00Z alpha',
+      '2026-05-06T00:02:00Z beta',
+      '2026-05-06T00:03:00Z alpha',
+    ].join('\n'), 'utf-8');
+
+    writeCommitment({
+      cycle_id: 10,
+      prediction: 'alpha appears often enough',
+      falsifier: `grep:${logPath} "alpha" since:2026-05-06T00:00:00Z >=3`,
+      ttl_cycles: 5,
+      counterparty: { kind: 'self' },
+    });
+
+    const resolved = resolveReadyCommitments(11);
+    const audit = auditCommitments(11);
+
+    expect(resolved).toEqual({ resolved: 1, skipped: 0 });
+    expect(audit.kept).toBe(1);
+    expect(readPendingCommitments()).toHaveLength(0);
+  });
+
+  it('resolves log_grep as refuted when count misses threshold', () => {
+    const logPath = path.join(tmpStateDir, 'server.log');
+    writeFileSync(logPath, [
+      '2026-05-06T00:00:00Z alpha',
+      '2026-05-06T00:01:00Z beta',
+    ].join('\n'), 'utf-8');
+
+    writeCommitment({
+      cycle_id: 10,
+      prediction: 'alpha appears three times',
+      falsifier: `grep:${logPath} "alpha" since:2026-05-06T00:00:00Z >=3`,
+      ttl_cycles: 5,
+      counterparty: { kind: 'self' },
+    });
+
+    resolveReadyCommitments(11);
+    const audit = auditCommitments(11);
+
+    expect(audit.refuted).toBe(1);
+  });
+
+  it('treats missing log_grep file as refuted evidence', () => {
+    writeCommitment({
+      cycle_id: 10,
+      prediction: 'missing log exists',
+      falsifier: `grep:${path.join(tmpStateDir, 'missing.log')} "alpha" >=1`,
+      ttl_cycles: 5,
+      counterparty: { kind: 'self' },
+    });
+
+    resolveReadyCommitments(11);
+    const ledger = readFileSync(path.join(tmpStateDir, 'commitments.jsonl'), 'utf-8');
+
+    expect(auditCommitments(11).refuted).toBe(1);
+    expect(ledger).toContain('does not exist');
+  });
+
+  it('filters ISO-timestamped log_grep lines by since timestamp', () => {
+    const logPath = path.join(tmpStateDir, 'server.log');
+    writeFileSync(logPath, [
+      '2026-05-05T23:59:00Z alpha',
+      '2026-05-06T00:00:00Z alpha',
+      'alpha without timestamp',
+    ].join('\n'), 'utf-8');
+
+    writeCommitment({
+      cycle_id: 10,
+      prediction: 'old alpha is ignored, timestamp-less alpha is conservative-counted',
+      falsifier: `grep:${logPath} "alpha" since:2026-05-06T00:00:00Z ==2`,
+      ttl_cycles: 5,
+      counterparty: { kind: 'self' },
+    });
+
+    resolveReadyCommitments(11);
+
+    expect(auditCommitments(11).kept).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary
- Extend `FalsifierQuery.log_grep` with an explicit `path`.
- Parse `grep:/abs/path "pattern" [since:ISO] >=N|<=N|==N` markers from falsifier text.
- Execute `log_grep` synchronously so commitments can resolve to kept/refuted instead of aging out.
- Add tests for parser, explicit/default since, missing file, threshold miss, and timestamp filtering.

Closes #78.

## Verification
- pnpm typecheck
- pnpm test --run tests/commitment-ledger.test.ts
- pnpm build