### PR TITLE
fix(delegation): wire phantom-prompt classifier into spawnDelegation (#141)

### DIFF
--- a/src/delegation.ts
+++ b/src/delegation.ts
@@ -46,6 +46,25 @@ import {
 import { diagnoseDelegationFailure } from './delegation-failure-diagnostics.js';
 
 // =============================================================================
+// Phantom-prompt classifier (issue #141 Layer 1)
+// =============================================================================
+
+/**
+ * Returns true if `prompt` is too thin to be a real delegation envelope.
+ * Pinned by tests/delegation-phantom-prompt.test.ts. Used as the pre-dispatch
+ * gate in `spawnDelegation` to block fail-ejkd7t-shaped repeats where a
+ * 24-char imperative like `Update src/agent.ts` slipped through and triggered
+ * 4× retries with masked forge errors.
+ */
+export function isPhantomPrompt(prompt: string): boolean {
+  if (!prompt) return true;
+  const trimmed = prompt.trim();
+  if (trimmed.length >= 80) return false;
+  if (/^##\s+Task:/m.test(trimmed)) return false;
+  return true;
+}
+
+// =============================================================================
 // Types (stable external surface)
 // =============================================================================
 
@@ -227,6 +246,26 @@ const writeLeases = new WriteLeaseManager();
 export function spawnDelegation(task: DelegationTask): string {
   const taskId = task.id ?? `del-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
   const taskType = task.type ?? 'code';
+
+  // Layer 1 phantom-prompt gate (issue #141): reject thin prompts pre-dispatch.
+  // Spec pinned by tests/delegation-phantom-prompt.test.ts.
+  if (isPhantomPrompt(task.prompt)) {
+    const preview = (task.prompt ?? '').trim().slice(0, 60);
+    slog(
+      'DELEGATION',
+      `phantom_prompt rejected ${taskId} type=${taskType} len=${(task.prompt ?? '').length} preview="${preview}"`,
+    );
+    const failed: TaskResult = {
+      id: taskId,
+      type: taskType,
+      status: 'failed',
+      startedAt: new Date().toISOString(),
+      completedAt: new Date().toISOString(),
+      output: `phantom_prompt: prompt lacks "## Task:" envelope and is shorter than 80 chars (got ${(task.prompt ?? '').length}). Rejected pre-dispatch to avoid fail-ejkd7t-shaped retries (#141).`,
+    };
+    completedTasks.set(taskId, failed);
+    return taskId;
+  }
   const worker = CAPABILITY_TO_WORKER[taskType];
   const workItem = buildWorkItemForDelegation(taskId, task, taskType);
   const timeoutMs = Math.min(

--- a/tests/delegation-phantom-prompt.test.ts
+++ b/tests/delegation-phantom-prompt.test.ts
@@ -14,18 +14,7 @@
  * lives in src/delegation.ts (or a dedicated guard module) once landed.
  */
 import { describe, expect, it } from 'vitest';
-
-// Minimal pure predicate — the classifier under test. Inlined here so the
-// test is self-contained and falsifiable even before src wiring lands. The
-// real implementation should live in src/delegation.ts adjacent to
-// spawnDelegation and be called pre-dispatch.
-function isPhantomPrompt(prompt: string): boolean {
-  if (!prompt) return true;
-  const trimmed = prompt.trim();
-  if (trimmed.length >= 80) return false;
-  if (/^##\s+Task:/m.test(trimmed)) return false;
-  return true;
-}
+import { isPhantomPrompt } from '../src/delegation.js';
 
 describe('phantom-prompt classifier (issue #141 layer 1)', () => {
   it('rejects the exact fail-ejkd7t signature', () => {


### PR DESCRIPTION
## Summary
- Wires Layer 1 of #141 — exports `isPhantomPrompt` from `src/delegation.ts` and gates `spawnDelegation` pre-dispatch.
- Predicate is identical to the one PR #143 pinned in `tests/delegation-phantom-prompt.test.ts`.
- Test now imports from src (no inline copy) — 6/6 still pass against the wired predicate.

## Why this PR (file-changing follow-up to #143)
PR #143 pinned the spec but explicitly deferred wiring per malware-guard. Without this, a 24-char `Update src/agent.ts` can still reach `/plan` dispatch and trigger the fail-ejkd7t shape (4× retries, 6 cycles of P0 stale pressure on 2026-05-06).

## What lands
- `src/delegation.ts`: new `export function isPhantomPrompt(prompt)` block (after imports). Pre-dispatch gate at top of `spawnDelegation`: if phantom, `slog('DELEGATION', 'phantom_prompt rejected ...')`, register a synchronous failed `TaskResult` in `completedTasks`, return taskId. No retry, no /plan call.
- `tests/delegation-phantom-prompt.test.ts`: replace inlined predicate with `import { isPhantomPrompt } from '../src/delegation.js'`.

## What's NOT in this PR (separate, scoped)
- Layer 2 — `forge.ts:62` catch unmask (separate PR)
- Layer 3 — upstream `<kuro:delegate>` parser hardening (separate PR)

## Verification
- [x] `pnpm vitest run tests/delegation-phantom-prompt.test.ts` — 6/6 passed locally
- [x] `pnpm build` (tsc) clean
- [ ] CI green
- [ ] Falsifier: a runtime fail-ejkd7t event with prompt < 80 chars and no `## Task:` envelope after this lands disproves the gate.

Closes Layer 1 of #141.