### PR TITLE
feat: promote curated memory into KG

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "setup:external-memory": "tsx scripts/setup-external-memory.ts",
     "memory:repo:setup": "tsx scripts/setup-memory-repo.ts --init",
     "memory:repo:check": "tsx scripts/setup-memory-repo.ts --check",
+    "memory:kg:promote": "tsx scripts/kg-promote-memory.ts",
     "setup": "pnpm install && pnpm build && npm link",
     "prepare": "git config core.hooksPath .githooks 2>/dev/null || true",
     "check:pr-lifecycle": "tsx scripts/check-pr-lifecycle.ts"

--- a/scripts/check-pr-lifecycle.ts
+++ b/scripts/check-pr-lifecycle.ts
@@ -10,15 +10,18 @@ const baseBranch = process.env.MINI_AGENT_BASE_BRANCH ?? 'main';
 const allowContamination = process.env.MINI_AGENT_ALLOW_SCOPE_CONTAMINATION === '1';
 const json = process.argv.includes('--json');
 
+git(['fetch', '--quiet', 'origin', baseBranch]);
 const branch = git(['rev-parse', '--abbrev-ref', 'HEAD']).trim() || null;
 const dirty = git(['status', '--porcelain']).trim().length > 0;
 const commitsAhead = parseGitLogRecords(git(['log', '--format=%H%x1f%s%x1f%b%x1e', `origin/${baseBranch}..HEAD`]));
+const behindBase = countBehindBase(baseBranch);
 const pullRequest = readCurrentPr();
 const analysis = analyzeBranchLifecycle({
   branch,
   baseBranch,
   dirty,
   commitsAhead,
+  behindBase,
   pullRequest,
 });
 
@@ -64,9 +67,15 @@ function git(args: string[]): string {
   }
 }
 
