### PR TITLE
fix: keep deploy checkout on runtime branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,6 +56,7 @@ jobs:
           if [ -d memory ]; then
             cp -a memory/ "$MEMORY_BACKUP/"
           fi
+          git checkout -B runtime/main origin/main
           git reset --hard origin/main
           # Restore memory files — prefer runtime version over repo version
           # (runtime has latest myelin rules, state files, etc.)
@@ -78,6 +79,8 @@ jobs:
           fi
 
           MINI_AGENT_SKIP_DEPLOY_PULL=1 ./scripts/deploy.sh
+
+          git checkout -B runtime/main origin/main
 
       - name: Notify Success
         if: success()


### PR DESCRIPTION
## Summary
- Update deploy workflow to explicitly checkout/reset `runtime/main` from `origin/main` before deploy work.
- Re-assert `runtime/main` after `scripts/deploy.sh` completes so the protected runtime checkout is not left on `main`.

## Verification
- `git diff --check`
- Runtime health after previous deploy correctly reported wrong-branch correction; manual `git switch runtime/main` cleared it.

## Operational impact
Future deployments should leave `/Users/user/Workspace/mini-agent` on `runtime/main`, keeping the protected checkout aligned with workspace isolation policy.