### PR TITLE
fix: hard guard runtime workspace isolation

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,11 @@
+#!/bin/sh
+# Runtime checkout guard:
+# code/config commits must happen in isolated feature worktrees, not in the
+# protected runtime/deploy checkout. Memory/state commits remain allowed.
+
+if ! command -v pnpm >/dev/null 2>&1; then
+  echo "[runtime-workspace] pnpm not found; skipping guard" >&2
+  exit 0
+fi
+
+pnpm exec tsx scripts/check-runtime-workspace.ts --staged

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "self-research:plan": "pnpm build && node scripts/self-research-plan.mjs",
     "sync:github-issues": "pnpm build && node dist/issue-autopilot-cli.js",
     "janitor:workspaces": "tsx scripts/workspace-janitor.ts",
+    "check:runtime-workspace": "tsx scripts/check-runtime-workspace.ts",
     "setup": "pnpm install && pnpm build && npm link",
     "prepare": "git config core.hooksPath .githooks 2>/dev/null || true",
     "check:pr-lifecycle": "tsx scripts/check-pr-lifecycle.ts"

--- a/scripts/check-runtime-workspace.ts
+++ b/scripts/check-runtime-workspace.ts
@@ -1,0 +1,77 @@
+#!/usr/bin/env tsx
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+import { isCodePath, isSafeRuntimeBranch, parseDirtyPaths } from '../src/workspace-isolation.js';
+
+const allow = process.env.MINI_AGENT_ALLOW_RUNTIME_WORKSPACE_WRITE === '1';
+const json = process.argv.includes('--json');
+const stagedOnly = process.argv.includes('--staged');
+const cwd = process.cwd();
+const repoRoot = git(['rev-parse', '--show-toplevel']) || cwd;
+const branch = git(['rev-parse', '--abbrev-ref', 'HEAD']) || null;
+const protectedRoot = path.resolve(process.env.MINI_AGENT_RUNTIME_WORKSPACE ?? inferRuntimeWorkspace(repoRoot));
+const isProtectedRuntime = path.resolve(repoRoot) === protectedRoot;
+const paths = stagedOnly ? stagedPaths() : parseDirtyPaths(git(['status', '--porcelain']) ?? '');
+const blockingPaths = paths.filter(isCodePath);
+
+const problems: string[] = [];
+if (isProtectedRuntime && !isSafeRuntimeBranch(branch)) {
+  problems.push(`protected runtime workspace is on ${branch ?? 'unknown'}; expected runtime/main`);
+}
+if (isProtectedRuntime && blockingPaths.length > 0) {
+  problems.push(`protected runtime workspace has code/config changes: ${blockingPaths.slice(0, 8).join(', ')}`);
+}
+
+const result = {
+  ok: problems.length === 0 || allow,
+  allowOverride: allow,
+  repoRoot,
+  branch,
+  protectedRoot,
+  isProtectedRuntime,
+  stagedOnly,
+  paths,
+  blockingPaths,
+  problems,
+};
+
+if (json) {
+  process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+} else if (problems.length > 0) {
+  for (const problem of problems) process.stderr.write(`[runtime-workspace] ${problem}\n`);
+  if (!allow) {
+    process.stderr.write('[runtime-workspace] commit blocked. Use an isolated forge worktree, or set MINI_AGENT_ALLOW_RUNTIME_WORKSPACE_WRITE=1 only for intentional recovery.\n');
+  }
+}
+
+if (!result.ok) process.exit(1);
+
+function stagedPaths(): string[] {
+  const out = git(['diff', '--cached', '--name-status', '--diff-filter=ACMR']) ?? '';
+  return out
+    .split('\n')
+    .map(line => line.trim())
+    .filter(Boolean)
+    .map(line => line.split(/\s+/).at(-1) ?? '')
+    .filter(Boolean);
+}
+
+function inferRuntimeWorkspace(root: string): string {
+  const baseName = path.basename(root);
+  if (baseName === 'mini-agent') return root;
+  if (baseName.startsWith('mini-agent-')) return path.join(path.dirname(root), 'mini-agent');
+  return root;
+}
+
+function git(args: string[]): string | null {
+  try {
+    return execFileSync('git', args, {
+      cwd,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 8000,
+    }).trim();
+  } catch {
+    return null;
+  }
+}

--- a/scripts/workspace-janitor.ts
+++ b/scripts/workspace-janitor.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env tsx
 import { execFileSync } from 'node:child_process';
 import path from 'node:path';
