### PR TITLE
feat: add memory repo and context fabric policy

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "janitor:workspaces": "tsx scripts/workspace-janitor.ts",
     "check:runtime-workspace": "tsx scripts/check-runtime-workspace.ts",
     "setup:external-memory": "tsx scripts/setup-external-memory.ts",
+    "memory:repo:setup": "tsx scripts/setup-memory-repo.ts --init",
+    "memory:repo:check": "tsx scripts/setup-memory-repo.ts --check",
     "setup": "pnpm install && pnpm build && npm link",
     "prepare": "git config core.hooksPath .githooks 2>/dev/null || true",
     "check:pr-lifecycle": "tsx scripts/check-pr-lifecycle.ts"

--- a/scripts/setup-memory-repo.ts
+++ b/scripts/setup-memory-repo.ts
@@ -1,0 +1,175 @@
+#!/usr/bin/env tsx
+import { execFileSync } from 'node:child_process';
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import path from 'node:path';
+import {
+  buildMemoryRepoHealthReport,
+  formatMemoryRepoHealthMarkdown,
+  MEMORY_REPO_GITIGNORE,
+  MEMORY_REPO_MAINTENANCE,
+  MEMORY_REPO_README,
+  CONTEXT_FABRIC_DESIGN,
+} from '../src/memory-repo-policy.js';
+
+const repoRoot = process.cwd();
+const memoryDir = path.resolve(
+  readArg('--memory-dir')
+    ?? process.env.MINI_AGENT_MEMORY_DIR
+    ?? path.join(path.dirname(repoRoot), 'mini-agent-memory', 'memory'),
+);
+const init = process.argv.includes('--init');
+const commit = process.argv.includes('--commit');
+const check = process.argv.includes('--check');
+const force = process.argv.includes('--force');
+const remote = readArg('--remote');
+
+if (!existsSync(memoryDir)) fail(`memory dir does not exist: ${memoryDir}`);
+if (path.basename(memoryDir) !== 'memory') {
+  fail(`memory dir should point at the memory/ directory, got: ${memoryDir}`);
+}
+
+if (init && !existsSync(path.join(memoryDir, '.git'))) {
+  git(['init', '-b', 'main'], memoryDir);
+}
+
+writePolicyFile('.gitignore', MEMORY_REPO_GITIGNORE);
+writePolicyFile('README.md', MEMORY_REPO_README);
+writePolicyFile('MAINTENANCE.md', MEMORY_REPO_MAINTENANCE);
+mkdirSync(path.join(memoryDir, 'docs'), { recursive: true });
+writePolicyFile('docs/context-fabric.md', CONTEXT_FABRIC_DESIGN);
+
+if (remote) {
+  ensureRemote(remote);
+}
+
+const report = buildMemoryRepoHealthReport(memoryDir, collectFiles(memoryDir));
+mkdirSync(path.join(memoryDir, 'reports'), { recursive: true });
+writeFileSync(path.join(memoryDir, 'reports', 'memory-repo-health.md'), formatMemoryRepoHealthMarkdown(report));
+mkdirSync(path.join(memoryDir, 'state'), { recursive: true });
+writeFileSync(path.join(memoryDir, 'state', 'memory-repo-health.json'), JSON.stringify(report, null, 2) + '\n');
+
+const status = existsSync(path.join(memoryDir, '.git')) ? git(['status', '--short'], memoryDir) : '';
+if (commit) {
+  if (!existsSync(path.join(memoryDir, '.git'))) fail('use --init before --commit');
+  git(['add', '.gitignore', 'README.md', 'MAINTENANCE.md', 'docs/context-fabric.md', 'reports/memory-repo-health.md'], memoryDir);
+  const staged = git(['diff', '--cached', '--quiet'], memoryDir, { allowFailure: true });
+  if (staged.exitCode !== 0) {
+    git(['commit', '-m', 'chore: initialize memory repo policy'], memoryDir);
+  }
+}
+
+const payload = {
+  memoryDir,
+  gitRepo: existsSync(path.join(memoryDir, '.git')),
+  remote: readRemote(),
+  status: status.trim().split('\n').filter(Boolean).slice(0, 30),
+  report: {
+    totals: report.totals,
+    classes: report.classes,
+    kgCandidates: report.kgCandidates.length,
+    healthReport: path.join(memoryDir, 'reports', 'memory-repo-health.md'),
+  },
+};
+
+process.stdout.write(JSON.stringify(payload, null, 2) + '\n');
+
+if (check) {
+  const problems: string[] = [];
+  if (!existsSync(path.join(memoryDir, '.git'))) problems.push('memory dir is not a git repository; run with --init');
+  if (!existsSync(path.join(memoryDir, '.gitignore'))) problems.push('missing .gitignore policy');
+  if (!existsSync(path.join(memoryDir, 'reports', 'memory-repo-health.md'))) problems.push('missing health report');
+  if (problems.length > 0) {
+    for (const problem of problems) process.stderr.write(`[memory-repo] ${problem}\n`);
+    process.exit(1);
+  }
+}
+
+function writePolicyFile(relPath: string, content: string): void {
+  const target = path.join(memoryDir, relPath);
+  if (existsSync(target) && !force) {
+    const current = readFileSync(target, 'utf-8');
+    if (current === content) return;
+    process.stderr.write(`[memory-repo] keeping existing ${relPath}; use --force to replace\n`);
+    return;
+  }
+  writeFileSync(target, content);
+}
+
+function ensureRemote(remoteUrl: string): void {
+  if (!existsSync(path.join(memoryDir, '.git'))) fail('use --init before setting --remote');
+  const current = readRemote();
+  if (!current) {
+    git(['remote', 'add', 'origin', remoteUrl], memoryDir);
+  } else if (current !== remoteUrl) {
+    process.stderr.write(`[memory-repo] remote already set to ${current}; leaving unchanged\n`);
+  }
+}
+
+function readRemote(): string | null {
+  if (!existsSync(path.join(memoryDir, '.git'))) return null;
+  const result = git(['remote', 'get-url', 'origin'], memoryDir, { allowFailure: true });
+  return result.exitCode === 0 ? result.stdout.trim() : null;
+}
+
+function collectFiles(root: string): Array<{ relPath: string; bytes: number }> {
+  const out: Array<{ relPath: string; bytes: number }> = [];
+  walk(root, '');
+  return out;
+
+  function walk(absDir: string, relDir: string): void {
+    for (const entry of readdirSync(absDir, { withFileTypes: true })) {
+      if (entry.name === '.git' || entry.name === 'node_modules') continue;
+      const rel = relDir ? `${relDir}/${entry.name}` : entry.name;
+      const abs = path.join(absDir, entry.name);
+      if (entry.isDirectory()) {
+        walk(abs, rel);
+      } else if (entry.isFile()) {
+        out.push({ relPath: rel, bytes: statSync(abs).size });
+      }
+    }
+  }
+}
+
+function readArg(name: string): string | undefined {
+  const argv = process.argv.slice(2);
+  const index = argv.indexOf(name);
+  if (index >= 0) return argv[index + 1];
+  const prefix = `${name}=`;
+  return argv.find(arg => arg.startsWith(prefix))?.slice(prefix.length);
+}
+
+function git(args: string[], cwd: string, options?: { allowFailure?: false }): string;
+function git(args: string[], cwd: string, options: { allowFailure: true }): { exitCode: number; stdout: string; stderr: string };
+function git(args: string[], cwd: string, options: { allowFailure?: boolean } = {}): string | { exitCode: number; stdout: string; stderr: string } {
+  try {
+    const stdout = execFileSync('git', args, {
+      cwd,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 30_000,
+    });
+    return options.allowFailure ? { exitCode: 0, stdout, stderr: '' } : stdout;
+  } catch (error) {
+    if (options.allowFailure) {
+      const e = error as { status?: number; stdout?: Buffer | string; stderr?: Buffer | string };
+      return {
+        exitCode: e.status ?? 1,
+        stdout: String(e.stdout ?? ''),
+        stderr: String(e.stderr ?? ''),
+      };
+    }
+    throw error;
+  }
+}
+
+function fail(message: string): never {
+  process.stderr.write(`[memory-repo] ${message}\n`);
+  process.exit(1);
+}

