### PR TITLE
fix: externalize runtime memory state

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,11 @@ PORT=3001
 # Optional: API authentication
 # MINI_AGENT_API_KEY=
 
+# Optional: external memory/state workspace.
+# Recommended for production runtime: keeps /Users/user/Workspace/mini-agent as
+# clean runtime/main while Kuro's file-truth memory writes land elsewhere.
+# MINI_AGENT_MEMORY_DIR=/Users/user/Workspace/mini-agent-memory/memory
+
 # Optional: Chrome CDP for web access
 # CDP_PORT=9222
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "sync:github-issues": "pnpm build && node dist/issue-autopilot-cli.js",
     "janitor:workspaces": "tsx scripts/workspace-janitor.ts",
     "check:runtime-workspace": "tsx scripts/check-runtime-workspace.ts",
+    "setup:external-memory": "tsx scripts/setup-external-memory.ts",
     "setup": "pnpm install && pnpm build && npm link",
     "prepare": "git config core.hooksPath .githooks 2>/dev/null || true",
     "check:pr-lifecycle": "tsx scripts/check-pr-lifecycle.ts"

--- a/scripts/setup-external-memory.ts
+++ b/scripts/setup-external-memory.ts
@@ -1,0 +1,53 @@
+#!/usr/bin/env tsx
+import { cpSync, existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+const repoRoot = process.cwd();
+const source = path.resolve(readArg('--source') ?? path.join(repoRoot, 'memory'));
+const targetRoot = path.resolve(readArg('--target-root') ?? path.join(path.dirname(repoRoot), 'mini-agent-memory'));
+const target = path.resolve(readArg('--target') ?? path.join(targetRoot, 'memory'));
+const writeEnv = process.argv.includes('--write-env');
+const force = process.argv.includes('--force');
+
+if (!existsSync(source)) {
+  fail(`source memory directory does not exist: ${source}`);
+}
+
+if (existsSync(target) && !force) {
+  process.stdout.write(`[external-memory] target exists; leaving it unchanged: ${target}\n`);
+} else {
+  mkdirSync(path.dirname(target), { recursive: true });
+  cpSync(source, target, { recursive: true, force: true, errorOnExist: false });
+  process.stdout.write(`[external-memory] copied ${source} -> ${target}\n`);
+}
+
+mkdirSync(path.join(target, 'state'), { recursive: true });
+
+const envLine = `MINI_AGENT_MEMORY_DIR=${target}`;
+if (writeEnv) {
+  const envPath = path.join(repoRoot, '.env');
+  writeFileSync(envPath, `${envLine}\n`, { flag: 'a' });
+  process.stdout.write(`[external-memory] appended to ${envPath}: ${envLine}\n`);
+} else {
+  process.stdout.write(`[external-memory] add to .env:\n${envLine}\n`);
+}
+
+process.stdout.write(JSON.stringify({
+  source,
+  target,
+  env: { MINI_AGENT_MEMORY_DIR: target },
+}, null, 2) + '\n');
+
+function readArg(name: string): string | undefined {
+  const argv = process.argv.slice(2);
+  const index = argv.indexOf(name);
+  if (index >= 0) return argv[index + 1];
+  const prefix = `${name}=`;
+  return argv.find(arg => arg.startsWith(prefix))?.slice(prefix.length);
+}
+
+function fail(message: string): never {
+  process.stderr.write(`[external-memory] ${message}\n`);
+  process.exit(1);
+}
+

--- a/src/activity-stream.ts
+++ b/src/activity-stream.ts
@@ -1,5 +1,6 @@
 import { appendFileSync, readFileSync, existsSync } from 'node:fs';
 import path from 'node:path';
+import { getMemoryRootDir, resolveMemoryPath } from './memory-paths.js';
 
 export interface ActivityEntry {
   ts: string;
@@ -11,7 +12,7 @@ export interface ActivityEntry {
 }
 
 function getStreamPath(): string {
-  return path.join(process.cwd(), 'memory', 'state', 'activity-stream.jsonl');
+  return resolveMemoryPath('state', 'activity-stream.jsonl');
 }
 
 export function emitActivity(entry: {

--- a/src/api.ts
+++ b/src/api.ts
@@ -17,6 +17,7 @@ import fsPromises from 'node:fs/promises';
 import https from 'node:https';
 import os from 'node:os';
 import path from 'node:path';
+import { getMemoryRootDir, resolveMemoryPath } from './memory-paths.js';
 import { monitorEventLoopDelay, type IntervalHistogram } from 'node:perf_hooks';
 import express, { type Request, type Response, type NextFunction } from 'express';
 
@@ -597,7 +598,7 @@ export function createApi(port = 3001): express.Express {
   function getRoomDiffForCC(agentNameLower: string, maxPerMsg = 800, maxMsgs = 5): string {
     try {
       const today = new Date().toISOString().slice(0, 10);
-      const convPath = path.join(process.cwd(), 'memory', 'conversations', `${today}.jsonl`);
+      const convPath = resolveMemoryPath('conversations', `${today}.jsonl`);
       if (!fs.existsSync(convPath)) return '';
 
       const cursorPath = path.join(getInstanceDir(getCurrentInstanceId()), 'cc-room-cursor.txt');
@@ -654,7 +655,7 @@ export function createApi(port = 3001): express.Express {
   function getRecentAgentReply(agentNameLower: string, maxLen = 200): string {
     try {
       const today = new Date().toISOString().slice(0, 10);
-      const convPath = path.join(process.cwd(), 'memory', 'conversations', `${today}.jsonl`);
+      const convPath = resolveMemoryPath('conversations', `${today}.jsonl`);
       if (!fs.existsSync(convPath)) return '';
       const raw = fs.readFileSync(convPath, 'utf-8');
       const lines = raw.split('\n').filter(Boolean);
@@ -674,7 +675,7 @@ export function createApi(port = 3001): express.Express {
   // Helper: get task summary from memory-index
   function getNextNowSummary(maxLen = 150): string {
     try {
-      const memDir = path.join(process.cwd(), 'memory');
+      const memDir = getMemoryRootDir();
       return getNowTaskSummary(memDir, maxLen);
     } catch { return ''; }
   }
@@ -1408,7 +1409,7 @@ export function createApi(port = 3001): express.Express {
   // Memory Files — list all files in memory/
   app.get('/api/memory/files', async (_req: Request, res: Response) => {
     try {
-      const memoryDir = path.join(process.cwd(), 'memory');
+      const memoryDir = getMemoryRootDir();
       const files: Array<{ name: string; path: string; size: number; modified: string }> = [];
 
       async function scanDir(dir: string, prefix: string): Promise<void> {
@@ -1445,7 +1446,7 @@ export function createApi(port = 3001): express.Express {
       const filePath = req.params.path;
 
       // Security: prevent path traversal (resolve and verify prefix)
-      const memoryRoot = path.resolve(process.cwd(), 'memory');
+      const memoryRoot = path.resolve(getMemoryRootDir());
       const fullPath = path.resolve(memoryRoot, filePath);
       if (!fullPath.startsWith(memoryRoot + path.sep) && fullPath !== memoryRoot) {
         res.status(400).json({ error: 'Invalid path' });
@@ -1587,7 +1588,7 @@ export function createApi(port = 3001): express.Express {
       void (async () => {
         try {
           // 擷取 in-progress 任務（from memory-index）
-          const inProgressLines = getTasksSnapshot(path.join(process.cwd(), 'memory'));
+          const inProgressLines = getTasksSnapshot(getMemoryRootDir());
 
           const snapshot = [
             '# Tracking Snapshot',
@@ -1624,9 +1625,9 @@ export function createApi(port = 3001): express.Express {
             const { promisify } = await import('node:util');
             const execAsync = promisify(exec);
             try {
-              await execAsync(`git -C "${process.cwd()}" add "${innerPath}"`);
+              await execAsync(`git -C "${memoryDir}" add "inner-notes.md"`);
               await execAsync(
-                `git -C "${process.cwd()}" commit -m "chore(inner): snapshot reserved working memory ${new Date().toISOString().slice(0, 10)}"`,
+                `git -C "${memoryDir}" commit -m "chore(inner): snapshot reserved working memory ${new Date().toISOString().slice(0, 10)}"`,
                 { env: { ...process.env, GIT_AUTHOR_NAME: 'Kuro', GIT_AUTHOR_EMAIL: 'kuro@mini-agent', GIT_COMMITTER_NAME: 'Kuro', GIT_COMMITTER_EMAIL: 'kuro@mini-agent' } },
               );
               slog('MODE', 'inner-notes.md committed');
@@ -1749,7 +1750,7 @@ export function createApi(port = 3001): express.Express {
 
   app.get('/api/task-queue', (_req: Request, res: Response) => {
     try {
-      const memDir = path.join(process.cwd(), 'memory');
+      const memDir = getMemoryRootDir();
       const tasks = queryMemoryIndexSync(memDir, {
         type: ['task', 'goal'],
         status: ['pending', 'in_progress', 'completed', 'abandoned'],
@@ -1767,7 +1768,7 @@ export function createApi(port = 3001): express.Express {
         res.status(400).json({ error: 'title is required' });
         return;
       }
-      const memDir = path.join(process.cwd(), 'memory');
+      const memDir = getMemoryRootDir();
       const entry = await createTask(memDir, {
         type: type ?? 'task',
         title,
@@ -1790,7 +1791,7 @@ export function createApi(port = 3001): express.Express {
   app.patch('/api/task-queue/:id', async (req: Request, res: Response) => {
     try {
       const { title, status, priority, type, assignee, blockedBy, pinned, pinContext } = req.body;
-      const memDir = path.join(process.cwd(), 'memory');
+      const memDir = getMemoryRootDir();
       const updated = await updateTask(memDir, req.params.id, {
         title,
         status,
@@ -1814,7 +1815,7 @@ export function createApi(port = 3001): express.Express {
 
   app.delete('/api/task-queue/:id', async (req: Request, res: Response) => {
     try {
-      const memDir = path.join(process.cwd(), 'memory');
+      const memDir = getMemoryRootDir();
       const ok = await deleteMemoryIndexEntry(memDir, req.params.id);
       if (!ok) {
         res.status(404).json({ error: 'task not found' });
@@ -1833,7 +1834,7 @@ export function createApi(port = 3001): express.Express {
 
   app.get('/api/claims', (req: Request, res: Response) => {
     try {
-      const memDir = path.join(process.cwd(), 'memory');
+      const memDir = getMemoryRootDir();
       const status = queryList(req.query.status).filter(isClaimStatus);
       const provider = queryList(req.query.provider);
       const taskId = typeof req.query.taskId === 'string' ? req.query.taskId : undefined;
@@ -1860,7 +1861,7 @@ export function createApi(port = 3001): express.Express {
         return;
       }
 
-      const memDir = path.join(process.cwd(), 'memory');
+      const memDir = getMemoryRootDir();
       const claim = transitionStoredProviderClaim(memDir, req.params.id, status);
       if (!claim) {
         res.status(404).json({ error: 'claim not found' });
@@ -1896,7 +1897,7 @@ export function createApi(port = 3001): express.Express {
 
   app.get('/api/delegation-failures', (req: Request, res: Response) => {
     try {
-      const memDir = path.join(process.cwd(), 'memory');
+      const memDir = getMemoryRootDir();
       const statuses = queryList(req.query.status).filter(isDelegationFailureStatus);
       let failures = readDelegationFailureRecordsSync(memDir);
       if (statuses.length > 0) failures = failures.filter(failure => statuses.includes(failure.status));
@@ -1914,7 +1915,7 @@ export function createApi(port = 3001): express.Express {
         return;
       }
       const resolution = typeof req.body?.resolution === 'string' ? req.body.resolution : undefined;
-      const memDir = path.join(process.cwd(), 'memory');
+      const memDir = getMemoryRootDir();
       const failure = transitionDelegationFailureStatus(
         memDir,
         decodeURIComponent(req.params.signature),
@@ -1938,7 +1939,7 @@ export function createApi(port = 3001): express.Express {
 
   app.post('/api/delegation-failures/:signature/diagnose', async (req: Request, res: Response) => {
     try {
-      const memDir = path.join(process.cwd(), 'memory');
+      const memDir = getMemoryRootDir();
       const diagnosis = await diagnoseDelegationFailure(memDir, decodeURIComponent(req.params.signature));
       if (!diagnosis) {
         res.status(404).json({ error: 'delegation failure not found' });
@@ -1954,7 +1955,7 @@ export function createApi(port = 3001): express.Express {
     try {
       const limitRaw = typeof req.body?.limit === 'number' ? req.body.limit : 5;
       const limit = Math.max(1, Math.min(25, Math.floor(limitRaw)));
-      const memDir = path.join(process.cwd(), 'memory');
+      const memDir = getMemoryRootDir();
       const diagnoses = await diagnosePendingDelegationFailures(memDir, limit);
       res.json({ success: true, diagnoses, total: diagnoses.length });
     } catch (err) {
@@ -1966,7 +1967,7 @@ export function createApi(port = 3001): express.Express {
     try {
       const windowRaw = parseInt(String(req.query.window ?? '500'), 10);
       const window = Number.isFinite(windowRaw) ? windowRaw : 500;
-      const memDir = path.join(process.cwd(), 'memory');
+      const memDir = getMemoryRootDir();
       res.json(getMyelinStatus(memDir, window));
     } catch (err) {
       res.status(500).json({ error: String(err) });
@@ -1975,7 +1976,7 @@ export function createApi(port = 3001): express.Express {
 
   app.post('/api/myelin/sync-kg', (req: Request, res: Response) => {
     try {
-      const memDir = path.join(process.cwd(), 'memory');
+      const memDir = getMemoryRootDir();
       const result = syncMyelinToKnowledge(memDir, {
         force: req.body?.force === true,
         limitPerDomain: typeof req.body?.limitPerDomain === 'number' ? req.body.limitPerDomain : undefined,
@@ -1989,7 +1990,7 @@ export function createApi(port = 3001): express.Express {
 
   app.get('/api/brain/runs', (req: Request, res: Response) => {
     try {
-      const memDir = path.join(process.cwd(), 'memory');
+      const memDir = getMemoryRootDir();
       const actor = queryList(req.query.actor).filter(isBrainActor);
       const event = queryList(req.query.event).filter(isBrainRunEvent);
       const status = queryList(req.query.status).filter(isBrainRunStatus);
@@ -2034,7 +2035,7 @@ export function createApi(port = 3001): express.Express {
 
   app.get('/api/brain/actor-stats', (req: Request, res: Response) => {
     try {
-      const memDir = path.join(process.cwd(), 'memory');
+      const memDir = getMemoryRootDir();
       const intent = typeof req.query.intent === 'string' && isWorkIntent(req.query.intent)
         ? req.query.intent
         : undefined;
@@ -2053,7 +2054,7 @@ export function createApi(port = 3001): express.Express {
         res.status(400).json({ error: 'title, acceptance_criteria, and tasks[] required' });
         return;
       }
-      const memDir = path.join(process.cwd(), 'memory');
+      const memDir = getMemoryRootDir();
       const result = await createGoal(memDir, { title, acceptance_criteria, verify_command }, tasks);
       res.json({ success: true, ...result });
     } catch (err) {
@@ -2069,7 +2070,7 @@ export function createApi(port = 3001): express.Express {
         res.status(400).json({ error: 'title required' });
         return;
       }
-      const memDir = path.join(process.cwd(), 'memory');
+      const memDir = getMemoryRootDir();
       const taskId = await addTaskToGoal(memDir, goalId, { title, verify_command, acceptance_criteria, depends_on_ids });
       res.json({ success: true, taskId });
     } catch (err) {
@@ -2083,7 +2084,7 @@ export function createApi(port = 3001): express.Express {
   app.get('/api/goals', (req: Request, res: Response) => {
     try {
       const includeArchived = req.query.include_archived === 'true';
-      const memDir = path.join(process.cwd(), 'memory');
+      const memDir = getMemoryRootDir();
       const allEntries = queryMemoryIndexSync(memDir, { type: ['goal', 'task'] });
       const goals = allEntries.filter(e => {
         if (e.type !== 'goal' || (e.payload as Record<string, unknown>)?.origin !== 'pipeline') return false;
@@ -2704,7 +2705,7 @@ export function createApi(port = 3001): express.Express {
       // --- Inner Voice (personal monologue) ---
       let innerVoice: { timestamp: string; content: string }[] = [];
       const voicePath = path.join(memory.getMemoryDir(), 'inner-voice.md');
-      const voiceFallback = path.join(process.cwd(), 'memory', 'inner-voice.md');
+      const voiceFallback = resolveMemoryPath('inner-voice.md');
       try {
         let voiceContent: string;
         try {
@@ -2820,7 +2821,7 @@ export function createApi(port = 3001): express.Express {
 
   app.get('/api/dashboard/scheduler', (_req: Request, res: Response) => {
     try {
-      const memDir = path.join(process.cwd(), 'memory');
+      const memDir = getMemoryRootDir();
       const state = getSchedulerState();
       const { tasks: topTasks, totalCount } = getTopPending(memDir, 5);
       const ATTENTION_BUDGET = 15;
@@ -2859,7 +2860,7 @@ export function createApi(port = 3001): express.Express {
         stats[e.state] = (stats[e.state] ?? 0) + 1;
       }
       // Today's completed/abandoned from memory index
-      const mDir = path.join(process.cwd(), 'memory');
+      const mDir = getMemoryRootDir();
       const todayStart = new Date().toISOString().slice(0, 10);
       const completedTasks = queryMemoryIndexSync(mDir, { type: ['task', 'goal'], status: ['completed', 'done'] }).filter(t => t.ts >= todayStart);
       const abandonedTasks = queryMemoryIndexSync(mDir, { type: ['task', 'goal'], status: ['abandoned'] }).filter(t => t.ts >= todayStart);
@@ -2893,7 +2894,7 @@ export function createApi(port = 3001): express.Express {
 
   app.get('/api/dashboard/health', (_req: Request, res: Response) => {
     try {
-      const memDir = path.join(process.cwd(), 'memory');
+      const memDir = getMemoryRootDir();
       res.json(evaluateCorrectionGate(memDir));
     } catch {
       res.json({ score: 50, breakdown: null, guidance: [], anomalies: [], reasons: [], suppressedActions: [], needsCorrection: false });
@@ -2902,7 +2903,7 @@ export function createApi(port = 3001): express.Express {
 
   app.get('/api/dashboard/correction', (_req: Request, res: Response) => {
     try {
-      const memDir = path.join(process.cwd(), 'memory');
+      const memDir = getMemoryRootDir();
       res.json(evaluateCorrectionGate(memDir));
     } catch {
       res.json({ score: 50, breakdown: null, guidance: [], anomalies: [], reasons: [], suppressedActions: [], needsCorrection: false });
@@ -2963,7 +2964,7 @@ export function createApi(port = 3001): express.Express {
 
   // Knowledge Graph viz — self-contained HTML rebuilt by kg-viz.ts
   app.get('/kg-graph', (_req: Request, res: Response) => {
-    const htmlPath = path.join(process.cwd(), 'memory/index/kg-graph.html');
+    const htmlPath = resolveMemoryPath('index', 'kg-graph.html');
     if (fs.existsSync(htmlPath)) {
       res.sendFile(htmlPath);
     } else {
@@ -3264,7 +3265,7 @@ export function createApi(port = 3001): express.Express {
       res.status(400).json({ error: 'Invalid filename' });
       return;
     }
-    const filePath = path.join(process.cwd(), 'memory', 'media', filename);
+    const filePath = resolveMemoryPath('media', filename);
     if (!fs.existsSync(filePath)) {
       res.status(404).json({ error: 'Not found' });
       return;
@@ -3352,7 +3353,7 @@ export function createApi(port = 3001): express.Express {
       // Intake Pipeline: only NEW messages (not replies) go through addIdea → qualify → promote → goal
       // Replies are context for existing tasks, not new ideas
       if (from === 'alex' && !replyTo) {
-        const memDir = path.join(process.cwd(), 'memory');
+        const memDir = getMemoryRootDir();
         if (text.trim().length >= 5) {
           addIdea(memDir, { raw_text: text, source: `room:${from}` }).catch(() => {});
         }
@@ -3384,7 +3385,7 @@ export function createApi(port = 3001): express.Express {
       // Intake Pipeline: capture KG discussion creation as idea (only new_discussion, not every position)
       const isNewDiscussion = events?.some((e: any) => e.type === 'new_discussion' || e.type === 'discussion_created');
       if (isNewDiscussion && discussion_id) {
-        const memDir = path.join(process.cwd(), 'memory');
+        const memDir = getMemoryRootDir();
         const topic = events?.find((e: any) => e.topic)?.topic ?? `KG discussion ${discussion_id}`;
         addIdea(memDir, { raw_text: topic, source: 'kg:discussion' }).catch(() => {});
       }
@@ -3409,7 +3410,7 @@ export function createApi(port = 3001): express.Express {
   app.get('/api/room', (req: Request, res: Response) => {
     try {
       const date = (req.query.date as string) || new Date().toISOString().slice(0, 10);
-      const convPath = path.join(process.cwd(), 'memory', 'conversations', `${date}.jsonl`);
+      const convPath = resolveMemoryPath('conversations', `${date}.jsonl`);
 
       if (!fs.existsSync(convPath)) {
         res.json({ date, messages: [] });
@@ -3904,7 +3905,7 @@ if (isMain) {
     // Startup memory size check — log only, daily prune handles cleanup
     setTimeout(() => void (async () => {
       try {
-        const memDir = path.join(process.cwd(), 'memory');
+        const memDir = getMemoryRootDir();
         const [memoryLines, topicsCount, soulSize, claudeSize] = await Promise.all([
           fsPromises.readFile(path.join(memDir, 'MEMORY.md'), 'utf-8')
             .then(c => c.split('\n').length).catch(() => 0),

--- a/src/auto-executor.ts
+++ b/src/auto-executor.ts
@@ -15,6 +15,7 @@ import { eventBus } from './event-bus.js';
 import { slog } from './utils.js';
 import { spawnSync } from 'node:child_process';
 import path from 'node:path';
+import { getMemoryRootDir, resolveMemoryPath } from './memory-paths.js';
 import { evaluateWorkspaceIsolation } from './workspace-isolation.js';
 
 // =============================================================================
@@ -199,14 +200,14 @@ function ensureListener(): void {
       failCounts.delete(taskId);
       slog('AUTO-EXEC', `task ${taskId.slice(0, 16)} completed successfully`);
 
-      const memoryDir = path.join(process.cwd(), 'memory');
+      const memoryDir = getMemoryRootDir();
       checkGoalClosure(memoryDir, taskId);
     } else {
       const count = (failCounts.get(taskId) ?? 0) + 1;
       failCounts.set(taskId, count);
       if (count >= MAX_FAILURES_PER_TASK) {
         dispatchedSet.add(taskId);
-        const memoryDir = path.join(process.cwd(), 'memory');
+        const memoryDir = getMemoryRootDir();
         const current = queryMemoryIndexSync(memoryDir, { id: taskId, limit: 1 })[0];
         const payload = (current?.payload ?? {}) as Record<string, unknown>;
         updateMemoryIndexEntry(memoryDir, taskId, {

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,6 +9,7 @@
 
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import { getMemoryRootDir, resolveMemoryPath } from './memory-paths.js';
 import {
   getCurrentInstanceId,
   getInstanceDir,
@@ -20,7 +21,7 @@ import type { GlobalDefaults, InstanceConfig } from './types.js';
 import { expandEnvVars } from './utils.js';
 
 // 本地配置目錄（向後兼容）
-const LOCAL_CONFIG_DIR = path.join(process.cwd(), 'memory');
+const LOCAL_CONFIG_DIR = getMemoryRootDir();
 // LOCAL_CONFIG_FILE removed — was declared but unused (config.json read via getInstanceConfig)
 
 // expandEnvVars lives in utils.ts to avoid circular dependency (config ↔ instance)

--- a/src/contradiction-scanner.ts
+++ b/src/contradiction-scanner.ts
@@ -15,6 +15,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
+import { getMemoryRootDir, resolveMemoryPath } from './memory-paths.js';
 // spawn removed — uses sideQuery (SDK path) instead of direct CLI subprocess
 import { existsSync, mkdirSync } from 'node:fs';
 import { slog } from './utils.js';
@@ -27,7 +28,7 @@ const MEMORY_DIR = path.join(
   process.env.HOME ?? '/tmp',
   '.claude/projects/-Users-user--mini-agent-subprocess/memory',
 );
-const REPORT_PATH = path.join(process.cwd(), 'memory', 'contradiction-report.md');
+const REPORT_PATH = resolveMemoryPath('contradiction-report.md');
 const SUBPROCESS_CWD = path.join(process.env.HOME ?? '/tmp', '.mini-agent-subprocess');
 const HAIKU_MODEL = 'claude-haiku-4-5-20251001';
 const SCAN_TIMEOUT_MS = 120_000; // 2 minutes — Haiku is fast

--- a/src/cycle-tasks.ts
+++ b/src/cycle-tasks.ts
@@ -8,6 +8,7 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { getMemoryRootDir, resolveMemoryPath } from './memory-paths.js';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { slog } from './utils.js';
@@ -122,8 +123,8 @@ export function parseInterval(str: string): number {
  * auto-create corresponding handoff task files in memory/handoffs/.
  */
 export async function checkApprovedProposals(): Promise<void> {
-  const proposalsDir = path.join(process.cwd(), 'memory', 'proposals');
-  const handoffsDir = path.join(process.cwd(), 'memory', 'handoffs');
+  const proposalsDir = resolveMemoryPath('proposals');
+  const handoffsDir = resolveMemoryPath('handoffs');
 
   if (!fs.existsSync(proposalsDir)) return;
   if (!fs.existsSync(handoffsDir)) {
@@ -329,7 +330,7 @@ export async function resolveStaleConversationThreads(actionText?: string): Prom
  * Max 2 P0 items — oldest beyond cap demoted to P1.
  */
 export async function autoEscalateOverdueTasks(): Promise<void> {
-  const heartbeatPath = path.join(process.cwd(), 'memory', 'HEARTBEAT.md');
+  const heartbeatPath = resolveMemoryPath('HEARTBEAT.md');
   if (!fs.existsSync(heartbeatPath)) return;
 
   try {
@@ -388,7 +389,7 @@ export async function autoEscalateOverdueTasks(): Promise<void> {
 // =============================================================================
 
 export function guardHeartbeatSize(): void {
-  const heartbeatPath = path.join(process.cwd(), 'memory', 'HEARTBEAT.md');
+  const heartbeatPath = resolveMemoryPath('HEARTBEAT.md');
   if (!fs.existsSync(heartbeatPath)) return;
   try {
     const content = fs.readFileSync(heartbeatPath, 'utf-8');

--- a/src/delegation.ts
+++ b/src/delegation.ts
@@ -16,6 +16,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
+import { getMemoryRootDir, resolveMemoryPath } from './memory-paths.js';
 import { slog } from './utils.js';
 import { getInstanceDir, getCurrentInstanceId } from './instance.js';
 import { eventBus } from './event-bus.js';
@@ -233,7 +234,7 @@ export function spawnDelegation(task: DelegationTask): string {
     MAX_TIMEOUT_MS,
   );
   const workdir = task.workdir.replace(/^~/, process.env.HOME ?? '');
-  const memDir = path.join(process.cwd(), 'memory');
+  const memDir = getMemoryRootDir();
   const arbitration = decideArbitration(
     workItem,
     isBrainRuntimeDelegationEnabled()
@@ -365,7 +366,7 @@ async function dispatchViaBrainRuntime(
   const runtime = new BrainRuntime({
     providers,
     peers,
-    memoryDir: path.join(process.cwd(), 'memory'),
+    memoryDir: getMemoryRootDir(),
   });
 
   const runtimeResult = await runtime.execute({
@@ -769,7 +770,7 @@ function finalizeTask(
 
   // Auto-update task-queue entry
   if (task.originTask) {
-    const memDir = path.join(process.cwd(), 'memory');
+    const memDir = getMemoryRootDir();
     updateTask(memDir, task.originTask, {
       status: result.status === 'completed' ? 'completed' : failureDecision?.repeated ? 'hold' : 'pending',
       verify: [{
@@ -813,7 +814,7 @@ function finalizeTask(
 function recordRepeatedDelegationFailure(entry: ActiveEntry): ReturnType<typeof recordDelegationFailure> | null {
   const { result, task } = entry;
   if (!shouldGuardDelegationFailure(result.output)) return null;
-  const memDir = path.join(process.cwd(), 'memory');
+  const memDir = getMemoryRootDir();
   try {
     const decision = recordDelegationFailure(memDir, {
       taskId: result.id,
@@ -882,7 +883,7 @@ function recordDelegationClaim(entry: ActiveEntry): string | undefined {
       ],
       confidence: result.status === 'completed' ? 0.7 : 0.35,
     });
-    appendProviderClaim(path.join(process.cwd(), 'memory'), claim);
+    appendProviderClaim(getMemoryRootDir(), claim);
     kbObserve({
       source: 'claims',
       type: 'claim',

--- a/src/evolution.ts
+++ b/src/evolution.ts
@@ -8,12 +8,13 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { slog } from './utils.js';
+import { resolveMemoryPath } from './memory-paths.js';
 
 // =============================================================================
 // Gap Scanner — 系統 capability gap 主動掃描
 // =============================================================================
 
-const TRACKS_DIR = path.join(process.cwd(), 'memory', 'evolution-tracks');
+const TRACKS_DIR = resolveMemoryPath('evolution-tracks');
 
 /**
  * Scan for capability gaps and write results.

--- a/src/feedback-loops.ts
+++ b/src/feedback-loops.ts
@@ -12,6 +12,7 @@
 
 import { existsSync, readFileSync, writeFileSync, mkdirSync, appendFileSync } from 'node:fs';
 import path from 'node:path';
+import { getMemoryRootDir, resolveMemoryPath } from './memory-paths.js';
 import { getInstanceDir, getCurrentInstanceId } from './instance.js';  // getInstanceDir kept for features.json (ephemeral)
 import { getLogger } from './logging.js';
 import { perceptionStreams } from './perception-stream.js';
@@ -447,7 +448,7 @@ export async function auditDecisionQuality(action: string | null, triggerReason?
   let hasExternalTasks = false;
   try {
     const { queryMemoryIndexSync } = await import('./memory-index.js');
-    const memDir = (await import('node:path')).join(process.cwd(), 'memory');
+    const memDir = getMemoryRootDir();
     const tasks = queryMemoryIndexSync(memDir, { type: ['task', 'goal'], status: ['pending', 'in_progress'] });
     hasExternalTasks = tasks.some(t => {
       const p = (t.payload ?? {}) as Record<string, unknown>;
@@ -836,7 +837,7 @@ export async function auditStructuralHealth(triggerReason?: string | null): Prom
   // ── Check 2: Task Hygiene (memory-index) ──
   try {
     const { getTaskHygieneInfo } = await import('./memory-index.js');
-    const memDir = path.join(process.cwd(), 'memory');
+    const memDir = getMemoryRootDir();
     const { pendingCount, staleCount } = getTaskHygieneInfo(memDir);
 
     if (pendingCount > 8) {
@@ -895,7 +896,7 @@ export async function auditStructuralHealth(triggerReason?: string | null): Prom
 
     if (recentSrcChanges && recentSrcChanges.split('\n').length >= 3) {
       // Check if there was a Telegram notification or upgrade report
-      const reportsDir = path.join(process.cwd(), 'memory', 'evolution-tracks', 'reports');
+      const reportsDir = resolveMemoryPath('evolution-tracks', 'reports');
       const today = new Date().toISOString().slice(0, 10);
       let hasReport = false;
       try {
@@ -965,7 +966,7 @@ export async function trackCompoundInterest(cycleCount: number): Promise<void> {
 
   if (cycleCount - state.lastScanCycle < COMPOUND_SCAN_INTERVAL) return;
 
-  const topicsDir = path.join(process.cwd(), 'memory', 'topics');
+  const topicsDir = resolveMemoryPath('topics');
   if (!existsSync(topicsDir)) return;
 
   const { readdirSync } = await import('node:fs');
@@ -1081,7 +1082,7 @@ export async function auditProblemAlignment(action: string | null): Promise<void
   let priorityKeywords: string[] = [];
   try {
     const { getPriorityKeywords } = await import('./memory-index.js');
-    const memDir = path.join(process.cwd(), 'memory');
+    const memDir = getMemoryRootDir();
     priorityKeywords = getPriorityKeywords(memDir);
   } catch { /* ignore */ }
 

--- a/src/github.ts
+++ b/src/github.ts
@@ -16,6 +16,7 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { getMemoryRootDir, resolveMemoryPath } from './memory-paths.js';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { slog } from './utils.js';
@@ -100,7 +101,7 @@ async function ghAvailable(): Promise<boolean> {
 // =============================================================================
 
 export async function autoCreateIssueFromProposal(): Promise<void> {
-  const proposalsDir = path.join(process.cwd(), 'memory', 'proposals');
+  const proposalsDir = resolveMemoryPath('proposals');
   if (!fs.existsSync(proposalsDir)) return;
 
   let files: string[];
@@ -188,7 +189,7 @@ function writeBackIssueRef(filePath: string, content: string, statusLine: string
 const TERMINAL_STATUSES = ['completed', 'implemented', 'superseded'];
 
 export async function autoCloseCompletedIssues(): Promise<void> {
-  const proposalsDir = path.join(process.cwd(), 'memory', 'proposals');
+  const proposalsDir = resolveMemoryPath('proposals');
   if (!fs.existsSync(proposalsDir)) return;
 
   let files: string[];
@@ -298,7 +299,7 @@ interface ReviewablePR {
 }
 
 export async function autoTrackPrReviewNeeds(): Promise<void> {
-  const activePath = path.join(process.cwd(), 'memory', 'handoffs', 'active.md');
+  const activePath = resolveMemoryPath('handoffs', 'active.md');
   if (!fs.existsSync(activePath)) return;
 
   let prs: ReviewablePR[];
@@ -426,7 +427,7 @@ export function autofixPrVerificationSection(body?: string | null): PrVerificati
 }
 
 export async function autoProduceInternalPrReviewClaims(): Promise<void> {
-  const memoryDir = path.join(process.cwd(), 'memory');
+  const memoryDir = getMemoryRootDir();
   const activePath = path.join(memoryDir, 'handoffs', 'active.md');
   if (!fs.existsSync(activePath)) return;
 
@@ -467,7 +468,7 @@ export async function autoProduceInternalPrReviewClaims(): Promise<void> {
 }
 
 export async function autoRepairPrVerificationEvidence(): Promise<void> {
-  const memoryDir = path.join(process.cwd(), 'memory');
+  const memoryDir = getMemoryRootDir();
   const activePath = path.join(memoryDir, 'handoffs', 'active.md');
   if (!fs.existsSync(activePath)) return;
 
@@ -517,7 +518,7 @@ async function updatePullRequestBody(prNumber: number, body: string): Promise<vo
 // =============================================================================
 
 export async function autoTrackPrReviewConsensus(): Promise<void> {
-  const result = runPrReviewConsensus(path.join(process.cwd(), 'memory'));
+  const result = runPrReviewConsensus(getMemoryRootDir());
   if (result.updated) {
     const counts = result.consensuses.reduce<Record<string, number>>((acc, c) => {
       acc[c.status] = (acc[c.status] ?? 0) + 1;
@@ -532,7 +533,7 @@ export async function autoTrackPrReviewConsensus(): Promise<void> {
 // =============================================================================
 
 export async function autoApplyInternalPrReviewConsensus(): Promise<void> {
-  const memoryDir = path.join(process.cwd(), 'memory');
+  const memoryDir = getMemoryRootDir();
   const activePath = path.join(memoryDir, 'handoffs', 'active.md');
   if (!fs.existsSync(activePath)) return;
 
@@ -552,7 +553,7 @@ export async function autoApplyInternalPrReviewConsensus(): Promise<void> {
 }
 
 export async function autoMergeInternallyApprovedPR(): Promise<void> {
-  const memoryDir = path.join(process.cwd(), 'memory');
+  const memoryDir = getMemoryRootDir();
   const activePath = path.join(memoryDir, 'handoffs', 'active.md');
   if (!fs.existsSync(activePath)) return;
 
@@ -677,7 +678,7 @@ async function addPrComment(prNumber: number, body: string): Promise<void> {
 }
 
 function appendConflictHandoff(pr: GhPrView, decision: { action: string; reason: string }): void {
-  const activePath = path.join(process.cwd(), 'memory', 'handoffs', 'active.md');
+  const activePath = resolveMemoryPath('handoffs', 'active.md');
   if (!fs.existsSync(activePath)) return;
   const content = fs.readFileSync(activePath, 'utf-8');
   const marker = `PR #${pr.number} conflict diagnostic`;
@@ -706,7 +707,7 @@ interface MergedPR {
 }
 
 export async function autoTrackMergedPrClosures(): Promise<void> {
-  const activePath = path.join(process.cwd(), 'memory', 'handoffs', 'active.md');
+  const activePath = resolveMemoryPath('handoffs', 'active.md');
   if (!fs.existsSync(activePath)) return;
 
   let prs: MergedPR[];
@@ -755,7 +756,7 @@ function isRecentlyMerged(mergedAt?: string | null): boolean {
 // =============================================================================
 
 export async function autoTrackNewIssues(): Promise<void> {
-  const activePath = path.join(process.cwd(), 'memory', 'handoffs', 'active.md');
+  const activePath = resolveMemoryPath('handoffs', 'active.md');
   if (!fs.existsSync(activePath)) return;
 
   let issues: Array<{ number: number; title: string; createdAt: string; labels?: Array<{ name: string }> }>;

--- a/src/housekeeping.ts
+++ b/src/housekeeping.ts
@@ -7,6 +7,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
+import { getMemoryRootDir, resolveMemoryPath } from './memory-paths.js';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { getCurrentInstanceId, getInstanceDir } from './instance.js';
@@ -171,7 +172,7 @@ export function buildTaskProgressSection(inboxItems: InboxItem[]): string {
  * 偵測 topics/*.md mtime > last index time → rebuildIndex()。
  */
 export async function refreshSearchIndex(): Promise<void> {
-  const memoryDir = path.join(process.cwd(), 'memory');
+  const memoryDir = getMemoryRootDir();
   const topicsDir = path.join(memoryDir, 'topics');
   if (!fs.existsSync(topicsDir)) return;
 
@@ -289,7 +290,7 @@ const closedIssues = new Set<string>();
  * 已 close 的 issue 不重複處理（檔案內 Issue-Closed 標記 + memory Set）。
  */
 export async function syncHandoffStatus(): Promise<void> {
-  const handoffsDir = path.join(process.cwd(), 'memory', 'handoffs');
+  const handoffsDir = resolveMemoryPath('handoffs');
   if (!fs.existsSync(handoffsDir)) return;
 
   try {
@@ -436,7 +437,7 @@ const DAY_MS = 86_400_000;
  * 排除：goals 不受 L3、pinned 不清理、有部分通過 verify 的不自動清
  */
 export async function cleanStaleTasks(dryRun = false): Promise<CleanupResult[]> {
-  const memDir = path.join(process.cwd(), 'memory');
+  const memDir = getMemoryRootDir();
   const results: CleanupResult[] = [];
   const now = Date.now();
 
@@ -803,7 +804,7 @@ async function consolidateMemory(): Promise<void> {
   } catch { /* no lock file — proceed */ }
 
   // Use project memory dir, not instance dir (MEMORY.md lives in project/memory/)
-  const memoryDir = path.join(process.cwd(), 'memory');
+  const memoryDir = getMemoryRootDir();
   let actions = 0;
 
   // Phase 1: Cold storage migration (entries >30 days in non-protected sections)

--- a/src/inbox-processor.ts
+++ b/src/inbox-processor.ts
@@ -14,6 +14,7 @@ import type { ParsedTags } from './types.js';
 import { callLocalFast } from './omlx-gate.js';
 import { recordCascadeMetric } from './cascade.js';
 import { resolveReplyTasksByRoomMsgId } from './memory-index.js';
+import { getMemoryRootDir, resolveMemoryPath } from './memory-paths.js';
 
 // =============================================================================
 // Chat Room Inbox Pre-classification (0.8B cascade)
@@ -145,7 +146,7 @@ function getRoomReplyStatus(): { replied: Set<string>, msgLookup: Map<string, st
 
     const allLines: string[] = [];
     for (const ds of dateStrs) {
-      const jsonlPath = path.join(process.cwd(), 'memory', 'conversations', `${ds}.jsonl`);
+      const jsonlPath = resolveMemoryPath('conversations', `${ds}.jsonl`);
       if (fs.existsSync(jsonlPath)) {
         allLines.push(...fs.readFileSync(jsonlPath, 'utf-8').split('\n').filter(Boolean));
       }
@@ -424,7 +425,7 @@ export function markChatRoomInboxProcessed(response: string, tags: ParsedTags, a
     // Auto-complete "回覆 alex" tasks whose inbox messages were addressed.
     // Closes the loop: enqueueRoomDirective creates → inbox replied → task completed.
     if (resolvedMsgIds.length > 0) {
-      const memDir = path.join(process.cwd(), 'memory');
+      const memDir = getMemoryRootDir();
       resolveReplyTasksByRoomMsgId(memDir, resolvedMsgIds).catch(() => {});
     }
   } catch { /* fire-and-forget */ }

--- a/src/kg-memory.ts
+++ b/src/kg-memory.ts
@@ -1,6 +1,7 @@
 import { readFileSync, readdirSync, appendFileSync, existsSync, mkdirSync } from 'node:fs';
 import path from 'node:path';
 import { slog } from './utils.js';
+import { getMemoryStateRootDir } from './memory-paths.js';
 
 const KG_BASE = 'http://localhost:3300';
 
@@ -10,7 +11,7 @@ const AGENT_MEMORY_DIRS: Record<string, string> = {
 };
 
 function getCachePathForAgent(agent: string): string {
-  const dir = AGENT_MEMORY_DIRS[agent] ?? path.join(process.cwd(), 'memory', 'state');
+  const dir = AGENT_MEMORY_DIRS[agent] ?? getMemoryStateRootDir();
   const cacheDir = path.join(dir);
   if (!existsSync(cacheDir)) mkdirSync(cacheDir, { recursive: true });
   return path.join(cacheDir, 'kg-memory-cache.jsonl');

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -12,6 +12,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
+import { getMemoryRootDir, resolveMemoryPath } from './memory-paths.js';
 import { callClaude, preemptLoopCycle, isLoopBusy, isForegroundBusy, abortForeground, acquireForegroundSlot, releaseForegroundSlot, getLaneStatus } from './agent.js';
 import { getMemory, getMemoryStateDir } from './memory.js';
 import { getLogger } from './logging.js';
@@ -1089,7 +1090,7 @@ export class AgentLoop {
     try { initProcessTable(getMemoryStateDir()); } catch { /* best effort */ }
 
     // Output Gate: restore persisted state
-    try { loadOutputGateState(path.join(process.cwd(), 'memory')); } catch { /* best effort */ }
+    try { loadOutputGateState(getMemoryRootDir()); } catch { /* best effort */ }
 
     // Phase 1c: Recover interrupted cycle on startup
     const stale = loadStaleCheckpoint();
@@ -1220,7 +1221,7 @@ export class AgentLoop {
       if (taskId) {
         const delegationStatus = (event?.data?.status as string) === 'completed' ? 'completed' : 'abandoned';
         import('./memory-index.js').then(({ updateMemoryIndexEntry }) => {
-          const memDir = path.join(process.cwd(), 'memory');
+          const memDir = getMemoryRootDir();
           updateMemoryIndexEntry(memDir, taskId!, { status: delegationStatus }).catch(() => {});
         }).catch(() => {});
         try { completeProcess(taskId); } catch { /* may not exist in process table */ }
@@ -1376,7 +1377,7 @@ export class AgentLoop {
 
     // Hard cap: don't idle too long when there's work to do
     try {
-      const memDir = path.join(process.cwd(), 'memory');
+      const memDir = getMemoryRootDir();
       if (this.currentInterval > 180_000 && hasP0Tasks(memDir)) {
         this.currentInterval = 180_000; // 3min cap for P0
         slog('LOOP', `[next-p0] Capping interval to 3min — memory-index has P0 items`);
@@ -1413,7 +1414,7 @@ export class AgentLoop {
         }
       }
       // Only P0/P1 tasks count as "pending work" — P2+ don't block learn/explore/idle
-      const memDir = path.join(process.cwd(), 'memory');
+      const memDir = getMemoryRootDir();
       const highPriCount = getHighPriorityPendingCount(memDir);
       if (highPriCount > 0) {
         return true;
@@ -1897,7 +1898,7 @@ export class AgentLoop {
         const { minutesSinceLastCodeOutput } = await import('./activity-stream.js');
         const gapMinutes = minutesSinceLastCodeOutput();
         if (gapMinutes >= 15) {
-          const memDirIdle = path.join(process.cwd(), 'memory');
+          const memDirIdle = getMemoryRootDir();
           const pipelineAll = queryMemoryIndexSync(memDirIdle, { type: ['task'], status: ['pending', 'in_progress'] })
             .filter(t => (t.payload as Record<string, unknown>)?.goal_id);
           const actionable = pipelineAll.filter(t => {
@@ -1934,7 +1935,7 @@ export class AgentLoop {
       // Task decomposer: split abstract tasks into concrete sub-tasks (M1)
       try {
         const { checkAndDecompose } = await import('./task-decomposer.js');
-        const decompResult = checkAndDecompose(path.join(process.cwd(), 'memory'));
+        const decompResult = checkAndDecompose(getMemoryRootDir());
         if (decompResult.decomposed) {
           slog('DECOMPOSE', decompResult.reason);
         }
@@ -1943,7 +1944,7 @@ export class AgentLoop {
       // Auto-executor: immediate dispatch for ready tasks (M2+M3+M5)
       try {
         const { checkAndDispatch } = await import('./auto-executor.js');
-        const autoResult = checkAndDispatch(path.join(process.cwd(), 'memory'));
+        const autoResult = checkAndDispatch(getMemoryRootDir());
         if (autoResult.fired) {
           slog('AUTO-EXEC', `dispatched: ${autoResult.reason}`);
           context = `<auto-executor status="fired">\n` +
@@ -1955,7 +1956,7 @@ export class AgentLoop {
 
       // Decomposition gate: tasks that are too abstract need to be broken down
       try {
-        const memDir = path.join(process.cwd(), 'memory');
+        const memDir = getMemoryRootDir();
         const decomp = queryMemoryIndexSync(memDir, { type: ['task'], status: ['needs-decomposition'] });
         if (decomp.length > 0) {
           const lines = decomp.map(t =>
@@ -1969,7 +1970,7 @@ export class AgentLoop {
 
       // Pipeline stuck injection: tell agent about blocked pipeline tasks
       try {
-        const stuckAnalyses = getPipelineStuckAnalysis(path.join(process.cwd(), 'memory'));
+        const stuckAnalyses = getPipelineStuckAnalysis(getMemoryRootDir());
         if (stuckAnalyses.length > 0) {
           context = stuckAnalyses.join('\n') + '\n\n' + context;
         }
@@ -1983,7 +1984,7 @@ export class AgentLoop {
       // Task Pull: idle/heartbeat OR just-finished-task cycles get next action suggestion
       // P1 fix: include pipeline tasks, pipeline-first sort (KG c9361f0a)
       if ((isRoutineHeartbeat && !isDirectMessage) || justFinishedTask) {
-        const memDir = path.join(process.cwd(), 'memory');
+        const memDir = getMemoryRootDir();
         const pending = queryMemoryIndexSync(memDir, { type: ['task', 'goal'], status: ['pending', 'in_progress'] });
         const sorted = pending.sort((a, b) => {
           const pa = (a.payload as Record<string, unknown>) ?? {};
@@ -2139,7 +2140,7 @@ export class AgentLoop {
 
       // Check memory-index for pending tasks BEFORE mode detection
       // Fix: mode detection must know about tracked tasks, not just inbox items
-      const memDir = path.join(process.cwd(), 'memory');
+      const memDir = getMemoryRootDir();
       let hasPendingTasks = false;
       try {
         const pendingPreviews = getPendingTaskPreviews(memDir);
@@ -2930,7 +2931,7 @@ export class AgentLoop {
         // Auto-register delegate as task in memory-index for Activity Monitor visibility
         try {
           const { appendMemoryIndexEntry } = await import('./memory-index.js');
-          const memDir = path.join(process.cwd(), 'memory');
+          const memDir = getMemoryRootDir();
           await appendMemoryIndexEntry(memDir, {
             id: taskId,
             type: 'task',
@@ -2974,7 +2975,7 @@ export class AgentLoop {
           return true;
         });
         if (filteredDones.length > 0) {
-          const markedCount = await markTaskDoneByDescription(path.join(process.cwd(), 'memory'), filteredDones).catch((err) => {
+          const markedCount = await markTaskDoneByDescription(getMemoryRootDir(), filteredDones).catch((err) => {
             slog('DONE', `⚠️ markTaskDoneByDescription error: ${err instanceof Error ? err.message : String(err)}`);
             return 0;
           });
@@ -2990,7 +2991,7 @@ export class AgentLoop {
               try {
                 const { markTaskDoneById } = await import('./memory-index.js');
                 const markedCurrent = await markTaskDoneById(
-                  path.join(process.cwd(), 'memory'),
+                  getMemoryRootDir(),
                   schedState.currentTaskId,
                   'current-task done fallback',
                 );
@@ -3563,14 +3564,14 @@ export class AgentLoop {
       }
 
       // ── Constraint Texture: task staleness pressure ──
-      incrementTaskStaleness(path.join(process.cwd(), 'memory')).then(staleTasks => {
+      incrementTaskStaleness(getMemoryRootDir()).then(staleTasks => {
         if (staleTasks.length === 0) return;
         this.staleTasks = staleTasks;
 
         // Escalation: >5 ticks → auto P0
         for (const t of staleTasks) {
           if (t.ticks > 5) {
-            updateTask(path.join(process.cwd(), 'memory'), t.id, { priority: 0 }).catch(() => {});
+            updateTask(getMemoryRootDir(), t.id, { priority: 0 }).catch(() => {});
             slog('CONSTRAINT', `Escalated to P0: ${t.summary.slice(0, 60)} (${t.ticks} ticks stale)`);
           }
         }
@@ -3589,7 +3590,7 @@ export class AgentLoop {
 
       // ── Pipeline: verify scan + goal self-heal (every 5 cycles) ──
       if (this.cycleCount % 5 === 0) {
-        const memDir = path.join(process.cwd(), 'memory');
+        const memDir = getMemoryRootDir();
         scanPipelineVerify(memDir).then(done => {
           if (done > 0) slog('PIPELINE', `Verify scan auto-completed ${done} task(s)`);
         }).catch(() => {});

--- a/src/memory-paths.ts
+++ b/src/memory-paths.ts
@@ -1,0 +1,22 @@
+import path from 'node:path';
+
+const MEMORY_DIR_ENV = 'MINI_AGENT_MEMORY_DIR';
+
+export function getMemoryRootDir(cwd = process.cwd()): string {
+  const configured = process.env[MEMORY_DIR_ENV]?.trim();
+  if (configured) return path.resolve(configured);
+  return path.join(cwd, 'memory');
+}
+
+export function getMemoryStateRootDir(cwd = process.cwd()): string {
+  return path.join(getMemoryRootDir(cwd), 'state');
+}
+
+export function resolveMemoryPath(...segments: string[]): string {
+  return path.join(getMemoryRootDir(), ...segments);
+}
+
+export function getMemoryDirSource(): 'env' | 'repo-default' {
+  return process.env[MEMORY_DIR_ENV]?.trim() ? 'env' : 'repo-default';
+}
+

--- a/src/memory-provenance-query.ts
+++ b/src/memory-provenance-query.ts
@@ -17,6 +17,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import readline from 'node:readline';
 import { memoryIdForContent, type ProvenanceRecord } from './memory-provenance.js';
+import { resolveMemoryPath } from './memory-paths.js';
 
 export interface KGEdgeProvenance {
   edge_id: string;
@@ -38,7 +39,7 @@ export interface ProvenanceChain {
   last_seen: string | null;             // latest ts
 }
 
-const PROVENANCE_PATH = path.join(process.cwd(), 'memory', 'state', 'memory-provenance.jsonl');
+const PROVENANCE_PATH = resolveMemoryPath('state', 'memory-provenance.jsonl');
 const KG_BASE = process.env.KG_BASE_URL || 'http://localhost:3300';
 
 /**

--- a/src/memory-provenance.ts
+++ b/src/memory-provenance.ts
@@ -15,6 +15,7 @@
  */
 import crypto from 'node:crypto';
 import path from 'node:path';
+import { getMemoryRootDir, resolveMemoryPath } from './memory-paths.js';
 import { existsSync, mkdirSync, appendFileSync } from 'node:fs';
 import { slog } from './utils.js';
 
@@ -69,7 +70,7 @@ export function memoryIdForContent(content: string): string {
 }
 
 const provenancePath = (): string => {
-  const stateDir = path.join(process.cwd(), 'memory', 'state');
+  const stateDir = resolveMemoryPath('state');
   if (!existsSync(stateDir)) mkdirSync(stateDir, { recursive: true });
   return path.join(stateDir, 'memory-provenance.jsonl');
 };

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -67,6 +67,7 @@ import { queryKGDiscussionContext } from './observability.js';
 import { getSkillsExcludeSet, shouldPruneSection, getEffectiveOutputCap, callLocalFast, classifyContextProfile, getContextProfileConfig, shouldLoadForProfile, extractKeywordsWithOMLX } from './omlx-gate.js';
 import { recordCascadeMetric } from './cascade.js';
 import { appendProvenance, memoryIdForContent } from './memory-provenance.js';
+import { getMemoryRootDir, getMemoryStateRootDir } from './memory-paths.js';
 
 // =============================================================================
 // Write-time Dedup — Jaccard word similarity (zero LLM cost)
@@ -508,8 +509,8 @@ export function setPerceptionProviders(providers: {
  * 取得記憶目錄 — 統一指向專案的 memory/ 資料夾
  * Runtime state（cycle-state, features, mode 等）留在 instanceDir
  */
-function getMemoryDir(_instanceId?: string): string {
-  return path.join(process.cwd(), 'memory');
+export function getMemoryDir(_instanceId?: string): string {
+  return getMemoryRootDir();
 }
 
 /**
@@ -518,7 +519,7 @@ function getMemoryDir(_instanceId?: string): string {
  * 與 instanceDir（ephemeral runtime）分離
  */
 export function getMemoryStateDir(): string {
-  const dir = path.join(process.cwd(), 'memory', 'state');
+  const dir = getMemoryStateRootDir();
   if (!existsSync(dir)) {
     mkdirSync(dir, { recursive: true });
   }

--- a/src/metabolism.ts
+++ b/src/metabolism.ts
@@ -12,6 +12,7 @@
 
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import { getMemoryRootDir, resolveMemoryPath } from './memory-paths.js';
 import { withFileLock } from './filelock.js';
 import { MUSHI_DEDUP_URL } from './mushi-client.js';
 import { createHash } from 'node:crypto';
@@ -202,7 +203,7 @@ async function detectPatterns(): Promise<void> {
 
 async function removeBulletFromTopic(topic: string, bullet: string): Promise<void> {
   const memory = getMemory();
-  const topicPath = path.join(process.cwd(), 'memory', 'topics', `${topic}.md`);
+  const topicPath = resolveMemoryPath('topics', `${topic}.md`);
 
   await withFileLock(topicPath, async () => {
     const content = await memory.readTopicMemory(topic);
@@ -270,7 +271,7 @@ async function detectStaleKnowledge(): Promise<void> {
     if (staleLines.length === 0) continue;
 
     // Auto-archive: remove stale lines from topic file (locked to prevent race with appendTopicMemory)
-    const topicPath = path.join(process.cwd(), 'memory', 'topics', `${topic}.md`);
+    const topicPath = resolveMemoryPath('topics', `${topic}.md`);
     await withFileLock(topicPath, async () => {
       // Re-read inside lock to avoid TOCTOU
       const freshContent = await memory.readTopicMemory(topic);

--- a/src/model-router.ts
+++ b/src/model-router.ts
@@ -162,6 +162,7 @@ export function getModelCliName(tier: ModelTier): string | undefined {
 
 import { appendFileSync, existsSync, mkdirSync } from 'node:fs';
 import path from 'node:path';
+import { getMemoryRootDir, resolveMemoryPath } from './memory-paths.js';
 
 interface DecisionProvenance {
   ts: string;
@@ -172,7 +173,7 @@ interface DecisionProvenance {
 }
 
 const provenancePath = (): string => {
-  const stateDir = path.join(process.cwd(), 'memory', 'state');
+  const stateDir = resolveMemoryPath('state');
   if (!existsSync(stateDir)) mkdirSync(stateDir, { recursive: true });
   return path.join(stateDir, 'decision-provenance.jsonl');
 };

--- a/src/myelin-fleet.ts
+++ b/src/myelin-fleet.ts
@@ -16,6 +16,7 @@ import { createMyelin, createFleet, logDecision } from 'myelinate';
 import type { Myelin, MyelinStats, TriageResult, MyelinFleet, FleetStats } from 'myelinate';
 
 import { slog } from './utils.js';
+import { getMemoryRootDir } from './memory-paths.js';
 import type { TaskLane } from './task-graph.js';
 
 // =============================================================================
@@ -371,7 +372,7 @@ export async function maybeDistill(): Promise<boolean> {
     try { persistRuleHitCounts(); } catch { /* fire-and-forget */ }
     try {
       const { syncMyelinToKnowledge } = await import('./myelin-kg-sync.js');
-      syncMyelinToKnowledge(`${process.cwd()}/memory`, { limitPerDomain: 3, minHitCount: 1 });
+      syncMyelinToKnowledge(getMemoryRootDir(), { limitPerDomain: 3, minHitCount: 1 });
     } catch { /* shared knowledge sync is optional */ }
 
     // Research methodology evolution (needs evolve() beyond basic distill)

--- a/src/observability.ts
+++ b/src/observability.ts
@@ -9,6 +9,7 @@
 import fs from 'node:fs';
 import fsPromises from 'node:fs/promises';
 import path from 'node:path';
+import { getMemoryRootDir, resolveMemoryPath } from './memory-paths.js';
 import { eventBus } from './event-bus.js';
 import type { AgentEvent } from './event-bus.js';
 import { slog } from './utils.js';
@@ -313,7 +314,7 @@ export async function writeRoomMessage(from: string, text: string, replyTo?: str
   const now = new Date();
   const dateStr = now.toISOString().slice(0, 10);
 
-  const convDir = path.join(process.cwd(), 'memory', 'conversations');
+  const convDir = resolveMemoryPath('conversations');
   if (!fs.existsSync(convDir)) {
     await fsPromises.mkdir(convDir, { recursive: true });
   }

--- a/src/omlx-gate.ts
+++ b/src/omlx-gate.ts
@@ -24,6 +24,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
+import { getMemoryRootDir, resolveMemoryPath } from './memory-paths.js';
 import { execFileSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { eventBus } from './event-bus.js';
@@ -117,7 +118,7 @@ export function cronGate(taskDescription: string): CronGateResult {
     return 'claude';
   }
 
-  const heartbeatPath = path.join(process.cwd(), 'memory', 'HEARTBEAT.md');
+  const heartbeatPath = resolveMemoryPath('HEARTBEAT.md');
 
   // Read file once for both Layer 1 (content hash) and Layer 2 (heuristic + 0.8B)
   let content: string;
@@ -222,7 +223,7 @@ function refreshDynamicPruneList(): Set<string> {
   const pruneSet = new Set<string>();
 
   try {
-    const citationsPath = path.join(process.cwd(), 'memory', 'state', 'perception-citations.json');
+    const citationsPath = resolveMemoryPath('state', 'perception-citations.json');
     if (!fs.existsSync(citationsPath)) return pruneSet;
 
     const data = JSON.parse(fs.readFileSync(citationsPath, 'utf-8'));

--- a/src/perception-stream.ts
+++ b/src/perception-stream.ts
@@ -21,6 +21,7 @@ import type { ComposePerception } from './types.js';
 import { analyzePerceptions, isAnalysisAvailable } from './perception-analyzer.js';
 import { slog } from './utils.js';
 import { getInstanceDir, getCurrentInstanceId } from './instance.js';
+import { resolveMemoryPath } from './memory-paths.js';
 
 // =============================================================================
 // Perception Cache — persist across restarts
@@ -216,7 +217,7 @@ class PerceptionStreamManager {
 
     // Apply persisted interval adjustments from citation tracking (survives restarts)
     try {
-      const statePath = path.join(process.cwd(), 'memory', 'state', 'perception-citations.json');
+      const statePath = resolveMemoryPath('state', 'perception-citations.json');
       if (fs.existsSync(statePath)) {
         const stateData = JSON.parse(fs.readFileSync(statePath, 'utf-8'));
         const adjusted = stateData.adjustedIntervals ?? {};

--- a/src/preprocess.ts
+++ b/src/preprocess.ts
@@ -14,6 +14,7 @@
 import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
+import { getMemoryRootDir, resolveMemoryPath } from './memory-paths.js';
 import { callLocalConcurrent } from './omlx-gate.js';
 import type { LocalLLMTask } from './omlx-gate.js';
 import { eventBus } from './event-bus.js';
@@ -145,7 +146,7 @@ function buildHeartbeatDiffTask(currentContent: string): LocalLLMTask | null {
 function buildConversationSummaryTask(): LocalLLMTask | null {
   try {
     const today = new Date().toISOString().slice(0, 10);
-    const convPath = path.join(process.cwd(), 'memory', 'conversations', `${today}.jsonl`);
+    const convPath = resolveMemoryPath('conversations', `${today}.jsonl`);
     if (!fs.existsSync(convPath)) return null;
 
     const raw = fs.readFileSync(convPath, 'utf-8');
@@ -215,7 +216,7 @@ export async function runPhase0(): Promise<Phase0Results> {
 
   // P0c: HEARTBEAT diff
   try {
-    const hbPath = path.join(process.cwd(), 'memory', 'HEARTBEAT.md');
+    const hbPath = resolveMemoryPath('HEARTBEAT.md');
     const hbContent = fs.readFileSync(hbPath, 'utf-8');
     const hbTask = buildHeartbeatDiffTask(hbContent);
     if (hbTask) tasks.push(hbTask);

--- a/src/prompt-builder.ts
+++ b/src/prompt-builder.ts
@@ -7,6 +7,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
+import { getMemoryRootDir, resolveMemoryPath } from './memory-paths.js';
 import { getMemory, getMemoryStateDir, getReviewBacklog } from './memory.js';
 import type { CycleMode } from './memory.js';
 import { buildThreadsPromptSection } from './temporal.js';
@@ -142,7 +143,7 @@ export function loadBehaviorConfig(
   lastValidConfig: BehaviorConfig | null,
 ): { config: BehaviorConfig | null; lastValidConfig: BehaviorConfig | null } {
   try {
-    const filePath = path.join(process.cwd(), 'memory', 'behavior.md');
+    const filePath = resolveMemoryPath('behavior.md');
     if (!fs.existsSync(filePath)) return { config: lastValidConfig, lastValidConfig };
     const content = fs.readFileSync(filePath, 'utf-8');
     const config = parseBehaviorConfig(content);

--- a/src/pulse.ts
+++ b/src/pulse.ts
@@ -18,6 +18,7 @@
 
 import { existsSync, readFileSync, writeFileSync, mkdirSync, unlinkSync, statSync } from 'node:fs';
 import path from 'node:path';
+import { getMemoryRootDir, resolveMemoryPath } from './memory-paths.js';
 import { getMemoryStateDir } from './memory.js';
 import { getLogger } from './logging.js';
 import { getMemory } from './memory.js';
@@ -585,7 +586,7 @@ export async function computePulseMetrics(action: string | null, state: PulseSta
   // ── Stale tasks ──
   try {
     const { auditStaleTasks } = await import('./memory-index.js');
-    const memDir = path.join(process.cwd(), 'memory');
+    const memDir = getMemoryRootDir();
     const stale = auditStaleTasks(memDir);
     metrics.staleTasks = stale.length;
   } catch { /* best effort */ }
@@ -615,7 +616,7 @@ export async function computePulseMetrics(action: string | null, state: PulseSta
   // ── Goal idle detection ──
   try {
     const { queryMemoryIndexSync } = await import('./memory-index.js');
-    const memDir = path.join(process.cwd(), 'memory');
+    const memDir = getMemoryRootDir();
     const goals = queryMemoryIndexSync(memDir, {
       type: 'goal',
       status: ['in_progress'],
@@ -676,7 +677,7 @@ export async function computePulseMetrics(action: string | null, state: PulseSta
     if (behaviors.length >= 5) {
       // Simple heuristic: check if recent actions mention P0 goal
       const { queryMemoryIndexSync: queryGoals } = await import('./memory-index.js');
-      const memDir = path.join(process.cwd(), 'memory');
+      const memDir = getMemoryRootDir();
       const goals = queryGoals(memDir, {
         type: 'goal',
         status: ['in_progress'],
@@ -1182,7 +1183,7 @@ const NON_MECHANICAL_SIGNALS = new Set<string>([
 function escalateToCrystallization(signal: PulseSignal, history: SignalHistoryEntry): void {
   try {
     // Dedup: skip if HEARTBEAT already has a task (or comment) for this signal type
-    const heartbeatPath = path.join(process.cwd(), 'memory', 'HEARTBEAT.md');
+    const heartbeatPath = resolveMemoryPath('HEARTBEAT.md');
     if (existsSync(heartbeatPath)) {
       const content = readFileSync(heartbeatPath, 'utf-8');
       if (content.includes(`結晶候選 — ${signal.type}`)) {
@@ -1230,7 +1231,7 @@ export async function runPulseCheck(
   // CT evolution: Learn goal vocabulary from this cycle's action
   try {
     const { queryMemoryIndexSync } = await import('./memory-index.js');
-    const memDir = path.join(process.cwd(), 'memory');
+    const memDir = getMemoryRootDir();
     const goals = queryMemoryIndexSync(memDir, {
       type: 'goal',
       status: ['in_progress'],

--- a/src/shared-knowledge.ts
+++ b/src/shared-knowledge.ts
@@ -21,6 +21,7 @@
 
 import { existsSync, mkdirSync, appendFileSync, readFileSync } from 'node:fs';
 import path from 'node:path';
+import { getMemoryRootDir, resolveMemoryPath } from './memory-paths.js';
 import { eventBus } from './event-bus.js';
 import { slog } from './utils.js';
 import { getRecentClaimsSummary } from './claim-ledger.js';
@@ -385,7 +386,7 @@ export function patterns(): KBPattern[] {
  */
 export function getKnowledgeSummary(): string | null {
   const allStats = stats();
-  const claims = _logDir ? getRecentClaimsSummary(path.join(process.cwd(), 'memory'), 5) : null;
+  const claims = _logDir ? getRecentClaimsSummary(getMemoryRootDir(), 5) : null;
   if (allStats.length === 0 && !claims) return null;
 
   const lines: string[] = [];

--- a/src/success-patterns.ts
+++ b/src/success-patterns.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { getMemoryStateDir } from './memory.js';
+import { resolveMemoryPath } from './memory-paths.js';
 import { slog } from './utils.js';
 
 interface SuccessPattern {
@@ -94,7 +95,7 @@ export function seedFromHeartbeat(): void {
     const filePath = path.join(stateDir, PATTERNS_FILE);
     if (fs.existsSync(filePath)) return;
 
-    const hbPath = path.join(process.cwd(), 'memory', 'HEARTBEAT.md');
+    const hbPath = resolveMemoryPath('HEARTBEAT.md');
     if (!fs.existsSync(hbPath)) return;
 
     const hb = fs.readFileSync(hbPath, 'utf-8');

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -22,6 +22,7 @@ import { isEnabled } from './features.js';
 import { isLoopBusy } from './agent.js';
 import { enqueueAlexMessage } from './memory-index.js';
 import { writeRoomMessage } from './observability.js';
+import { getMemoryRootDir } from './memory-paths.js';
 
 // =============================================================================
 // Types
@@ -507,7 +508,7 @@ export class TelegramPoller {
     // Sync TG message to Chat Room conversation log, then enqueue task with roomMsgId
     // so resolveReplyTasksByRoomMsgId can auto-complete it when replied.
     writeRoomMessage('alex', parsed.text)
-      .then(roomMsgId => enqueueAlexMessage(path.join(process.cwd(), 'memory'), parsed.text, parsed.timestamp, roomMsgId))
+      .then(roomMsgId => enqueueAlexMessage(getMemoryRootDir(), parsed.text, parsed.timestamp, roomMsgId))
       .catch(() => {});
 
     // Add to buffer and schedule flush
@@ -1316,5 +1317,4 @@ export function getLastAlexMessageId(): number | null {
 export function clearLastReaction(): void {
   pollerInstance?.clearLastReaction();
 }
-
 

--- a/src/temporal.ts
+++ b/src/temporal.ts
@@ -12,6 +12,7 @@
 
 import fsSync from 'node:fs';
 import path from 'node:path';
+import { getMemoryRootDir, resolveMemoryPath } from './memory-paths.js';
 
 // =============================================================================
 // Types
@@ -56,7 +57,7 @@ let cachedState: TemporalState | null = null;
 let stateDirty = false;
 
 function getTemporalPath(): string {
-  return path.join(process.cwd(), 'memory', 'temporal.json');
+  return resolveMemoryPath('temporal.json');
 }
 
 function getDefaultState(): TemporalState {
@@ -469,7 +470,7 @@ export async function buildThreadsPromptSection(): Promise<string | null> {
 // =============================================================================
 
 export function buildThreadsContextSection(): string | null {
-  const threadsDir = path.join(process.cwd(), 'memory', 'threads');
+  const threadsDir = resolveMemoryPath('threads');
   if (!fsSync.existsSync(threadsDir)) return null;
 
   let files: string[];

--- a/tests/memory-paths.test.ts
+++ b/tests/memory-paths.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import path from 'node:path';
+
+import { getMemoryDirSource, getMemoryRootDir, getMemoryStateRootDir, resolveMemoryPath } from '../src/memory-paths.js';
+
+const original = process.env.MINI_AGENT_MEMORY_DIR;
+
+afterEach(() => {
+  if (original === undefined) delete process.env.MINI_AGENT_MEMORY_DIR;
+  else process.env.MINI_AGENT_MEMORY_DIR = original;
+});
+
+describe('memory path resolution', () => {
+  it('defaults to repo-local memory for backward compatibility', () => {
+    delete process.env.MINI_AGENT_MEMORY_DIR;
+
+    expect(getMemoryRootDir('/repo/mini-agent')).toBe(path.join('/repo/mini-agent', 'memory'));
+    expect(getMemoryStateRootDir('/repo/mini-agent')).toBe(path.join('/repo/mini-agent', 'memory', 'state'));
+    expect(getMemoryDirSource()).toBe('repo-default');
+  });
+
+  it('uses MINI_AGENT_MEMORY_DIR as the external state root', () => {
+    process.env.MINI_AGENT_MEMORY_DIR = '/state/mini-agent-memory/memory';
+
+    expect(getMemoryRootDir('/repo/mini-agent')).toBe('/state/mini-agent-memory/memory');
+    expect(getMemoryStateRootDir('/repo/mini-agent')).toBe('/state/mini-agent-memory/memory/state');
+    expect(resolveMemoryPath('handoffs', 'active.md')).toBe('/state/mini-agent-memory/memory/handoffs/active.md');
+    expect(getMemoryDirSource()).toBe('env');
+  });
+});
+


### PR DESCRIPTION
## Summary
- add MINI_AGENT_MEMORY_DIR support through a shared memory-paths module
- route hot runtime writers/readers away from repo-local memory/ when an external memory dir is configured
- add setup:external-memory to copy existing memory into a dedicated state workspace
- document MINI_AGENT_MEMORY_DIR in .env.example

## Why
Runtime checkout should stay clean runtime/main. Memory/state is live file truth and should not dirty the code/deploy checkout.

## Verification
- pnpm typecheck
- pnpm build
- pnpm test --run tests/memory-paths.test.ts tests/workspace-isolation.test.ts tests/commitment-ledger.test.ts
- pnpm exec tsx scripts/setup-external-memory.ts --target /tmp/mini-agent-memory-smoke/memory --force