### PR TITLE
fix: prune disposable base worktrees

### DIFF
--- a/scripts/workspace-janitor.ts
+++ b/scripts/workspace-janitor.ts
@@ -39,6 +39,15 @@ if (path.resolve(root) === protectedRoot && !['main', 'runtime/main'].includes(c
 for (const wt of worktrees) {
   if (!wt.branch) continue;
   if (path.resolve(wt.path) === protectedRoot) continue;
+  if (wt.branch === base && isDisposableBaseWorktree(wt.path) && isWorktreeClean(wt.path)) {
+    actions.push({
+      type: 'remove-worktree',
+      target: wt.path,
+      reason: `clean disposable ${base} worktree blocks future checkout of ${base}`,
+      command: ['git', 'worktree', 'remove', wt.path],
+    });
+    continue;
+  }
   if (openPrBranches.has(wt.branch)) continue;
   if (mergedPrBranches.has(wt.branch) && isWorktreeClean(wt.path)) {
     actions.push({
@@ -188,6 +197,12 @@ function readRemoteBranches(): string[] {
 
 function isWorktreeClean(worktreePath: string): boolean {
   return (git(['-C', worktreePath, 'status', '--porcelain']) ?? '').trim().length === 0;
+}
+
+function isDisposableBaseWorktree(worktreePath: string): boolean {
+  const name = path.basename(worktreePath);
+  const runtimeName = path.basename(protectedRoot);
+  return name !== runtimeName && name.startsWith(`${runtimeName}-`);
 }
 
 function isBranchCheckedOut(branch: string, records: WorktreeRecord[]): boolean {


### PR DESCRIPTION
## Summary
- Teach workspace janitor to remove clean disposable worktrees that checkout the base branch (`main`).
- Prevent `fatal: main is already used by worktree ...` from recurring when GUI/agents try to switch branches.
- Keep protected runtime workspace exempt; runtime remains on `runtime/main`, while task work uses feature branches.

## Operating rule
- Runtime/deploy checkout: `/Users/user/Workspace/mini-agent` on `runtime/main`, tracking `origin/main`.
- Work changes: isolated `mini-agent-*` worktree on feature branch from `origin/main`.
- No long-lived `main` worktree.

## Verification
- Created temporary `../mini-agent-main-guard-test` on `main`.
- `pnpm exec tsx scripts/workspace-janitor.ts --json` reported `clean disposable main worktree blocks future checkout of main`.
- Removed temporary worktree.
- pnpm typecheck
- pnpm build