### PR TITLE
fix(issue-autopilot): reconcile GitHub-closed issues to drain stale P0 queue

### DIFF
--- a/memory/handoffs/active.md
+++ b/memory/handoffs/active.md
@@ -106,4 +106,7 @@
 | github | akari | PR #134 fix: route forge changes through PR branches | merged | 05-06 | 05-06 |
 | github | codex | PR #134 fix: route forge changes through PR branches | merged | 05-06 | 05-06 |
 | github | claude-code | PR #134 fix: route forge changes through PR branches | merged | 05-06 | 05-06 |
-| github | akari | PR #133 fix(memory): broaden isStaleFailureOutput patterns (#83 follow-up) | changes-requested | 05-06 | - |
+| github | akari | PR #133 fix(memory): broaden isStaleFailureOutput patterns (#83 follow-up) | merged | 05-06 | 05-06 |
+| github | akari | PR #135 fix(issue-autopilot): reconcile GitHub-closed issues to drain stale P0 queue | changes-requested | 05-06 | - |
+| github | codex | PR #135 fix(issue-autopilot): reconcile GitHub-closed issues to drain stale P0 queue | changes-requested | 05-06 | - |
+| github | claude-code | PR #135 fix(issue-autopilot): reconcile GitHub-closed issues to drain stale P0 queue | changes-requested | 05-06 | - |

--- a/src/issue-autopilot.ts
+++ b/src/issue-autopilot.ts
@@ -6,6 +6,7 @@ export interface GitHubIssueSummary {
   number: number;
   title: string;
   url?: string;
+  state?: 'OPEN' | 'CLOSED' | string;
   body?: string;
   labels?: Array<{ name: string } | string>;
   assignees?: Array<{ login: string } | string>;
@@ -35,6 +36,7 @@ export interface IssueAutopilotSyncResult {
   scanned: number;
   created: number;
   updated: number;
+  closed: number;
   skipped: number;
   plans: IssueTaskPlan[];
 }
@@ -74,13 +76,36 @@ export async function syncGitHubIssuesToTasks(
   issues: GitHubIssueSummary[],
   options: IssueAutopilotSyncOptions,
 ): Promise<IssueAutopilotSyncResult> {
-  const plans = issues
-    .filter(issue => Number.isInteger(issue.number) && issue.number > 0 && issue.title.trim().length > 0)
-    .map(issue => planIssueTask(issue, options));
+  const validIssues = issues
+    .filter(issue => Number.isInteger(issue.number) && issue.number > 0 && issue.title.trim().length > 0);
+  const openIssues = validIssues.filter(issue => (issue.state ?? 'OPEN').toUpperCase() !== 'CLOSED');
+  const closedIssues = validIssues.filter(issue => (issue.state ?? 'OPEN').toUpperCase() === 'CLOSED');
+  const plans = openIssues.map(issue => planIssueTask(issue, options));
 
   let created = 0;
   let updated = 0;
+  let closed = 0;
   let skipped = 0;
+
+  // Reconcile: GitHub-closed issues whose local task entry is still pending/in_progress.
+  // Without this, closed issues stay rendered as P0 forever (root cause of stale task queue).
+  for (const issue of closedIssues) {
+    const id = issueTaskId(options.repo, issue.number);
+    const existing = queryMemoryIndexSync(memoryDir, { id, limit: 1 })[0];
+    if (!existing) { skipped++; continue; }
+    if (TERMINAL_TASK_STATUSES.has(String(existing.status))) { skipped++; continue; }
+    if (options.dryRun) { closed++; continue; }
+    await updateMemoryIndexEntry(memoryDir, existing.id, {
+      status: 'completed',
+      payload: {
+        ...(existing.payload ?? {}),
+        closed_via: 'issue-autopilot-reconciliation',
+        github_state: 'CLOSED',
+        closed_at: (options.now ?? new Date()).toISOString(),
+      },
+    });
+    closed++;
+  }
 
   for (const plan of plans) {
     const existing = queryMemoryIndexSync(memoryDir, { id: plan.id, limit: 1 })[0];
@@ -116,8 +141,8 @@ export async function syncGitHubIssuesToTasks(
     created++;
   }
 
-  const result = { scanned: issues.length, created, updated, skipped, plans };
-  slog('ISSUE-AUTOPILOT', `scanned=${result.scanned} created=${created} updated=${updated} skipped=${skipped}`);
+  const result = { scanned: issues.length, created, updated, closed, skipped, plans };
+  slog('ISSUE-AUTOPILOT', `scanned=${result.scanned} created=${created} updated=${updated} closed=${closed} skipped=${skipped}`);
   return result;
 }
 
@@ -128,11 +153,11 @@ export function readOpenIssuesFromGitHub(repo: string, limit = 50): GitHubIssueS
     '--repo',
     repo,
     '--state',
-    'open',
+    'all',
     '--limit',
     String(limit),
     '--json',
-    'number,title,url,labels,assignees,createdAt,updatedAt',
+    'number,title,url,state,labels,assignees,createdAt,updatedAt',
   ], {
     encoding: 'utf-8',
     stdio: ['ignore', 'pipe', 'pipe'],

--- a/tests/issue-autopilot.test.ts
+++ b/tests/issue-autopilot.test.ts
@@ -115,4 +115,54 @@ describe('issue autopilot', () => {
     expect(result).toEqual(expect.objectContaining({ created: 0, updated: 0, skipped: 1 }));
     expect(queryMemoryIndexSync(tmpDir, { id: issueTaskId('miles990/mini-agent', 77) })[0].status).toBe('completed');
   });
+
+  it('reconciles GitHub-closed issues by marking local pending entries completed', async () => {
+    // Seed: a local task entry for what was previously an open issue.
+    await appendMemoryIndexEntry(tmpDir, {
+      id: issueTaskId('miles990/mini-agent', 75),
+      type: 'task',
+      status: 'pending',
+      source: 'github-issue',
+      summary: 'P2 GitHub issue #75: stale-pending despite closed remote',
+      refs: ['https://github.com/miles990/mini-agent/issues/75'],
+      tags: ['github', 'issue', 'issue:75', 'P2'],
+      payload: { origin: 'github-issue', issue_number: 75, repo: 'miles990/mini-agent' },
+    });
+
+    // Now the remote is CLOSED. The fetch returns the closed issue alongside any open ones.
+    const issues = [
+      { number: 75, title: 'stale-pending despite closed remote', state: 'CLOSED' as const, labels: [] },
+      { number: 200, title: 'still open work', state: 'OPEN' as const, labels: [] },
+    ];
+
+    const result = await syncGitHubIssuesToTasks(tmpDir, issues, {
+      repo: 'miles990/mini-agent',
+      now: new Date('2026-05-06T09:00:00.000Z'),
+    });
+
+    expect(result).toEqual(expect.objectContaining({ scanned: 2, created: 1, closed: 1 }));
+
+    const stillPending = queryMemoryIndexSync(tmpDir, { type: ['task'], status: ['pending'] });
+    expect(stillPending.map(t => t.payload?.issue_number).sort()).toEqual([200]);
+
+    const completed = queryMemoryIndexSync(tmpDir, { type: ['task'], status: ['completed'] });
+    expect(completed.map(t => t.payload?.issue_number)).toContain(75);
+    expect(completed[0].payload).toEqual(expect.objectContaining({
+      closed_via: 'issue-autopilot-reconciliation',
+      github_state: 'CLOSED',
+    }));
+  });
+
+  it('does not create entries for closed issues with no prior local record', async () => {
+    const issues = [
+      { number: 999, title: 'closed before we ever saw it', state: 'CLOSED' as const, labels: [] },
+    ];
+    const result = await syncGitHubIssuesToTasks(tmpDir, issues, {
+      repo: 'miles990/mini-agent',
+      now: new Date('2026-05-06T09:00:00.000Z'),
+    });
+    expect(result).toEqual(expect.objectContaining({ scanned: 1, created: 0, closed: 0, skipped: 1 }));
+    expect(queryMemoryIndexSync(tmpDir, { type: ['task'] })).toHaveLength(0);
+  });
+
 });