+function countBehindBase(base: string): number {
+  const raw = git(['rev-list', '--left-right', '--count', `HEAD...origin/${base}`]).trim();
+  const parts = raw.split(/\s+/);
+  return Number(parts[1] ?? 0) || 0;
+}
+
 function formatHuman(analysis: ReturnType<typeof analyzeBranchLifecycle>): string {
   const lines = [
-    `[pr-lifecycle] status=${analysis.status} branch=${analysis.branch ?? 'unknown'} base=${analysis.baseBranch} ahead=${analysis.ahead} dirty=${analysis.dirty}`,
+    `[pr-lifecycle] status=${analysis.status} branch=${analysis.branch ?? 'unknown'} base=${analysis.baseBranch} ahead=${analysis.ahead} behind=${analysis.behindBase} dirty=${analysis.dirty}`,
   ];
   if (analysis.pullRequest) {
     lines.push(`[pr-lifecycle] pr=#${analysis.pullRequest.number} ${analysis.pullRequest.title}`);

--- a/scripts/kg-promote-memory.ts
+++ b/scripts/kg-promote-memory.ts
@@ -1,0 +1,170 @@
+#!/usr/bin/env tsx
+import {
+  existsSync,
+  readdirSync,
+  statSync,
+} from 'node:fs';
+import path from 'node:path';
+import {
+  appendKGPromotionRecord,
+  buildKGPromotionCandidates,
+  candidateToKGTriple,
+  getKGPromotionLedgerPath,
+  type KGPromotionRecord,
+  type KGPromotionTriple,
+} from '../src/kg-promotion.js';
+import { buildMemoryRepoHealthReport } from '../src/memory-repo-policy.js';
+
+const repoRoot = process.cwd();
+const memoryDir = path.resolve(
+  readArg('--memory-dir')
+    ?? process.env.MINI_AGENT_MEMORY_DIR
+    ?? path.join(path.dirname(repoRoot), 'mini-agent-memory', 'memory'),
+);
+const kgUrl = String(readArg('--kg-url') ?? process.env.KG_SERVICE_URL ?? 'http://localhost:3300').replace(/\/$/, '');
+const namespace = String(readArg('--namespace') ?? 'kuro');
+const sourceAgent = String(readArg('--source-agent') ?? 'kuro');
+const limit = Math.max(1, Math.min(Number(readArg('--limit') ?? 20) || 20, 100));
+const dryRun = process.argv.includes('--dry-run') || process.argv.includes('--dry');
+const recordDryRun = process.argv.includes('--record-dry-run');
+
+if (!existsSync(memoryDir)) fail(`memory dir does not exist: ${memoryDir}`);
+
+const report = buildMemoryRepoHealthReport(memoryDir, collectFiles(memoryDir));
+const candidates = buildKGPromotionCandidates(memoryDir, report.kgCandidates, limit);
+const triples = candidates.map(candidate => candidateToKGTriple(candidate, { namespace, sourceAgent }));
+
+if (dryRun) {
+  if (recordDryRun) {
+    for (const candidate of candidates) {
+      appendKGPromotionRecord(memoryDir, recordFor('dry-run', candidate, kgUrl, namespace, sourceAgent));
+    }
+  }
+  writeSummary({ dryRun: true, candidates: candidates.length, promoted: 0, failed: 0, triples });
+  process.exit(0);
+}
+
+let promoted = 0;
+let failed = 0;
+
+if (triples.length > 0) {
+  try {
+    const result = await pushTriples(kgUrl, triples);
+    promoted = result.created;
+    failed = result.failed;
+    for (let i = 0; i < candidates.length; i++) {
+      appendKGPromotionRecord(
+        memoryDir,
+        recordFor(i < promoted ? 'promoted' : 'failed', candidates[i], kgUrl, namespace, sourceAgent, i < promoted ? undefined : 'KG service did not accept this triple'),
+      );
+    }
+  } catch (err) {
+    failed = candidates.length;
+    const message = err instanceof Error ? err.message : String(err);
+    for (const candidate of candidates) {
+      appendKGPromotionRecord(memoryDir, recordFor('failed', candidate, kgUrl, namespace, sourceAgent, message));
+    }
+  }
+}
+
+writeSummary({ dryRun: false, candidates: candidates.length, promoted, failed, triples });
+
+function recordFor(
+  status: KGPromotionRecord['status'],
+  candidate: (typeof candidates)[number],
+  targetKgUrl: string,
+  targetNamespace: string,
+  targetSourceAgent: string,
+  error?: string,
+): KGPromotionRecord {
+  return {
+    ts: new Date().toISOString(),
+    status,
+    relPath: candidate.relPath,
+    title: candidate.title,
+    sha1: candidate.sha1,
+    confidence: candidate.confidence,
+    scope: candidate.scope,
+    kgUrl: targetKgUrl,
+    namespace: targetNamespace,
+    sourceAgent: targetSourceAgent,
+    tripleSubject: candidate.title,
+    ...(error ? { error: error.slice(0, 500) } : {}),
+  };
+}
+
+async function pushTriples(targetKgUrl: string, batch: KGPromotionTriple[]): Promise<{ created: number; failed: number }> {
+  const resp = await fetch(`${targetKgUrl}/api/write/triples`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ triples: batch }),
+    signal: AbortSignal.timeout(10_000),
+  });
+  if (!resp.ok) {
+    const text = await resp.text();
+    throw new Error(`KG service returned ${resp.status}: ${text.slice(0, 300)}`);
+  }
+  const data = await resp.json() as { summary?: { created?: number; failed?: number } };
+  return {
+    created: data.summary?.created ?? batch.length,
+    failed: data.summary?.failed ?? 0,
+  };
+}
+
+function writeSummary(data: {
+  dryRun: boolean;
+  candidates: number;
+  promoted: number;
+  failed: number;
+  triples: KGPromotionTriple[];
+}): void {
+  process.stdout.write(JSON.stringify({
+    memoryDir,
+    ledgerPath: getKGPromotionLedgerPath(memoryDir),
+    kgUrl,
+    namespace,
+    sourceAgent,
+    dryRun: data.dryRun,
+    candidates: data.candidates,
+    promoted: data.promoted,
+    failed: data.failed,
+    sample: data.triples.slice(0, 5).map(triple => ({
+      subject: triple.subject,
+      source_file: triple.properties.source_file,
+      confidence: triple.confidence,
+      scope: triple.properties.scope,
+    })),
+  }, null, 2) + '\n');
+}
+
+function collectFiles(root: string): Array<{ relPath: string; bytes: number }> {
+  const out: Array<{ relPath: string; bytes: number }> = [];
+  walk(root, '');
+  return out;
+
+  function walk(absDir: string, relDir: string): void {
+    for (const entry of readdirSync(absDir, { withFileTypes: true })) {
+      if (entry.name === '.git' || entry.name === 'node_modules') continue;
+      const rel = relDir ? `${relDir}/${entry.name}` : entry.name;
+      const abs = path.join(absDir, entry.name);
+      if (entry.isDirectory()) {
+        walk(abs, rel);
+      } else if (entry.isFile()) {
+        out.push({ relPath: rel, bytes: statSync(abs).size });
+      }
+    }
+  }
+}
+
+function readArg(name: string): string | undefined {
+  const argv = process.argv.slice(2);
+  const index = argv.indexOf(name);
+  if (index >= 0) return argv[index + 1];
+  const prefix = `${name}=`;
+  return argv.find(arg => arg.startsWith(prefix))?.slice(prefix.length);
+}
+
+function fail(message: string): never {
+  process.stderr.write(`[kg-promote-memory] ${message}\n`);
+  process.exit(1);
+}

