### PR TITLE
fix: serialize deploy before janitor cleanup

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -6,6 +6,7 @@ set -e
 
 DEPLOY_DIR="/Users/user/Workspace/mini-agent"
 LOG_FILE="$HOME/.mini-agent/deploy.log"
+LOCK_DIR="$HOME/.mini-agent/deploy.lock"
 
 mkdir -p "$HOME/.mini-agent"
 
@@ -13,7 +14,34 @@ log() {
     echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1" | tee -a "$LOG_FILE"
 }
 
+acquire_lock() {
+    if mkdir "$LOCK_DIR" 2>/dev/null; then
+        echo "$$" > "$LOCK_DIR/pid"
+        trap 'rm -rf "$LOCK_DIR"' EXIT
+        return 0
+    fi
+
+    LOCK_PID=$(cat "$LOCK_DIR/pid" 2>/dev/null || true)
+    if [ -n "$LOCK_PID" ] && kill -0 "$LOCK_PID" 2>/dev/null; then
+        log "Another deploy is already running (PID $LOCK_PID); aborting"
+        exit 1
+    fi
+
+    log "Removing stale deploy lock"
+    rm -rf "$LOCK_DIR"
+    if mkdir "$LOCK_DIR" 2>/dev/null; then
+        echo "$$" > "$LOCK_DIR/pid"
+        trap 'rm -rf "$LOCK_DIR"' EXIT
+        return 0
+    fi
+
+    log "Could not acquire deploy lock; aborting"
+    exit 1
+}
+
 cd "$DEPLOY_DIR"
+
+acquire_lock
 
 log "Starting deployment..."
 
@@ -133,6 +161,10 @@ if [ "$HEALTH_OK" = true ]; then
     log "Deployment successful"
     if [ "${MINI_AGENT_SKIP_WORKSPACE_JANITOR:-0}" = "1" ]; then
         log "Skipping workspace janitor"
+    elif [ "$(git branch --show-current 2>/dev/null)" != "runtime/main" ]; then
+        log "Skipping workspace janitor because deploy checkout is not on runtime/main"
+    elif git status --porcelain | grep -q '^UU '; then
+        log "Skipping workspace janitor because deploy checkout has unresolved conflicts"
     else
         log "Running workspace janitor..."
         if pnpm exec tsx scripts/workspace-janitor.ts --apply >> "$LOG_FILE" 2>&1; then

--- a/tests/deploy-script.test.ts
+++ b/tests/deploy-script.test.ts
@@ -3,6 +3,19 @@ import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 describe('deploy script workspace janitor hook', () => {
+  it('serializes deployments with a process lock', () => {
+    const script = readFileSync(path.join(process.cwd(), 'scripts', 'deploy.sh'), 'utf-8');
+    const lockIndex = script.indexOf('LOCK_DIR="$HOME/.mini-agent/deploy.lock"');
+    const acquireIndex = script.indexOf('acquire_lock');
+    const startIndex = script.indexOf('log "Starting deployment..."');
+
+    expect(lockIndex).toBeGreaterThan(-1);
+    expect(acquireIndex).toBeGreaterThan(lockIndex);
+    expect(acquireIndex).toBeLessThan(startIndex);
+    expect(script).toContain('Another deploy is already running');
+    expect(script).toContain("trap 'rm -rf \"$LOCK_DIR\"' EXIT");
+  });
+
   it('runs workspace janitor after successful health check without making deploy fail', () => {
     const script = readFileSync(path.join(process.cwd(), 'scripts', 'deploy.sh'), 'utf-8');
     const successIndex = script.indexOf('log "Deployment successful"');
@@ -13,6 +26,8 @@ describe('deploy script workspace janitor hook', () => {
     expect(janitorIndex).toBeGreaterThan(successIndex);
     expect(janitorIndex).toBeLessThan(exitIndex);
     expect(script).toContain('MINI_AGENT_SKIP_WORKSPACE_JANITOR');
+    expect(script).toContain('Skipping workspace janitor because deploy checkout is not on runtime/main');
+    expect(script).toContain('Skipping workspace janitor because deploy checkout has unresolved conflicts');
     expect(script).toContain('Workspace janitor failed (non-fatal)');
   });
 });


### PR DESCRIPTION
## Summary
- Add a deploy lock at `$HOME/.mini-agent/deploy.lock` so overlapping local/GitHub deploys cannot interleave stop/start/janitor phases.
- Remove stale locks only when the recorded PID is gone.
- Keep post-deploy janitor gated: it runs only when the deploy checkout is still `runtime/main` and has no unresolved conflicts.
- Extend deploy script regression coverage for lock ordering and janitor safety gates.

## Verification
- `pnpm typecheck`
- `pnpm test --run tests/deploy-script.test.ts tests/workspace-isolation.test.ts`
- `pnpm build`
- `pnpm exec tsx scripts/check-pr-lifecycle.ts --json` reported `behindBase: 0` before commit/push.