### PR DESCRIPTION
## Summary

The scheduler keeps rendering CLOSED GitHub issues (#75/#78/#80 today) as P0 pending because `readOpenIssuesFromGitHub` fetches `--state open` only — when an issue closes on GitHub it falls out of the sync set entirely, and the local task entry never gets reconciled. **Local memory has no notion of "GitHub state changed underneath us"**, so `status=pending` is sticky forever.

## Evidence (this cycle, 2026-05-06T17:08Z)

```
$ for n in 75 78 80; do
    grep "idx-github-issue-miles990-mini-agent-$n" memory/state/task-events.jsonl | tail -1
  done | jq '.status'
"pending"  # but #75 CLOSED 08:28Z (PR #126)
"pending"  # but #78 CLOSED via PR #130
"pending"  # but #80 CLOSED 09:04Z this cycle
```

## Patch

1. `readOpenIssuesFromGitHub` → fetch `--state all` + include `state` in JSON projection
2. `syncGitHubIssuesToTasks` → split into open/closed; closed issues with non-terminal local entries get `updateMemoryIndexEntry({ status: 'completed', closed_via: 'issue-autopilot-reconciliation' })`
3. Closed issues with no prior local record → skipped (no retroactive history fabrication)
4. `result` + slog now expose `closed` count

## Falsifier

After merge + one autopilot sync cycle:
- `idx-github-issue-miles990-mini-agent-{75,78,80}` latest-by-id should be `status=completed`
- If they stay `pending` → autopilot is not actually being driven in production (separate orchestration bug; file follow-up)

## Cross-ref

Orthogonal to PR #126: that fixed `markTaskDoneByDescription` for scheduler-bound tasks; this fixes the **issue-autopilot ingestion path** which never had reconciliation logic.

## Verification

- [x] 7/7 issue-autopilot tests pass (5 existing + 2 new for closed-reconcile path)
- [x] `pnpm typecheck` clean
- [ ] After merge: re-run issue-autopilot sync; verify the 3 stale entries flip to completed

🤖 Generated with [Claude Code](https://claude.com/claude-code)