--- a/src/api.ts
+++ b/src/api.ts
@@ -91,6 +91,7 @@ import { createTelegramPoller, getTelegramPoller, getNotificationStats } from '.
 import { searchEntities as kgSearchEntities, getEntityCard as kgGetEntityCard, getKgStats } from './kg-entity-search.js';
 import { getIngestStats as kgGetIngestStats } from './kg-live-ingest.js';
 import { query as kgQuery, formatReport as kgFormatReport } from './kg-query.js';
+import { getKGPromotionLedgerPath, readKGPromotionRecords, summarizeKGPromotions } from './kg-promotion.js';
 import {
   getProcessStatus, getLogSummary, getNetworkStatus, getConfigSnapshot,
   getActivitySummary,
@@ -3090,6 +3091,21 @@ export function createApi(port = 3001): express.Express {
   app.get('/api/kg/ingest-stats', (_req: Request, res: Response) => {
     try {
       res.json(kgGetIngestStats());
+    } catch (err) {
+      res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  app.get('/api/kg/promotions', (req: Request, res: Response) => {
+    try {
+      const limit = Math.min(Number(req.query.limit ?? 50) || 50, 200);
+      const memoryDir = getMemoryRootDir();
+      const records = readKGPromotionRecords(memoryDir, limit);
+      res.json({
+        ledgerPath: getKGPromotionLedgerPath(memoryDir),
+        summary: summarizeKGPromotions(records),
+        records,
+      });
     } catch (err) {
       res.status(500).json({ error: (err as Error).message });
     }

--- a/src/kg-promotion.ts
+++ b/src/kg-promotion.ts
@@ -1,0 +1,200 @@
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { getMemoryRootDir } from './memory-paths.js';
+import type { MemoryRepoFileStat } from './memory-repo-policy.js';
+
+export type KGPromotionStatus = 'candidate' | 'dry-run' | 'promoted' | 'failed' | 'skipped';
+
+export interface KGPromotionCandidate {
+  relPath: string;
+  absPath: string;
+  bytes: number;
+  title: string;
+  sha1: string;
+  charCount: number;
+  confidence: number;
+  scope: 'private' | 'shared-candidate';
+  reason: string;
+  description: string;
+}
+
+export interface KGPromotionTriple {
+  subject: string;
+  subject_type: string;
+  predicate: string;
+  object: string;
+  object_type: string;
+  confidence: number;
+  source_agent: string;
+  description: string;
+  namespace: string;
+  properties: Record<string, unknown>;
+}
+
+export interface KGPromotionRecord {
+  ts: string;
+  status: KGPromotionStatus;
+  relPath: string;
+  title: string;
+  sha1: string;
+  confidence: number;
+  scope: KGPromotionCandidate['scope'];
+  kgUrl?: string;
+  namespace?: string;
+  sourceAgent?: string;
+  tripleSubject?: string;
+  error?: string;
+}
+
+export interface KGPromotionSummary {
+  total: number;
+  candidates: number;
+  dryRun: number;
+  promoted: number;
+  failed: number;
+  skipped: number;
+  latestAt: string | null;
+}
+
+const DESC_CAP = 2000;
+
+export function getKGPromotionLedgerPath(memoryDir = getMemoryRootDir()): string {
+  return path.join(memoryDir, 'index', 'kg-promotions.jsonl');
+}
+
+export function buildKGPromotionCandidates(
+  memoryDir: string,
+  files: MemoryRepoFileStat[],
+  limit = 20,
+): KGPromotionCandidate[] {
+  const candidates: KGPromotionCandidate[] = [];
+  for (const file of files.slice(0, Math.max(0, limit))) {
+    const absPath = path.join(memoryDir, file.relPath);
+    let content: string;
+    try {
+      content = fs.readFileSync(absPath, 'utf-8');
+    } catch {
+      continue;
+    }
+    const trimmed = content.trim();
+    if (trimmed.length < 80) continue;
+    candidates.push({
+      relPath: file.relPath,
+      absPath,
+      bytes: file.bytes,
+      title: extractTitle(trimmed, file.relPath),
+      sha1: hashText(trimmed),
+      charCount: trimmed.length,
+      confidence: confidenceForPath(file.relPath),
+      scope: scopeForPath(file.relPath),
+      reason: reasonForPath(file.relPath),
+      description: trimmed.slice(0, DESC_CAP),
+    });
+  }
+  return candidates;
+}
+
+export function candidateToKGTriple(
+  candidate: KGPromotionCandidate,
+  opts: { namespace?: string; sourceAgent?: string } = {},
+): KGPromotionTriple {
+  const namespace = opts.namespace ?? 'kuro';
+  const sourceAgent = opts.sourceAgent ?? 'kuro';
+  return {
+    subject: candidate.title,
+    subject_type: 'concept',
+    predicate: 'context_anchor_for',
+    object: 'mini-agent-memory',
+    object_type: 'project',
+    confidence: candidate.confidence,
+    source_agent: sourceAgent,
+    description: candidate.description,
+    namespace,
+    properties: {
+      source_file: candidate.relPath,
+      source_sha1: candidate.sha1,
+      provenance: 'memory-repo',
+      epistemic_status: 'candidate',
+      scope: candidate.scope,
+      promotion_reason: candidate.reason,
+      char_count: candidate.charCount,
+      bytes: candidate.bytes,
+      memory_type: 'curated-markdown',
+    },
+  };
+}
+
+export function appendKGPromotionRecord(memoryDir: string, record: KGPromotionRecord): void {
+  const ledgerPath = getKGPromotionLedgerPath(memoryDir);
+  fs.mkdirSync(path.dirname(ledgerPath), { recursive: true });
+  fs.appendFileSync(ledgerPath, `${JSON.stringify(record)}\n`, 'utf-8');
+}
+
+export function readKGPromotionRecords(memoryDir = getMemoryRootDir(), limit = 50): KGPromotionRecord[] {
+  const ledgerPath = getKGPromotionLedgerPath(memoryDir);
+  if (!fs.existsSync(ledgerPath)) return [];
+  const lines = fs.readFileSync(ledgerPath, 'utf-8').trim().split('\n').filter(Boolean);
+  const records: KGPromotionRecord[] = [];
+  for (const line of lines.slice(Math.max(0, lines.length - limit))) {
+    try {
+      records.push(JSON.parse(line) as KGPromotionRecord);
+    } catch {
+      // Skip malformed manual edits.
+    }
+  }
+  return records.reverse();
+}
+
+export function summarizeKGPromotions(records: KGPromotionRecord[]): KGPromotionSummary {
+  const summary: KGPromotionSummary = {
+    total: records.length,
+    candidates: 0,
+    dryRun: 0,
+    promoted: 0,
+    failed: 0,
+    skipped: 0,
+    latestAt: records[0]?.ts ?? null,
+  };
+  for (const record of records) {
+    if (record.status === 'candidate') summary.candidates++;
+    else if (record.status === 'dry-run') summary.dryRun++;
+    else if (record.status === 'promoted') summary.promoted++;
+    else if (record.status === 'failed') summary.failed++;
+    else if (record.status === 'skipped') summary.skipped++;
+  }
+  return summary;
+}
+
+function extractTitle(content: string, relPath: string): string {
+  const firstHeading = content.split('\n').find(line => /^#\s+/.test(line.trim()));
+  if (firstHeading) return firstHeading.replace(/^#+\s*/, '').trim().slice(0, 160);
+  return relPath.replace(/\.md$/, '').split('/').join(':').slice(0, 160);
+}
+
+function hashText(text: string): string {
+  return createHash('sha1').update(text).digest('hex');
+}
+
+function confidenceForPath(relPath: string): number {
+  if (/^(MEMORY|SOUL|HEARTBEAT|NEXT)\.md$/.test(relPath)) return 0.85;
+  if (/^(reports|reviews|handoffs)\//.test(relPath)) return 0.8;
+  if (/^(proposals|research|learning|discussions)\//.test(relPath)) return 0.75;
+  return 0.72;
+}
+
+function scopeForPath(relPath: string): KGPromotionCandidate['scope'] {
+  if (/^(handoffs|reports|reviews|proposals|research|learning|discussions)\//.test(relPath)) {
+    return 'shared-candidate';
+  }
+  return 'private';
+}
+
+function reasonForPath(relPath: string): string {
+  if (/^(MEMORY|SOUL|HEARTBEAT|NEXT)\.md$/.test(relPath)) return 'core durable memory file';
+  if (relPath.startsWith('topics/')) return 'topic memory with reusable behavior or concept links';
+  if (relPath.startsWith('handoffs/')) return 'cross-agent handoff context';
+  if (relPath.startsWith('reports/')) return 'auditable maintenance or verification report';
+  if (relPath.startsWith('proposals/')) return 'decision candidate with design context';
+  return 'curated markdown candidate';
+}

--- a/src/memory-repo-policy.ts
+++ b/src/memory-repo-policy.ts
@@ -305,6 +305,7 @@ export function isKgCandidate(file: MemoryRepoFileStat): boolean {
   if (!file.track) return false;
   if (!file.relPath.endsWith('.md')) return false;
   if (file.relPath === 'README.md' || file.relPath === 'MAINTENANCE.md') return false;
+  if (/(^|\/)\.?archive\//.test(file.relPath) || /-archived-\d{8}\.md$/.test(file.relPath)) return false;
   return /^(MEMORY|SOUL|HEARTBEAT|NEXT)\.md$/.test(file.relPath)
     || /^(topics|handoffs|proposals|reports|research|reviews|learning|discussions)\//.test(file.relPath);
 }

--- a/src/pr-lifecycle-governance.ts
+++ b/src/pr-lifecycle-governance.ts
@@ -71,6 +71,7 @@ export interface BranchLifecycleInput {
   baseBranch: string;
   dirty: boolean;
   commitsAhead: CommitSummary[];
+  behindBase?: number;
   pullRequest?: PullRequestSummary | null;
 }
 
@@ -78,6 +79,7 @@ export type BranchLifecycleStatus =
   | 'base'
   | 'feature-no-pr'
   | 'pending-review'
+  | 'stale-base'
   | 'scope-contaminated';
 
 export interface BranchLifecycleAnalysis {
@@ -86,6 +88,7 @@ export interface BranchLifecycleAnalysis {
   baseBranch: string;
   dirty: boolean;
   ahead: number;
+  behindBase: number;
   pullRequest: PullRequestSummary | null;
   issueRefs: number[];
   allowedIssueRefs: number[];
@@ -102,6 +105,7 @@ const RESOLUTION_REF_RE = /(?:^|\n)\s*(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?|i
 export function analyzeBranchLifecycle(input: BranchLifecycleInput): BranchLifecycleAnalysis {
   const pr = input.pullRequest ?? null;
   const onBase = !input.branch || input.branch === input.baseBranch;
+  const behindBase = Math.max(0, input.behindBase ?? 0);
   const issueRefs = uniqueNumbers(input.commitsAhead.flatMap(c => extractIssueRefs(`${c.subject}\n${c.body ?? ''}`)));
   const allowedIssueRefs = pr ? extractAllowedIssueRefs(pr) : [];
   const foreignIssueRefs = pr
@@ -123,6 +127,11 @@ export function analyzeBranchLifecycle(input: BranchLifecycleInput): BranchLifec
   if (onBase) {
     status = 'base';
     if (input.dirty) guidance.push('Base branch is dirty; finish or stash local changes before starting new work.');
+  } else if (behindBase > 0) {
+    status = 'stale-base';
+    shouldBlockPush = true;
+    guidance.push(`Branch ${input.branch} is ${behindBase} commit(s) behind origin/${input.baseBranch}; rebase before push/PR completion.`);
+    guidance.push(`Run: git fetch origin && git rebase origin/${input.baseBranch}, then rerun verification.`);
   } else if (!pr) {
     status = 'feature-no-pr';
     guidance.push(`Branch ${input.branch} has no detected PR. Open a PR before treating it as complete.`);
@@ -153,6 +162,7 @@ export function analyzeBranchLifecycle(input: BranchLifecycleInput): BranchLifec
     baseBranch: input.baseBranch,
     dirty: input.dirty,
     ahead: input.commitsAhead.length,
+    behindBase,
     pullRequest: pr,
     issueRefs,
     allowedIssueRefs,

--- a/tests/kg-promotion.test.ts
+++ b/tests/kg-promotion.test.ts
@@ -1,0 +1,96 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  appendKGPromotionRecord,
+  buildKGPromotionCandidates,
+  candidateToKGTriple,
+  readKGPromotionRecords,
+  summarizeKGPromotions,
+} from '../src/kg-promotion.js';
+import { buildMemoryRepoHealthReport } from '../src/memory-repo-policy.js';
+
+describe('KG memory promotion', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(path.join(os.tmpdir(), 'mini-agent-kg-promotion-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('promotes only curated markdown candidates from memory repo policy', () => {
+    writeFileSync(path.join(tmpDir, 'MEMORY.md'), '# Durable Memory\n\nThis memory contains reusable context for future behavior and decisions.\n');
+    writeFileSync(path.join(tmpDir, 'live-ingest-log.jsonl'), '{"raw":true}\n');
+    const report = buildMemoryRepoHealthReport(tmpDir, [
+      { relPath: 'MEMORY.md', bytes: 86 },
+      { relPath: 'live-ingest-log.jsonl', bytes: 13 },
+    ], '2026-05-06T00:00:00.000Z');
+
+    const candidates = buildKGPromotionCandidates(tmpDir, report.kgCandidates, 10);
+
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]).toMatchObject({
+      relPath: 'MEMORY.md',
+      title: 'Durable Memory',
+      scope: 'private',
+      confidence: 0.85,
+    });
+  });
+
+  it('preserves provenance, confidence, and epistemic status in triples', () => {
+    writeFileSync(path.join(tmpDir, 'topic.md'), '# KG Fabric\n\nThis note explains how memory becomes reliable context through provenance.\n');
+    const candidate = buildKGPromotionCandidates(tmpDir, [{
+      relPath: 'topic.md',
+      bytes: 86,
+      klass: 'curated-knowledge',
+      track: true,
+      reason: 'test',
+    }], 1)[0];
+
+    const triple = candidateToKGTriple(candidate, { namespace: 'shared', sourceAgent: 'kuro' });
+
+    expect(triple.predicate).toBe('context_anchor_for');
+    expect(triple.namespace).toBe('shared');
+    expect(triple.properties).toMatchObject({
+      source_file: 'topic.md',
+      provenance: 'memory-repo',
+      epistemic_status: 'candidate',
+      memory_type: 'curated-markdown',
+    });
+    expect(typeof triple.properties.source_sha1).toBe('string');
+  });
+
+  it('writes an observable promotion ledger summary', () => {
+    appendKGPromotionRecord(tmpDir, {
+      ts: '2026-05-06T01:00:00.000Z',
+      status: 'promoted',
+      relPath: 'MEMORY.md',
+      title: 'Memory',
+      sha1: 'abc',
+      confidence: 0.85,
+      scope: 'private',
+    });
+    appendKGPromotionRecord(tmpDir, {
+      ts: '2026-05-06T01:01:00.000Z',
+      status: 'failed',
+      relPath: 'topics/kg.md',
+      title: 'KG',
+      sha1: 'def',
+      confidence: 0.72,
+      scope: 'private',
+      error: 'offline',
+    });
+
+    const records = readKGPromotionRecords(tmpDir, 10);
+    const summary = summarizeKGPromotions(records);
+
+    expect(records.map(record => record.relPath)).toEqual(['topics/kg.md', 'MEMORY.md']);
+    expect(summary).toMatchObject({ total: 2, promoted: 1, failed: 1 });
+    expect(summary.latestAt).toBe('2026-05-06T01:01:00.000Z');
+  });
+});

--- a/tests/memory-repo-policy.test.ts
+++ b/tests/memory-repo-policy.test.ts
@@ -31,11 +31,12 @@ describe('memory repo policy', () => {
     const report = buildMemoryRepoHealthReport('/memory', [
       { relPath: 'MEMORY.md', bytes: 1200 },
       { relPath: 'topics/kg.md', bytes: 2400 },
+      { relPath: 'topics/archive/old-archived-20260426.md', bytes: 5000 },
       { relPath: 'context-checkpoints/2026-05-06.jsonl', bytes: 9000 },
       { relPath: 'state/activity-journal.jsonl', bytes: 5000 },
     ], '2026-05-06T00:00:00.000Z');
 
-    expect(report.totals.trackableFiles).toBe(2);
+    expect(report.totals.trackableFiles).toBe(3);
     expect(report.totals.ignoredFiles).toBe(2);
     expect(report.kgCandidates.map(file => file.relPath)).toEqual(['topics/kg.md', 'MEMORY.md']);
 

--- a/tests/pr-lifecycle-governance.test.ts
+++ b/tests/pr-lifecycle-governance.test.ts
@@ -69,6 +69,26 @@ describe('PR lifecycle governance', () => {
     expect(analysis.shouldBlockPush).toBe(false);
   });
 
+  it('blocks feature branch push when branch is behind origin base', () => {
+    const analysis = analyzeBranchLifecycle(input({
+      branch: 'feat/kg-promotion-context-fabric',
+      behindBase: 1,
+      pullRequest: {
+        number: 150,
+        title: 'feat: promote curated memory into KG',
+        body: '',
+      },
+      commitsAhead: [
+        { sha: 'a', subject: 'feat: promote curated memory into KG' },
+      ],
+    }));
+
+    expect(analysis.status).toBe('stale-base');
+    expect(analysis.behindBase).toBe(1);
+    expect(analysis.shouldBlockPush).toBe(true);
+    expect(analysis.guidance.join('\n')).toContain('rebase before push');
+  });
+
   it('downgrades scope-contaminated block when HEAD is a memory-only chore (Issue #102)', () => {
     const analysis = analyzeBranchLifecycle(input({
       branch: 'feat/correction-gate-hold-reasons',


### PR DESCRIPTION
## Summary
- Add a KG promotion module and CLI that promotes curated external memory Markdown into KG triples with provenance, confidence, scope, and source hashes.
- Add `/api/kg/promotions` to inspect the external memory promotion ledger.
- Exclude archived memory files from KG candidates and keep dry-run promotion non-mutating by default.
- Strengthen PR lifecycle governance: pre-push now fetches `origin/main`, computes `behindBase`, and blocks stale feature branches until they rebase and rerun verification.

## Verification
- `pnpm typecheck`
- `pnpm test --run tests/pr-lifecycle-governance.test.ts tests/kg-promotion.test.ts tests/memory-repo-policy.test.ts tests/kg-paths.test.ts`
- `pnpm build`
- `pnpm exec tsx scripts/check-pr-lifecycle.ts --json` reports `behindBase: 0`
- `pnpm exec tsx scripts/kg-promote-memory.ts --dry-run --limit 5`
- `pnpm exec tsx scripts/kg-promote-memory.ts --limit 3` promoted 3 curated research notes to KG with 0 failures.