+import { isSafeRuntimeBranch } from '../src/workspace-isolation.js';
 
 interface WorktreeRecord {
   path: string;
@@ -28,7 +29,7 @@ const protectedRoot = path.resolve(process.env.MINI_AGENT_RUNTIME_WORKSPACE ?? i
 
 const actions: JanitorAction[] = [];
 
-if (path.resolve(root) === protectedRoot && !['main', 'runtime/main'].includes(currentBranch)) {
+if (path.resolve(root) === protectedRoot && !isSafeRuntimeBranch(currentBranch)) {
   actions.push({
     type: 'warn-runtime-branch',
     target: currentBranch,
@@ -60,7 +61,7 @@ for (const wt of worktrees) {
 }
 
 for (const branch of readLocalBranches()) {
-  if (['main', 'runtime/main'].includes(branch)) continue;
+  if (branch === 'runtime/main') continue;
   if (openPrBranches.has(branch)) continue;
   if (isBranchCheckedOut(branch, worktrees)) continue;
   if (mergedPrBranches.has(branch) || isMergedToBase(branch, base)) {

--- a/src/correction-gate.ts
+++ b/src/correction-gate.ts
@@ -11,13 +11,14 @@ import {
   type ActiveHoldMatch,
   type CorrectionHold,
 } from './correction-holds.js';
-import { isCodePath } from './workspace-isolation.js';
+import { isCodePath, isSafeRuntimeBranch } from './workspace-isolation.js';
 
 export type CorrectionReasonType =
   | 'pending-pledge'
   | 'low-responsiveness'
   | 'low-output-quality'
   | 'local-commit-not-pushed'
+  | 'runtime-workspace-wrong-branch'
   | 'dirty-runtime-workspace';
 
 export interface CorrectionReason {
@@ -114,6 +115,12 @@ export function evaluateCorrectionGate(memoryDir: string, repoRoot = process.cwd
   }
 
   const shipTruth = readShipTruth(repoRoot);
+
+  if (shipTruth.repoPresent && !isSafeRuntimeBranch(shipTruth.branch)) {
+    const message = `runtime workspace 在錯誤分支 ${shipTruth.branch ?? 'unknown'} — protected runtime checkout 只能在 runtime/main；功能修改要用 isolated worktree + PR。`;
+    reasons.push({ type: 'runtime-workspace-wrong-branch', severity: 'high', message });
+    guidance.push(message);
+  }
 
   if (shipTruth.state === 'pending-push' || shipTruth.state === 'diverged') {
     const match = findActiveHold(holds, 'local-commit-not-pushed', {

--- a/src/workspace-isolation.ts
+++ b/src/workspace-isolation.ts
@@ -16,7 +16,7 @@ export interface WorkspaceIsolationDecision extends WorkspaceIsolationSnapshot {
   warnings: string[];
 }
 
-const SAFE_RUNTIME_BRANCHES = new Set(['main', 'runtime/main']);
+const SAFE_RUNTIME_BRANCHES = new Set(['runtime/main']);
 const CODE_PATH_PATTERN = /^(src|tests|scripts|plugins|skills|tools|kuro-portfolio|knowledge-graph|\.githooks|\.github)\//;
 const CODE_FILE_PATTERN = /^(package\.json|pnpm-lock\.yaml|tsconfig\.json|agent-compose\.yaml)$/;
 
@@ -42,7 +42,7 @@ export function evaluateWorkspaceIsolation(cwd = process.cwd(), protectedRoot = 
     };
   }
 
-  if (!branch || !SAFE_RUNTIME_BRANCHES.has(branch)) {
+  if (!isSafeRuntimeBranch(branch)) {
     return {
       cwd,
       repoRoot,
@@ -51,7 +51,7 @@ export function evaluateWorkspaceIsolation(cwd = process.cwd(), protectedRoot = 
       dirtyPaths,
       codeDirtyPaths,
       ok: false,
-      reason: `protected runtime workspace is on branch ${branch ?? 'unknown'}; expected main or runtime/main`,
+      reason: `protected runtime workspace is on branch ${branch ?? 'unknown'}; expected runtime/main`,
       warnings,
     };
   }
@@ -92,12 +92,22 @@ export function parseDirtyPaths(porcelain: string): string[] {
     .split('\n')
     .map(line => line.trimEnd())
     .filter(Boolean)
-    .map(line => line.slice(3).trim())
+    .map(parseDirtyPath)
     .filter(Boolean);
 }
 
 export function isCodePath(filePath: string): boolean {
   return CODE_PATH_PATTERN.test(filePath) || CODE_FILE_PATTERN.test(filePath);
+}
+
+export function isSafeRuntimeBranch(branch: string | null | undefined): boolean {
+  return Boolean(branch && SAFE_RUNTIME_BRANCHES.has(branch));
+}
+
+function parseDirtyPath(line: string): string {
+  if (line.startsWith('?? ') || line.startsWith('!! ')) return line.slice(3).trim();
+  if (line.length > 3 && line[2] === ' ') return line.slice(3).trim();
+  return line.replace(/^[ MADRCU?!]{1,2}\s+/, '').trim();
 }
 
 function isProtectedRuntimeWorkspace(cwd: string, repoRoot: string | null, protectedRoot?: string): boolean {

--- a/tests/correction-gate.test.ts
+++ b/tests/correction-gate.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from 'node:child_process';
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -106,6 +107,22 @@ describe('correction gate', () => {
     }));
   });
 
+  it('flags protected runtime checkout when it is on main instead of runtime/main', () => {
+    execGit(['init'], tmpDir);
+    execGit(['config', 'user.email', 'test@example.com'], tmpDir);
+    execGit(['config', 'user.name', 'Test User'], tmpDir);
+    writeFileSync(path.join(tmpDir, 'README.md'), 'runtime guard fixture\n', 'utf-8');
+    execGit(['add', 'README.md'], tmpDir);
+    execGit(['commit', '-m', 'init'], tmpDir);
+    execGit(['branch', '-M', 'main'], tmpDir);
+
+    const snapshot = evaluateCorrectionGate(tmpDir, tmpDir);
+
+    expect(snapshot.needsCorrection).toBe(true);
+    expect(snapshot.reasons.map(r => r.type)).toContain('runtime-workspace-wrong-branch');
+    expect(snapshot.guidance.join('\n')).toContain('只能在 runtime/main');
+  });
+
   it('classifies only managed/code dirt as blocking runtime dirt', () => {
     expect(getBlockingRuntimeDirtyPaths([
       'memory/inner-notes.md',
@@ -184,3 +201,7 @@ describe('correction gate', () => {
     }));
   });
 });
+
+function execGit(args: string[], cwd = tmpDir): void {
+  execFileSync('git', args, { cwd, stdio: 'ignore' });
+}

--- a/tests/workspace-isolation.test.ts
+++ b/tests/workspace-isolation.test.ts
@@ -1,15 +1,17 @@
 import { describe, expect, it } from 'vitest';
 
-import { isCodePath, parseDirtyPaths } from '../src/workspace-isolation.js';
+import { isCodePath, isSafeRuntimeBranch, parseDirtyPaths } from '../src/workspace-isolation.js';
 
 describe('workspace isolation guard', () => {
   it('parses porcelain paths without losing renamed or untracked paths', () => {
     expect(parseDirtyPaths([
       ' M memory/inner-notes.md',
+      'M  scripts/check-runtime-workspace.ts',
       '?? papers/',
       'A  src/workspace-isolation.ts',
     ].join('\n'))).toEqual([
       'memory/inner-notes.md',
+      'scripts/check-runtime-workspace.ts',
       'papers/',
       'src/workspace-isolation.ts',
     ]);
@@ -23,5 +25,12 @@ describe('workspace isolation guard', () => {
     expect(isCodePath('knowledge-graph/')).toBe(true);
     expect(isCodePath('memory/inner-notes.md')).toBe(false);
     expect(isCodePath('papers/')).toBe(false);
+  });
+
+  it('only treats runtime/main as safe for the protected runtime checkout', () => {
+    expect(isSafeRuntimeBranch('runtime/main')).toBe(true);
+    expect(isSafeRuntimeBranch('main')).toBe(false);
+    expect(isSafeRuntimeBranch('fix/example')).toBe(false);
+    expect(isSafeRuntimeBranch(null)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- make runtime/main the only safe branch for the protected runtime checkout
- add a pre-commit runtime workspace guard that blocks code/config commits in the runtime checkout
- surface wrong runtime branch as a correction-gate reason and let janitor clean local main when safe
- fix porcelain path parsing so scripts/ paths are not misread

## Verification
- pnpm typecheck
- pnpm build
- pnpm test --run tests/workspace-isolation.test.ts tests/correction-gate.test.ts
- pnpm exec tsx scripts/check-runtime-workspace.ts --json
- MINI_AGENT_RUNTIME_WORKSPACE=/Users/user/Workspace/mini-agent-runtime-guard pnpm exec tsx scripts/check-runtime-workspace.ts --json; test 0 -eq 1