### PR TITLE
fix(ledger): surface unacked agent commitments

### DIFF
--- a/src/commitment-ledger.ts
+++ b/src/commitment-ledger.ts
@@ -501,6 +501,27 @@ export function buildLedgerSection(currentCycleId: number): string {
   lines.push('');
   lines.push(`Stats: pending=${audit.pending} kept=${audit.kept} refuted=${audit.refuted} resolved=${audit.resolved} expired=${audit.expired} abandoned=${audit.abandoned}`);
 
+  // Phase B circulation fix (#82 Finding 1): surface unacked agent-counterparty
+  // commitments at prompt-time so the agent learns the <kuro:ack> DSL inline
+  // instead of letting them silently age into 'abandoned'. age>=2 threshold
+  // gives counterparty time to respond before nagging.
+  const unackedAgent = pending.filter(e =>
+    e.counterparty?.kind === 'agent' &&
+    !e.ack_at &&
+    (currentCycleId - e.cycle_id) >= 2,
+  );
+  if (unackedAgent.length > 0) {
+    lines.push('');
+    lines.push(`Awaiting ack from counterparty (${unackedAgent.length}):`);
+    for (const e of unackedAgent) {
+      const age = currentCycleId - e.cycle_id;
+      const cp = e.counterparty as { kind: 'agent'; agent_id: string };
+      const snippet = e.prediction.length > 80 ? e.prediction.slice(0, 77) + '...' : e.prediction;
+      lines.push(`  - ${e.id} (counterparty=${cp.agent_id}, age=${age} cycles): "${snippet}"`);
+    }
+    lines.push(`  → If counterparty has addressed any of these, emit: <kuro:ack id="cl-X" by="${(unackedAgent[0].counterparty as { kind: 'agent'; agent_id: string }).agent_id}" />`);
+  }
+
   const warnings: string[] = [];
 
   if (audit.analysisParalysis) {

--- a/tests/commitment-ledger.test.ts
+++ b/tests/commitment-ledger.test.ts
@@ -20,6 +20,7 @@ vi.mock('../src/utils.js', () => ({
 
 import {
   writeCommitment,
+  buildLedgerSection,
   expireOverdueCommitments,
   auditCommitments,
   readPendingCommitments,
@@ -120,6 +121,44 @@ describe('commitment-ledger trust-layer branching', () => {
     expect(audit.pending).toBe(1);
     expect(audit.abandoned).toBe(0);
     expect(audit.expired).toBe(0);
+  });
+
+  it('surfaces aged unacked agent commitments in the ledger section', () => {
+    writeCommitment({
+      cycle_id: 1,
+      prediction: 'Akari will review the handoff and report contradictions',
+      falsifier: 'no review reply',
+      ttl_cycles: 10,
+      counterparty: { kind: 'agent', agent_id: 'akari' },
+    });
+    writeCommitment({
+      cycle_id: 2,
+      prediction: 'Self promise should not request counterparty ack',
+      falsifier: 'no note',
+      ttl_cycles: 10,
+      counterparty: { kind: 'self' },
+    });
+
+    const section = buildLedgerSection(4);
+
+    expect(section).toContain('Awaiting ack from counterparty (1):');
+    expect(section).toContain('counterparty=akari');
+    expect(section).toContain('emit: <kuro:ack');
+    expect(section.slice(section.indexOf('Awaiting ack from counterparty'))).not.toContain('Self promise should not request counterparty ack');
+  });
+
+  it('does not nag for fresh unacked agent commitments before age threshold', () => {
+    writeCommitment({
+      cycle_id: 3,
+      prediction: 'Claude will review after the next cycle',
+      falsifier: 'no review reply',
+      ttl_cycles: 10,
+      counterparty: { kind: 'agent', agent_id: 'claude' },
+    });
+
+    const section = buildLedgerSection(4);
+
+    expect(section).not.toContain('Awaiting ack from counterparty');
   });
 
   it('writeCommitment rejects ack_at without counterparty', () => {


### PR DESCRIPTION
## Summary
- preserve the runtime checkout change by moving it into an isolated PR branch
- surface old unacked agent-counterparty commitments in the ledger prompt section
- keep runtime/deploy checkout free of code dirt

## Verification
- pnpm typecheck
- pnpm test --run tests/commitment-ledger.test.ts