### PR TITLE
fix(forge): unmask forgeCreate error details (#141 layer 2)

### DIFF
--- a/src/forge.ts
+++ b/src/forge.ts
@@ -59,7 +59,11 @@ export function forgeCreate(taskId: string, workdir: string, taskType?: Delegati
     const output = forgeExec(`create "${taskId}" --caller-pid ${process.pid}${noInstall}`, workdir);
     return output.split('\n').pop()!.trim();
   } catch (e) {
-    slog('FORGE', `forgeCreate failed for ${taskId}: ${(e as Error).message?.split('\n')[0] ?? e}`);
+    const err = e as NodeJS.ErrnoException & { stderr?: Buffer | string; stdout?: Buffer | string; status?: number | null; signal?: string | null };
+    const errMsg = (err.message ?? String(e)).split('\n')[0];
+    const errType = err.constructor?.name ?? typeof e;
+    const stderrStr = typeof err.stderr === 'string' ? err.stderr : (err.stderr ? err.stderr.toString('utf-8') : '');
+    slog('FORGE', `forgeCreate failed: ${JSON.stringify({ taskId, errMsg, errType, stderr: stderrStr.slice(0, 500), status: err.status ?? null, signal: err.signal ?? null })}`);
     return null;
   }
 }


### PR DESCRIPTION
## Summary
- Replace `forge.ts:62` single-line error swallow with structured `JSON.stringify({ taskId, errMsg, errType, stderr, status, signal })`
- Closes layer 2 of #141 (layer 1 — phantom-prompt classifier — shipped in #145)
- No behavior change on success path; on exception path the underlying `forge-lite.sh` stderr/exit code now reaches the failure record

## Why
`fail-ejkd7t` (signature `code:update src/agent.ts:blocked by workspace isolation policy: forge worktree allocation failed`) recurred 4× on 2026-05-06 because the catch block in `forgeCreate` discarded the real cause (slot exhaustion vs git lock vs permission) and only the wrapper "forge worktree allocation failed" string survived.

Issue #141 explicitly proposed this patch:
> replace `forge.ts:62` swallow with `slog('FORGE', JSON.stringify({ taskId, errMsg, errType, stderr }))`

This PR implements that, plus exit `status` and `signal` for `execSync` errors (where the most useful info lives).

## Verification
- [x] `pnpm exec tsc --noEmit` clean
- [ ] After merge: trigger any code-typed delegation that hits forge slot exhaustion → check `server.log` for `FORGE forgeCreate failed: {"taskId":...,"stderr":"...","status":...}` line
- [ ] Confirm next `fail-ejkd7t`-shaped recurrence carries actionable stderr in failure record

🤖 Generated with [Claude Code](https://claude.com/claude-code)