### PR TITLE
fix(memory): broaden isStaleFailureOutput patterns (#83 follow-up)

### DIFF
--- a/src/memory.ts
+++ b/src/memory.ts
@@ -4317,6 +4317,13 @@ function isStaleFailureOutput(text: string): boolean {
   if (/Claude Code returned an error result/i.test(head)) return true;
   if (/process aborted by user/i.test(head)) return true;
   if (/^\s*\[(ERROR|TIMEOUT|ABORT)/i.test(head)) return true;
+  // Issue #83 follow-up: broaden coverage to dispatch/runtime failures observed in prompt
+  if (/^\s*dispatch error:/i.test(head)) return true;
+  if (/^\s*\(no output\)\s*$/.test(head.trim())) return true;
+  if (/cancelled via killAllDelegations/.test(head)) return true;
+  if (/middleware plan did not reach terminal state/i.test(head)) return true;
+  if (/Reached maximum number of turns/i.test(head)) return true;
+  if (/timed out after \d+ms/i.test(head)) return true;
   return false;
 }
 


### PR DESCRIPTION
Closes part of #83 (Patch A coverage gap follow-up).

## Why

Patches A (e815f789) and B (f1693afa) shipped, but the cycle prompt this morning still showed `## 84 unreviewed delegations` with `... +74 more [delegation-render-cap]`. Patch A is supposed to filter failure-class entries at archival, but the existing regex set only catches:

- `[FAILED ...`
- `[ERROR / [TIMEOUT / [ABORT ...`
- `Claude Code returned an error result`
- `process aborted by user`

Real entries currently surviving filter (sampled from this cycle's prompt):

- `dispatch error: POST /accomplish timed out after 30000ms` (×dozens)
- `(no output)` (×many)
- `cancelled via killAllDelegations`
- `middleware plan did not reach terminal state`
- `Reached maximum number of turns`

These age out only at the 7-day TTL → ~22KB prompt tax for a week per burst.

## Patch

`src/memory.ts: isStaleFailureOutput` — +6 regex branches matching the failure phrases above.

## Falsifier

- After merge + one cycle, `tail review-backlog.jsonl | wc -l` in running instance ≤30 (vs current ~84). `clearReviewedDelegations` runs every cycle and now retroactively prunes pre-patch failures via the broadened detector.
- 30 days post-merge, no observed regression (false positive: legitimate review entry getting filtered) — the patterns are anchored or unique enough that prose summaries with mid-text "timed out" should not match (`/timed out after \d+ms/i` requires the `\d+ms` suffix).

## Risk

+7 lines. No exported API change. Patterns are anchored regex against the head 500 chars of the summary. typecheck passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)