### PR TITLE
fix(#82): surface unacked agent commitments with <kuro:ack> DSL hint

### DIFF
--- a/src/commitment-ledger.ts
+++ b/src/commitment-ledger.ts
@@ -501,6 +501,27 @@ export function buildLedgerSection(currentCycleId: number): string {
   lines.push('');
   lines.push(`Stats: pending=${audit.pending} kept=${audit.kept} refuted=${audit.refuted} resolved=${audit.resolved} expired=${audit.expired} abandoned=${audit.abandoned}`);
 
+  // Phase B circulation fix (#82 Finding 1): surface unacked agent-counterparty
+  // commitments at prompt-time so the agent learns the <kuro:ack> DSL inline
+  // instead of letting them silently age into 'abandoned'. age>=2 threshold
+  // gives counterparty time to respond before nagging.
+  const unackedAgent = pending.filter(e =>
+    e.counterparty?.kind === 'agent' &&
+    !e.ack_at &&
+    (currentCycleId - e.cycle_id) >= 2,
+  );
+  if (unackedAgent.length > 0) {
+    lines.push('');
+    lines.push(`Awaiting ack from counterparty (${unackedAgent.length}):`);
+    for (const e of unackedAgent) {
+      const age = currentCycleId - e.cycle_id;
+      const cp = e.counterparty as { kind: 'agent'; agent_id: string };
+      const snippet = e.prediction.length > 80 ? e.prediction.slice(0, 77) + '...' : e.prediction;
+      lines.push(`  - ${e.id} (counterparty=${cp.agent_id}, age=${age} cycles): "${snippet}"`);
+    }
+    lines.push(`  → If counterparty has addressed any of these, emit: <kuro:ack id="cl-X" by="${(unackedAgent[0].counterparty as { kind: 'agent'; agent_id: string }).agent_id}" />`);
+  }
+
   const warnings: string[] = [];
 
   if (audit.analysisParalysis) {

--- a/tests/commitment-ledger.test.ts
+++ b/tests/commitment-ledger.test.ts
@@ -25,6 +25,7 @@ import {
   readPendingCommitments,
   parseFalsifierToQuery,
   resolveReadyCommitments,
+  buildLedgerSection,
 } from '../src/commitment-ledger.js';
 
 describe('commitment-ledger trust-layer branching', () => {
@@ -286,5 +287,39 @@ describe('commitment-ledger trust-layer branching', () => {
     resolveReadyCommitments(11);
 
     expect(auditCommitments(11).kept).toBe(1);
+  });
+
+  it('buildLedgerSection (#82) surfaces unacked agent commitments with <kuro:ack> hint after age>=2', () => {
+    writeCommitment({
+      cycle_id: 5,
+      prediction: 'Alex will review PR #82 patch',
+      falsifier: 'pr merged within 7d',
+      ttl_cycles: 10,
+      counterparty: { kind: 'agent', agent_id: 'alex' },
+    });
+
+    // age=1 → below threshold, should NOT appear in awaiting-ack section
+    const sec1 = buildLedgerSection(6);
+    expect(sec1).not.toMatch(/Awaiting ack from counterparty/);
+
+    // age=2 → at threshold, should appear with DSL hint
+    const sec2 = buildLedgerSection(7);
+    expect(sec2).toMatch(/Awaiting ack from counterparty \(1\)/);
+    expect(sec2).toMatch(/counterparty=alex, age=2 cycles/);
+    expect(sec2).toMatch(/<kuro:ack id="cl-X" by="alex"/);
+  });
+
+  it('buildLedgerSection (#82) excludes self-counterparty and already-acked entries', () => {
+    // self-counterparty: should never appear in awaiting-ack
+    writeCommitment({
+      cycle_id: 1,
+      prediction: 'self promise',
+      falsifier: 'something',
+      ttl_cycles: 10,
+      counterparty: { kind: 'self' },
+    });
+
+    const sec = buildLedgerSection(5);
+    expect(sec).not.toMatch(/Awaiting ack from counterparty/);
   });
 });


### PR DESCRIPTION
Closes Finding 1 of #82. Schema was wired, circulation was cold (0 ack_at in 10 cycles). Surfaces age>=2 unacked agent-counterparty entries with DSL example pre-filled. Tests 14→16. Falsifier: 7d ack_at>=1.