--- a/src/kg-live-ingest.ts
+++ b/src/kg-live-ingest.ts
@@ -16,10 +16,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { isEnabled } from './features.js';
-
-const ROOT = process.cwd();
-const LOG_PATH = path.join(ROOT, 'memory/index/live-ingest-log.jsonl');
-const ERRORS_PATH = path.join(ROOT, 'memory/index/ingest-errors.jsonl');
+import { getMemoryRootDir } from './memory-paths.js';
 
 export type WriteSource =
   | 'memory-md'
@@ -48,6 +45,23 @@ function appendLine(file: string, obj: unknown): void {
   }
 }
 
+export function getKgLiveIngestPaths(memoryDir = getMemoryRootDir()): {
+  indexDir: string;
+  logPath: string;
+  errorsPath: string;
+  manifestPath: string;
+  pushStatePath: string;
+} {
+  const indexDir = path.join(memoryDir, 'index');
+  return {
+    indexDir,
+    logPath: path.join(indexDir, 'live-ingest-log.jsonl'),
+    errorsPath: path.join(indexDir, 'ingest-errors.jsonl'),
+    manifestPath: path.join(indexDir, 'manifest.json'),
+    pushStatePath: path.join(indexDir, 'kg-push-state.json'),
+  };
+}
+
 /**
  * Record a memory write. Caller must not await — this is fire-and-forget.
  * Returns quickly after the single fs.appendFileSync.
@@ -55,12 +69,13 @@ function appendLine(file: string, obj: unknown): void {
 export function onMemoryWrite(event: Omit<MemoryWriteEvent, 'ts'>): void {
   if (!isEnabled('kg-live-ingest')) return;
   try {
+    const { logPath } = getKgLiveIngestPaths();
     const ev: MemoryWriteEvent = {
       ts: new Date().toISOString(),
       ...event,
       preview: event.preview?.slice(0, 160),
     };
-    appendLine(LOG_PATH, ev);
+    appendLine(logPath, ev);
   } catch (err) {
     logIngestError('onMemoryWrite', event.file, err);
   }
@@ -68,7 +83,8 @@ export function onMemoryWrite(event: Omit<MemoryWriteEvent, 'ts'>): void {
 
 export function logIngestError(stage: string, file: string, err: unknown): void {
   const msg = err instanceof Error ? err.message : String(err);
-  appendLine(ERRORS_PATH, {
+  const { errorsPath } = getKgLiveIngestPaths();
+  appendLine(errorsPath, {
     ts: new Date().toISOString(),
     stage,
     file,
@@ -82,7 +98,6 @@ export function logIngestError(stage: string, file: string, err: unknown): void 
 
 const INGEST_THRESHOLD = 10; // minimum new writes before triggering rebuild
 const INGEST_COOLDOWN_MS = 4 * 60 * 60 * 1000; // 4h cooldown between triggers
-const MANIFEST_PATH = path.join(ROOT, 'memory/index/manifest.json');
 
 let lastTriggerTs = 0;
 
@@ -98,10 +113,11 @@ export function shouldTriggerKGIngest(): { should: boolean; newWrites: number; r
   }
 
   // Read manifest to get last_incremental timestamp
+  const { logPath, manifestPath } = getKgLiveIngestPaths();
   let lastIncrementalTs = 0;
   try {
-    if (fs.existsSync(MANIFEST_PATH)) {
-      const manifest = JSON.parse(fs.readFileSync(MANIFEST_PATH, 'utf8'));
+    if (fs.existsSync(manifestPath)) {
+      const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
       if (manifest.last_incremental && manifest.last_incremental !== 'never') {
         lastIncrementalTs = new Date(manifest.last_incremental).getTime();
       }
@@ -111,10 +127,10 @@ export function shouldTriggerKGIngest(): { should: boolean; newWrites: number; r
   // Count new writes since last ingest
   let newWrites = 0;
   try {
-    if (!fs.existsSync(LOG_PATH)) {
+    if (!fs.existsSync(logPath)) {
       return { should: false, newWrites: 0, reason: 'no log file' };
     }
-    for (const line of fs.readFileSync(LOG_PATH, 'utf8').split('\n')) {
+    for (const line of fs.readFileSync(logPath, 'utf8').split('\n')) {
       const s = line.trim();
       if (!s) continue;
       try {
@@ -156,11 +172,11 @@ export async function pushToKGService(): Promise<{ pushed: number; errors: numbe
   let errors = 0;
 
   try {
-    if (!fs.existsSync(LOG_PATH)) return { pushed: 0, errors: 0 };
+    const { logPath, pushStatePath } = getKgLiveIngestPaths();
+    if (!fs.existsSync(logPath)) return { pushed: 0, errors: 0 };
 
     // Read manifest to get last push timestamp
     let lastPushTs = 0;
-    const pushStatePath = path.join(ROOT, 'memory/index/kg-push-state.json');
     try {
       if (fs.existsSync(pushStatePath)) {
         const state = JSON.parse(fs.readFileSync(pushStatePath, 'utf8'));
@@ -170,7 +186,7 @@ export async function pushToKGService(): Promise<{ pushed: number; errors: numbe
 
     // Collect writes since last push
     const writes: MemoryWriteEvent[] = [];
-    for (const line of fs.readFileSync(LOG_PATH, 'utf8').split('\n')) {
+    for (const line of fs.readFileSync(logPath, 'utf8').split('\n')) {
       const s = line.trim();
       if (!s) continue;
       try {
@@ -237,8 +253,9 @@ export function getIngestStats(): {
   };
 
   try {
-    if (fs.existsSync(LOG_PATH)) {
-      for (const line of fs.readFileSync(LOG_PATH, 'utf8').split('\n')) {
+    const { logPath, errorsPath } = getKgLiveIngestPaths();
+    if (fs.existsSync(logPath)) {
+      for (const line of fs.readFileSync(logPath, 'utf8').split('\n')) {
         const s = line.trim();
         if (!s) continue;
         try {
@@ -252,8 +269,8 @@ export function getIngestStats(): {
         }
       }
     }
-    if (fs.existsSync(ERRORS_PATH)) {
-      const content = fs.readFileSync(ERRORS_PATH, 'utf8');
+    if (fs.existsSync(errorsPath)) {
+      const content = fs.readFileSync(errorsPath, 'utf8');
       stats.errors = content.split('\n').filter((l) => l.trim()).length;
     }
   } catch {

--- a/src/kg-memory.ts
+++ b/src/kg-memory.ts
@@ -6,12 +6,13 @@ import { getMemoryStateRootDir } from './memory-paths.js';
 const KG_BASE = 'http://localhost:3300';
 
 const AGENT_MEMORY_DIRS: Record<string, string> = {
-  kuro: '/Users/user/Workspace/mini-agent/memory/state',
   akari: '/Users/user/Workspace/akari/memory/state',
 };
 
-function getCachePathForAgent(agent: string): string {
-  const dir = AGENT_MEMORY_DIRS[agent] ?? getMemoryStateRootDir();
+export function getCachePathForAgent(agent: string): string {
+  const dir = agent === 'kuro'
+    ? getMemoryStateRootDir()
+    : (AGENT_MEMORY_DIRS[agent] ?? getMemoryStateRootDir());
   const cacheDir = path.join(dir);
   if (!existsSync(cacheDir)) mkdirSync(cacheDir, { recursive: true });
   return path.join(cacheDir, 'kg-memory-cache.jsonl');

--- a/src/memory-repo-policy.ts
+++ b/src/memory-repo-policy.ts
@@ -1,0 +1,332 @@
+import path from 'node:path';
+
+export type MemoryRepoClass =
+  | 'curated-knowledge'
+  | 'runtime-state'
+  | 'raw-log'
+  | 'cache'
+  | 'backup'
+  | 'local-artifact';
+
+export interface MemoryRepoPathClassification {
+  relPath: string;
+  klass: MemoryRepoClass;
+  track: boolean;
+  reason: string;
+}
+
+export interface MemoryRepoFileStat extends MemoryRepoPathClassification {
+  bytes: number;
+}
+
+export interface MemoryRepoHealthReport {
+  generatedAt: string;
+  memoryDir: string;
+  totals: {
+    files: number;
+    bytes: number;
+    trackableFiles: number;
+    ignoredFiles: number;
+  };
+  classes: Record<MemoryRepoClass, { files: number; bytes: number }>;
+  largest: MemoryRepoFileStat[];
+  kgCandidates: MemoryRepoFileStat[];
+}
+
+export const MEMORY_REPO_GITIGNORE = `# mini-agent external memory repository policy
+# Track curated knowledge, not high-frequency runtime scratch.
+
+.DS_Store
+.gitignore.local
+
+# Runtime state and append-only telemetry
+state/
+logs/
+compiled-chunks.json
+pending-memories.jsonl
+*.jsonl
+
+# Local inbox/buffers/cursors
+.conversation-threads.json
+.inner-voice-buffer.json
+.memory-access.json
+.state-snapshot.json
+.telegram-inbox.md
+.telegram-offset
+.topic-hits.json
+inbox.jsonl
+
+# Generated caches and bulky media
+media/
+context-checkpoints/
+*.cache
+*-cache.json
+*-cache.jsonl
+
+# Backups remain local unless explicitly promoted into docs/reports.
+*.bak
+*.backup-*
+*.corrupt-backup-*
+*.tmp
+
+# Package/tool artifacts should never live in memory repo history.
+node_modules/
+dist/
+`;
+
+export const MEMORY_REPO_README = `# mini-agent Memory
+
+Private, versioned memory for mini-agent.
+
+This repository is for curated knowledge, durable decisions, handoffs, topic notes, reports, and maintenance artifacts. High-frequency runtime state stays local and is ignored by git.
+
+## Policy
+
+- Track: Markdown knowledge, topic summaries, handoffs, decisions, proposals, reports, rules, and small curated JSON.
+- Ignore: runtime state, append-only telemetry, raw logs, caches, buffers, local cursors, backups, and media.
+- Promote raw observations only after refinement into a concise Markdown note or report.
+
+## Observability
+
+Run from the mini-agent code repo:
+
+\`\`\`sh
+pnpm memory:repo:setup
+pnpm memory:repo:check
+\`\`\`
+
+The check writes \`reports/memory-repo-health.md\` and prints a JSON summary.
+
+## KG Usage
+
+The memory repo is the auditable text layer. The knowledge graph is the relationship and retrieval layer. Promote concise Markdown into KG; do not push raw logs, state, caches, or backups.
+`;
+
+export const MEMORY_REPO_MAINTENANCE = `# Memory Maintenance
+
+## Goal
+
+Memory should become clearer over time: fewer stale raw traces, stronger links, better summaries, and more reusable knowledge.
+
+## Cadence
+
+- Runtime writes high-frequency state into ignored paths.
+- Maintenance cycles refine useful observations into tracked Markdown.
+- Large raw files are summarized before they are promoted.
+- Conflicts are resolved by preserving both facts first, then writing a concise synthesis.
+
+## Promotion Criteria
+
+A memory item is worth tracking when it is:
+
+- reusable for future behavior or decisions
+- connected to a topic, project, person, or system
+- falsifiable or backed by a concrete artifact
+- shorter and clearer than the raw trace it came from
+
+## Quarantine Criteria
+
+Do not track:
+
+- raw append-only logs
+- temporary buffers
+- generated caches
+- local offsets/cursors
+- stale backups
+- unreviewed large dumps
+`;
+
+export const CONTEXT_FABRIC_DESIGN = `# Context Fabric
+
+mini-agent uses three memory layers together:
+
+1. Runtime context: short-lived checkpoints, buffers, current task state, telemetry.
+2. Curated memory repo: auditable Markdown knowledge, handoffs, reports, and durable decisions.
+3. Knowledge Graph: shared semantic memory for cross-agent relationships, verification, conflicts, and retrieval.
+
+## Composition Rule
+
+Context should be assembled by need, not dumped wholesale.
+
+- Immediate task execution reads current runtime state and recent checkpoints.
+- Planning and review read curated summaries, handoffs, decisions, and relevant reports.
+- Cross-agent work reads KG neighborhoods, conflicts, verification edges, and shared claims.
+- Long-term learning promotes repeated useful patterns from runtime state into curated memory, then into KG when relationship queries would help.
+
+## Promotion Rule
+
+Context can become memory only after it gains enough epistemic support:
+
+- provenance: where it came from is recorded
+- confidence: the system knows whether it is fact, inference, preference, or hypothesis
+- review: an agent or deterministic check accepted it, or repeated evidence supports it
+- scope: the memory says whether it is private, shared, project-specific, or temporary
+
+Memory can become context only with its source and confidence preserved. Low-confidence or conflicting memories must be injected as candidates, not as facts.
+
+## Storage Rule
+
+- Raw context checkpoints stay local and ignored.
+- Digest context can be tracked when it is useful across sessions.
+- Shared context anchors belong in KG when another agent may need to discover, verify, challenge, or connect them.
+
+## KG Rule
+
+KG is the shared external semantic memory. It should store relationship-bearing knowledge, not raw append-only logs. Good KG candidates include decisions, claims, issues, PRs, agents, projects, concepts, conflicts, verifications, and context anchors.
+`;
+
+const BACKUP_PATTERNS = [
+  /\.bak(?:$|-)/,
+  /\.backup-/,
+  /\.corrupt-backup-/,
+  /backup-\d{8}/,
+];
+
+const CACHE_PATTERNS = [
+  /(^|\/)compiled-chunks\.json$/,
+  /(^|\/)context-checkpoints\//,
+  /(^|\/)pending-memories\.jsonl$/,
+  /-cache\.jsonl?$/,
+  /\.cache$/,
+];
+
+const LOCAL_ARTIFACT_PATTERNS = [
+  /(^|\/)\.DS_Store$/,
+  /(^|\/)\.conversation-threads\.json$/,
+  /(^|\/)\.inner-voice-buffer\.json$/,
+  /(^|\/)\.memory-access\.json$/,
+  /(^|\/)\.state-snapshot\.json$/,
+  /(^|\/)\.telegram-inbox\.md$/,
+  /(^|\/)\.telegram-offset$/,
+  /(^|\/)\.topic-hits\.json$/,
+  /(^|\/)media\//,
+];
+
+export function classifyMemoryRepoPath(relPath: string): MemoryRepoPathClassification {
+  const normalized = relPath.split(path.sep).join('/');
+
+  if (normalized.startsWith('state/')) {
+    return { relPath: normalized, klass: 'runtime-state', track: false, reason: 'high-frequency runtime state' };
+  }
+
+  if (BACKUP_PATTERNS.some(pattern => pattern.test(normalized))) {
+    return { relPath: normalized, klass: 'backup', track: false, reason: 'backup or stale recovery artifact' };
+  }
+
+  if (CACHE_PATTERNS.some(pattern => pattern.test(normalized))) {
+    return { relPath: normalized, klass: 'cache', track: false, reason: 'generated cache' };
+  }
+
+  if (normalized.startsWith('logs/') || normalized.endsWith('.jsonl')) {
+    return { relPath: normalized, klass: 'raw-log', track: false, reason: 'append-only raw log or telemetry' };
+  }
+
+  if (LOCAL_ARTIFACT_PATTERNS.some(pattern => pattern.test(normalized))) {
+    return { relPath: normalized, klass: 'local-artifact', track: false, reason: 'machine-local buffer, cursor, or media artifact' };
+  }
+
+  return { relPath: normalized, klass: 'curated-knowledge', track: true, reason: 'curated memory artifact' };
+}
+
+export function buildMemoryRepoHealthReport(
+  memoryDir: string,
+  files: Array<{ relPath: string; bytes: number }>,
+  generatedAt = new Date().toISOString(),
+): MemoryRepoHealthReport {
+  const classes = emptyClassCounts();
+  const stats = files.map(file => ({ ...classifyMemoryRepoPath(file.relPath), bytes: file.bytes }));
+  for (const stat of stats) {
+    classes[stat.klass].files += 1;
+    classes[stat.klass].bytes += stat.bytes;
+  }
+
+  return {
+    generatedAt,
+    memoryDir,
+    totals: {
+      files: stats.length,
+      bytes: stats.reduce((sum, stat) => sum + stat.bytes, 0),
+      trackableFiles: stats.filter(stat => stat.track).length,
+      ignoredFiles: stats.filter(stat => !stat.track).length,
+    },
+    classes,
+    largest: [...stats].sort((a, b) => b.bytes - a.bytes).slice(0, 20),
+    kgCandidates: stats.filter(isKgCandidate).sort((a, b) => b.bytes - a.bytes).slice(0, 20),
+  };
+}
+
+export function formatMemoryRepoHealthMarkdown(report: MemoryRepoHealthReport): string {
+  const lines = [
+    '# Memory Repo Health',
+    '',
+    `Generated: ${report.generatedAt}`,
+    `Memory dir: \`${report.memoryDir}\``,
+    '',
+    '## Summary',
+    '',
+    `- Files: ${report.totals.files}`,
+    `- Size: ${formatBytes(report.totals.bytes)}`,
+    `- Trackable curated files: ${report.totals.trackableFiles}`,
+    `- Ignored runtime/raw files: ${report.totals.ignoredFiles}`,
+    '',
+    '## Classes',
+    '',
+    '| Class | Files | Size |',
+    '| --- | ---: | ---: |',
+  ];
+
+  for (const [klass, entry] of Object.entries(report.classes)) {
+    lines.push(`| ${klass} | ${entry.files} | ${formatBytes(entry.bytes)} |`);
+  }
+
+  lines.push('', '## Largest Files', '', '| Path | Class | Size | Tracked |', '| --- | --- | ---: | --- |');
+  for (const file of report.largest) {
+    lines.push(`| \`${file.relPath}\` | ${file.klass} | ${formatBytes(file.bytes)} | ${file.track ? 'yes' : 'no'} |`);
+  }
+
+  lines.push(
+    '',
+    '## KG Candidates',
+    '',
+    'These curated Markdown files are good candidates for KG sync or relationship extraction.',
+    '',
+    '| Path | Size |',
+    '| --- | ---: |',
+  );
+  for (const file of report.kgCandidates) {
+    lines.push(`| \`${file.relPath}\` | ${formatBytes(file.bytes)} |`);
+  }
+
+  lines.push('');
+  return `${lines.join('\n')}\n`;
+}
+
+export function isKgCandidate(file: MemoryRepoFileStat): boolean {
+  if (!file.track) return false;
+  if (!file.relPath.endsWith('.md')) return false;
+  if (file.relPath === 'README.md' || file.relPath === 'MAINTENANCE.md') return false;
+  return /^(MEMORY|SOUL|HEARTBEAT|NEXT)\.md$/.test(file.relPath)
+    || /^(topics|handoffs|proposals|reports|research|reviews|learning|discussions)\//.test(file.relPath);
+}
+
+function emptyClassCounts(): Record<MemoryRepoClass, { files: number; bytes: number }> {
+  return {
+    'curated-knowledge': { files: 0, bytes: 0 },
+    'runtime-state': { files: 0, bytes: 0 },
+    'raw-log': { files: 0, bytes: 0 },
+  cache: { files: 0, bytes: 0 },
+    backup: { files: 0, bytes: 0 },
+    'local-artifact': { files: 0, bytes: 0 },
+  };
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  const units = ['KB', 'MB', 'GB'];
+  let value = bytes / 1024;
+  for (const unit of units) {
+    if (value < 1024) return `${value.toFixed(value >= 10 ? 1 : 2)} ${unit}`;
+    value /= 1024;
+  }
+  return `${value.toFixed(1)} TB`;
+}

--- a/tests/kg-paths.test.ts
+++ b/tests/kg-paths.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { getKgLiveIngestPaths } from '../src/kg-live-ingest.js';
+import { getCachePathForAgent } from '../src/kg-memory.js';
+
+const originalMemoryDir = process.env.MINI_AGENT_MEMORY_DIR;
+
+afterEach(() => {
+  if (originalMemoryDir === undefined) delete process.env.MINI_AGENT_MEMORY_DIR;
+  else process.env.MINI_AGENT_MEMORY_DIR = originalMemoryDir;
+});
+
+describe('KG path placement', () => {
+  it('places live ingest logs under the configured external memory index', () => {
+    const paths = getKgLiveIngestPaths('/external/memory');
+
+    expect(paths.logPath).toBe(path.join('/external/memory', 'index', 'live-ingest-log.jsonl'));
+    expect(paths.errorsPath).toBe(path.join('/external/memory', 'index', 'ingest-errors.jsonl'));
+    expect(paths.pushStatePath).toBe(path.join('/external/memory', 'index', 'kg-push-state.json'));
+  });
+
+  it('uses MINI_AGENT_MEMORY_DIR for kuro KG cache instead of the runtime checkout', () => {
+    const memoryDir = mkdtempSync(path.join(os.tmpdir(), 'mini-agent-memory-'));
+    process.env.MINI_AGENT_MEMORY_DIR = memoryDir;
+
+    expect(getCachePathForAgent('kuro')).toBe(path.join(memoryDir, 'state', 'kg-memory-cache.jsonl'));
+
+    rmSync(memoryDir, { recursive: true, force: true });
+  });
+});

--- a/tests/memory-repo-policy.test.ts
+++ b/tests/memory-repo-policy.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildMemoryRepoHealthReport,
+  classifyMemoryRepoPath,
+  CONTEXT_FABRIC_DESIGN,
+  formatMemoryRepoHealthMarkdown,
+} from '../src/memory-repo-policy.js';
+
+describe('memory repo policy', () => {
+  it('keeps runtime state, context checkpoints, raw logs, and caches out of tracked memory', () => {
+    expect(classifyMemoryRepoPath('state/activity-journal.jsonl')).toMatchObject({
+      klass: 'runtime-state',
+      track: false,
+    });
+    expect(classifyMemoryRepoPath('context-checkpoints/2026-05-06.jsonl')).toMatchObject({
+      klass: 'cache',
+      track: false,
+    });
+    expect(classifyMemoryRepoPath('logs/api.jsonl')).toMatchObject({
+      klass: 'raw-log',
+      track: false,
+    });
+    expect(classifyMemoryRepoPath('MEMORY.md')).toMatchObject({
+      klass: 'curated-knowledge',
+      track: true,
+    });
+  });
+
+  it('surfaces curated Markdown as KG candidates for shared semantic memory', () => {
+    const report = buildMemoryRepoHealthReport('/memory', [
+      { relPath: 'MEMORY.md', bytes: 1200 },
+      { relPath: 'topics/kg.md', bytes: 2400 },
+      { relPath: 'context-checkpoints/2026-05-06.jsonl', bytes: 9000 },
+      { relPath: 'state/activity-journal.jsonl', bytes: 5000 },
+    ], '2026-05-06T00:00:00.000Z');
+
+    expect(report.totals.trackableFiles).toBe(2);
+    expect(report.totals.ignoredFiles).toBe(2);
+    expect(report.kgCandidates.map(file => file.relPath)).toEqual(['topics/kg.md', 'MEMORY.md']);
+
+    const markdown = formatMemoryRepoHealthMarkdown(report);
+    expect(markdown).toContain('## KG Candidates');
+    expect(markdown).toContain('topics/kg.md');
+  });
+
+  it('documents that context promotion to memory requires provenance and confidence', () => {
+    expect(CONTEXT_FABRIC_DESIGN).toContain('Context can become memory only after');
+    expect(CONTEXT_FABRIC_DESIGN).toContain('provenance');
+    expect(CONTEXT_FABRIC_DESIGN).toContain('confidence');
+    expect(CONTEXT_FABRIC_DESIGN).toContain('Low-confidence or conflicting memories');
+  });
+});


### PR DESCRIPTION
## Summary
- Add memory repo setup/check tooling that initializes external memory as a private-repo-ready, policy-governed store.
- Add Memory Repo Health report with classes for curated knowledge, runtime state, raw logs, caches, backups, local artifacts, and KG candidate surfacing.
- Document Context Fabric: runtime context, curated memory repo, and KG shared semantic memory, including provenance/confidence rules for context↔memory promotion.
- Move KG live ingest paths and Kuro KG cache to `MINI_AGENT_MEMORY_DIR`, preventing KG/context state from writing back into the protected runtime checkout.

## Verification
- `pnpm typecheck`
- `pnpm test --run tests/memory-repo-policy.test.ts tests/kg-paths.test.ts tests/memory-paths.test.ts`
- `pnpm build`
- `pnpm memory:repo:check`

## Operational notes
Generated external memory artifacts at `/Users/user/Workspace/mini-agent-memory/memory`:
- `.gitignore`
- `README.md`
- `MAINTENANCE.md`
- `docs/context-fabric.md`
- `reports/memory-repo-health.md`

The memory repo has no remote configured yet. It is ready to connect to a private GitHub repository.