### PR TITLE
fix: require external memory for runtime checkout

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -17,7 +17,7 @@ import fsPromises from 'node:fs/promises';
 import https from 'node:https';
 import os from 'node:os';
 import path from 'node:path';
-import { getMemoryRootDir, resolveMemoryPath } from './memory-paths.js';
+import { assertRuntimeMemoryPlacement, getMemoryRootDir, resolveMemoryPath } from './memory-paths.js';
 import { monitorEventLoopDelay, type IntervalHistogram } from 'node:perf_hooks';
 import express, { type Request, type Response, type NextFunction } from 'express';
 
@@ -3651,6 +3651,7 @@ process.on('unhandledRejection', (reason) => {
 const isMain = import.meta.url === `file://${process.argv[1]}`;
 if (isMain) {
   const port = parseInt(process.env.PORT ?? '3001', 10);
+  const memoryPlacement = assertRuntimeMemoryPlacement();
   const app = createApi(port);
   const instanceId = getCurrentInstanceId();
   const instanceConfig = loadInstanceConfig(instanceId);
@@ -3871,6 +3872,7 @@ if (isMain) {
 
   const server = app.listen(port, '0.0.0.0', () => {
     slog('SERVER', `Started on :${port} (instance: ${instanceId})`);
+    slog('MEMORY', `${memoryPlacement.memoryRoot} (${memoryPlacement.reason})`);
     const cronCount = getCronTaskCount();
     if (cronCount > 0) slog('CRON', `${cronCount} task(s) active`);
     if (loopRef) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -63,6 +63,7 @@ import { initObservability } from './observability.js';
 import { initActivityJournal } from './activity-journal.js';
 import { perceptionStreams } from './perception-stream.js';
 import { initClaudeMdJIT } from './claudemd-jit.js';
+import { assertRuntimeMemoryPlacement } from './memory-paths.js';
 import type { InstanceConfig } from './types.js';
 
 // =============================================================================
@@ -1340,6 +1341,8 @@ function describeCapability(pluginName: string): string {
 }
 
 async function runChat(port: number): Promise<void> {
+  const memoryPlacement = assertRuntimeMemoryPlacement();
+
   // 同時啟動 API server
   const app = createApi(port);
   const config = await getConfig();
@@ -1487,6 +1490,7 @@ async function runChat(port: number): Promise<void> {
     console.log(`Mini-Agent - Memory + Cron + Loop`);
     console.log(`Instance: ${instanceId}`);
     console.log(`API server: http://localhost:${port}`);
+    console.log(`Memory: ${memoryPlacement.memoryRoot} (${memoryPlacement.reason})`);
     if (cronCount > 0) {
       console.log(`Cron: ${cronCount} task(s) active`);
     }

--- a/src/memory-paths.ts
+++ b/src/memory-paths.ts
@@ -1,6 +1,9 @@
 import path from 'node:path';
+import { existsSync } from 'node:fs';
+import { evaluateWorkspaceIsolation } from './workspace-isolation.js';
 
 const MEMORY_DIR_ENV = 'MINI_AGENT_MEMORY_DIR';
+const ALLOW_REPO_MEMORY_ENV = 'MINI_AGENT_ALLOW_REPO_MEMORY';
 
 export function getMemoryRootDir(cwd = process.cwd()): string {
   const configured = process.env[MEMORY_DIR_ENV]?.trim();
@@ -20,3 +23,101 @@ export function getMemoryDirSource(): 'env' | 'repo-default' {
   return process.env[MEMORY_DIR_ENV]?.trim() ? 'env' : 'repo-default';
 }
 
+export interface RuntimeMemoryPlacement {
+  ok: boolean;
+  reason: string;
+  memoryRoot: string;
+  source: 'env' | 'repo-default';
+  repoRoot: string | null;
+  protectedRuntimeWorkspace: boolean;
+}
+
+export function evaluateRuntimeMemoryPlacement(cwd = process.cwd()): RuntimeMemoryPlacement {
+  const memoryRoot = getMemoryRootDir(cwd);
+  const source = getMemoryDirSource();
+  const workspace = evaluateWorkspaceIsolation(cwd);
+  const protectedRoot = workspace.repoRoot ?? cwd;
+  const allowedOverride = process.env[ALLOW_REPO_MEMORY_ENV] === '1';
+
+  if (!workspace.protectedRuntimeWorkspace) {
+    return {
+      ok: true,
+      reason: 'isolated worktree may use local memory',
+      memoryRoot,
+      source,
+      repoRoot: workspace.repoRoot,
+      protectedRuntimeWorkspace: false,
+    };
+  }
+
+  if (allowedOverride) {
+    return {
+      ok: true,
+      reason: `${ALLOW_REPO_MEMORY_ENV}=1 override enabled`,
+      memoryRoot,
+      source,
+      repoRoot: workspace.repoRoot,
+      protectedRuntimeWorkspace: true,
+    };
+  }
+
+  if (source !== 'env') {
+    return {
+      ok: false,
+      reason: `${MEMORY_DIR_ENV} is required for protected runtime workspace`,
+      memoryRoot,
+      source,
+      repoRoot: workspace.repoRoot,
+      protectedRuntimeWorkspace: true,
+    };
+  }
+
+  if (isInside(memoryRoot, protectedRoot)) {
+    return {
+      ok: false,
+      reason: `${MEMORY_DIR_ENV} must point outside protected repo checkout`,
+      memoryRoot,
+      source,
+      repoRoot: workspace.repoRoot,
+      protectedRuntimeWorkspace: true,
+    };
+  }
+
+  if (!existsSync(memoryRoot)) {
+    return {
+      ok: false,
+      reason: `${MEMORY_DIR_ENV} does not exist; run pnpm setup:external-memory`,
+      memoryRoot,
+      source,
+      repoRoot: workspace.repoRoot,
+      protectedRuntimeWorkspace: true,
+    };
+  }
+
+  return {
+    ok: true,
+    reason: 'protected runtime workspace uses external memory',
+    memoryRoot,
+    source,
+    repoRoot: workspace.repoRoot,
+    protectedRuntimeWorkspace: true,
+  };
+}
+
+export function assertRuntimeMemoryPlacement(cwd = process.cwd()): RuntimeMemoryPlacement {
+  const decision = evaluateRuntimeMemoryPlacement(cwd);
+  if (!decision.ok) {
+    throw new Error([
+      `[runtime-memory] ${decision.reason}`,
+      `memoryRoot=${decision.memoryRoot}`,
+      decision.repoRoot ? `repoRoot=${decision.repoRoot}` : null,
+      `Fix: set ${MEMORY_DIR_ENV} to an external memory directory, e.g. ../mini-agent-memory/memory.`,
+    ].filter(Boolean).join('\n'));
+  }
+  return decision;
+}
+
+function isInside(child: string, parent: string): boolean {
+  const relative = path.relative(path.resolve(parent), path.resolve(child));
+  return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
+}

--- a/tests/memory-paths.test.ts
+++ b/tests/memory-paths.test.ts
@@ -1,13 +1,27 @@
 import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 
-import { getMemoryDirSource, getMemoryRootDir, getMemoryStateRootDir, resolveMemoryPath } from '../src/memory-paths.js';
+import {
+  evaluateRuntimeMemoryPlacement,
+  getMemoryDirSource,
+  getMemoryRootDir,
+  getMemoryStateRootDir,
+  resolveMemoryPath,
+} from '../src/memory-paths.js';
 
 const original = process.env.MINI_AGENT_MEMORY_DIR;
+const originalProtectedRoot = process.env.MINI_AGENT_RUNTIME_WORKSPACE;
+const originalAllowRepoMemory = process.env.MINI_AGENT_ALLOW_REPO_MEMORY;
 
 afterEach(() => {
   if (original === undefined) delete process.env.MINI_AGENT_MEMORY_DIR;
   else process.env.MINI_AGENT_MEMORY_DIR = original;
+  if (originalProtectedRoot === undefined) delete process.env.MINI_AGENT_RUNTIME_WORKSPACE;
+  else process.env.MINI_AGENT_RUNTIME_WORKSPACE = originalProtectedRoot;
+  if (originalAllowRepoMemory === undefined) delete process.env.MINI_AGENT_ALLOW_REPO_MEMORY;
+  else process.env.MINI_AGENT_ALLOW_REPO_MEMORY = originalAllowRepoMemory;
 });
 
 describe('memory path resolution', () => {
@@ -27,5 +41,59 @@ describe('memory path resolution', () => {
     expect(resolveMemoryPath('handoffs', 'active.md')).toBe('/state/mini-agent-memory/memory/handoffs/active.md');
     expect(getMemoryDirSource()).toBe('env');
   });
-});
 
+  it('requires external memory when running from the protected runtime workspace', () => {
+    const repo = mkdtempSync(path.join(os.tmpdir(), 'mini-agent-runtime-'));
+    process.env.MINI_AGENT_RUNTIME_WORKSPACE = repo;
+    delete process.env.MINI_AGENT_MEMORY_DIR;
+
+    const decision = evaluateRuntimeMemoryPlacement(repo);
+
+    expect(decision.ok).toBe(false);
+    expect(decision.reason).toContain('MINI_AGENT_MEMORY_DIR is required');
+
+    rmSync(repo, { recursive: true, force: true });
+  });
+
+  it('rejects protected runtime memory paths inside the repo checkout', () => {
+    const repo = mkdtempSync(path.join(os.tmpdir(), 'mini-agent-runtime-'));
+    process.env.MINI_AGENT_RUNTIME_WORKSPACE = repo;
+    process.env.MINI_AGENT_MEMORY_DIR = path.join(repo, 'memory');
+
+    const decision = evaluateRuntimeMemoryPlacement(repo);
+
+    expect(decision.ok).toBe(false);
+    expect(decision.reason).toContain('outside protected repo checkout');
+
+    rmSync(repo, { recursive: true, force: true });
+  });
+
+  it('accepts an existing external memory directory for the protected runtime workspace', () => {
+    const repo = mkdtempSync(path.join(os.tmpdir(), 'mini-agent-runtime-'));
+    const memory = mkdtempSync(path.join(os.tmpdir(), 'mini-agent-memory-'));
+    process.env.MINI_AGENT_RUNTIME_WORKSPACE = repo;
+    process.env.MINI_AGENT_MEMORY_DIR = memory;
+
+    const decision = evaluateRuntimeMemoryPlacement(repo);
+
+    expect(decision.ok).toBe(true);
+    expect(decision.reason).toContain('external memory');
+
+    rmSync(repo, { recursive: true, force: true });
+    rmSync(memory, { recursive: true, force: true });
+  });
+
+  it('allows an explicit recovery override for repo-local runtime memory', () => {
+    const repo = mkdtempSync(path.join(os.tmpdir(), 'mini-agent-runtime-'));
+    process.env.MINI_AGENT_RUNTIME_WORKSPACE = repo;
+    process.env.MINI_AGENT_ALLOW_REPO_MEMORY = '1';
+    delete process.env.MINI_AGENT_MEMORY_DIR;
+
+    const decision = evaluateRuntimeMemoryPlacement(repo);
+
+    expect(decision.ok).toBe(true);
+    expect(decision.reason).toContain('MINI_AGENT_ALLOW_REPO_MEMORY=1');
+
+    rmSync(repo, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
## Summary
- Add runtime memory placement validation for protected runtime checkouts.
- Block startup when `MINI_AGENT_MEMORY_DIR` is missing, inside the repo checkout, or points to a missing directory.
- Keep isolated worktrees backward-compatible and provide `MINI_AGENT_ALLOW_REPO_MEMORY=1` as explicit recovery override.

## Verification
- `pnpm typecheck`
- `pnpm test --run tests/memory-paths.test.ts tests/workspace-isolation.test.ts`
- `pnpm build`

## Operational impact
Protected `/Users/user/Workspace/mini-agent` runtime must use external memory, e.g. `/Users/user/Workspace/mini-agent-memory/memory`. Code and deployment stay clean on `runtime/main`; high-frequency memory state no longer dirties the runtime checkout.