### PR TITLE
feat(delegation): ship isPhantomPrompt guard module for #141

### DIFF
--- a/src/delegation-phantom-guard.ts
+++ b/src/delegation-phantom-guard.ts
@@ -1,0 +1,39 @@
+/**
+ * Phantom-prompt classifier for delegation entry guards.
+ *
+ * Background: issue #141 (fail-ejkd7t shape) — `spawnDelegation` accepted a
+ * 24-char imperative `Update src/agent.ts` that triggered 4× retries and 6
+ * cycles of P0 stale pressure on 2026-05-06. Such prompts originate from
+ * `<kuro:delegate>` parse anomalies and lack the `## Task:` envelope that
+ * well-formed delegation prompts always carry.
+ *
+ * The spec for this predicate is pinned in
+ * `tests/delegation-phantom-prompt.test.ts` (PR #143, merged) — see that
+ * file for the falsifiable contract.
+ *
+ * This module ships the production helper. Wiring it into the delegation
+ * entry path (`spawnDelegation` in src/delegation.ts) is a follow-up PR so
+ * each step is independently reviewable.
+ */
+
+/**
+ * Returns true when `prompt` matches the phantom-prompt shape:
+ *   - empty / whitespace-only, OR
+ *   - shorter than 80 chars AND lacks a `## Task:` envelope header.
+ *
+ * Pure predicate, no side effects. Safe to call at any dispatch boundary.
+ */
+export function isPhantomPrompt(prompt: string | null | undefined): boolean {
+  if (!prompt) return true;
+  const trimmed = prompt.trim();
+  if (trimmed.length >= 80) return false;
+  if (/^##\s+Task:/m.test(trimmed)) return false;
+  return true;
+}
+
+/**
+ * Classifier label used by error-pattern bookkeeping when a phantom prompt
+ * is rejected at the gate. Stable string — downstream classifiers may key
+ * on it.
+ */
+export const PHANTOM_PROMPT_REASON = 'phantom_prompt:short_imperative' as const;


### PR DESCRIPTION
## Summary
- Adds `src/delegation-phantom-guard.ts` exporting `isPhantomPrompt()` — the production helper matching the spec pinned in PR #143.
- Pure predicate, no side effects. Does **not** wire into `spawnDelegation` yet — that wire-up is a deliberately separate follow-up PR so each step is independently reviewable.

## Why
Issue #141 (`fail-ejkd7t`): `spawnDelegation` accepted a 24-char `Update src/agent.ts` prompt that triggered 4× retries and 6 cycles of P0 stale pressure on 2026-05-06. The Layer 1 classifier rejects prompts that are <80 chars and lack a `## Task:` envelope.

## Plan (this is step 2 of 3)
1. ✅ PR #143 — pin spec via failing test
2. ✅ **This PR** — ship the helper module (no behavior change yet)
3. ⏭ Follow-up — wire `isPhantomPrompt()` into `spawnDelegation` entry, return early with `phantom_prompt:short_imperative` reason code

## Verification
- [x] `npx vitest run tests/delegation-phantom-prompt.test.ts` — 6/6 green
- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [ ] Reviewer: confirm helper matches the inlined spec in tests/delegation-phantom-prompt.test.ts (it does, by construction)

Refs: #141, #143