### PR TITLE
fix: run workspace janitor after deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "self-research:plan": "pnpm build && node scripts/self-research-plan.mjs",
     "sync:github-issues": "pnpm build && node dist/issue-autopilot-cli.js",
     "janitor:workspaces": "tsx scripts/workspace-janitor.ts",
+    "janitor:workspaces:apply": "tsx scripts/workspace-janitor.ts --apply",
     "check:runtime-workspace": "tsx scripts/check-runtime-workspace.ts",
     "setup:external-memory": "tsx scripts/setup-external-memory.ts",
     "memory:repo:setup": "tsx scripts/setup-memory-repo.ts --init",

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -131,6 +131,16 @@ done
 
 if [ "$HEALTH_OK" = true ]; then
     log "Deployment successful"
+    if [ "${MINI_AGENT_SKIP_WORKSPACE_JANITOR:-0}" = "1" ]; then
+        log "Skipping workspace janitor"
+    else
+        log "Running workspace janitor..."
+        if pnpm exec tsx scripts/workspace-janitor.ts --apply >> "$LOG_FILE" 2>&1; then
+            log "Workspace janitor completed"
+        else
+            log "Workspace janitor failed (non-fatal)"
+        fi
+    fi
     exit 0
 else
     log "Health check failed after 30s"

--- a/tests/deploy-script.test.ts
+++ b/tests/deploy-script.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('deploy script workspace janitor hook', () => {
+  it('runs workspace janitor after successful health check without making deploy fail', () => {
+    const script = readFileSync(path.join(process.cwd(), 'scripts', 'deploy.sh'), 'utf-8');
+    const successIndex = script.indexOf('log "Deployment successful"');
+    const janitorIndex = script.indexOf('scripts/workspace-janitor.ts --apply');
+    const exitIndex = script.indexOf('exit 0', successIndex);
+
+    expect(successIndex).toBeGreaterThan(-1);
+    expect(janitorIndex).toBeGreaterThan(successIndex);
+    expect(janitorIndex).toBeLessThan(exitIndex);
+    expect(script).toContain('MINI_AGENT_SKIP_WORKSPACE_JANITOR');
+    expect(script).toContain('Workspace janitor failed (non-fatal)');
+  });
+});


### PR DESCRIPTION
## Summary
- Run `scripts/workspace-janitor.ts --apply` automatically after a successful deploy health check.
- Keep janitor failures non-fatal and logged, so a successful service deploy is not marked failed because cleanup hit a stale branch/delete race.
- Add `MINI_AGENT_SKIP_WORKSPACE_JANITOR=1` as an emergency bypass.
- Add `janitor:workspaces:apply` script and a regression test asserting the deploy hook placement.

## Verification
- `pnpm typecheck`
- `pnpm test --run tests/deploy-script.test.ts tests/workspace-isolation.test.ts`
- `pnpm build`
- `pnpm exec tsx scripts/workspace-janitor.ts --json`
- `pnpm exec tsx scripts/check-pr-lifecycle.ts --json` reported `behindBase: 0`.