### PR TITLE
fix(staleness): make P0 escalation idempotent (#156)

### DIFF
--- a/src/loop.ts
+++ b/src/loop.ts
@@ -38,7 +38,7 @@ import {
   updateTemporalState, flushTemporalState,
   startThread, progressThread, completeThread, pauseThread,
 } from './temporal.js';
-import { hasP0Tasks, getPendingTaskPreviews, getP0TaskPreviews, markTaskDoneByDescription, getHighPriorityPendingCount, queryMemoryIndexSync, incrementTaskStaleness, updateTask, healAbandonedGoals, scanPipelineVerify, getPipelineStuckAnalysis, cleanStaleEntries } from './memory-index.js';
+import { hasP0Tasks, getPendingTaskPreviews, getP0TaskPreviews, markTaskDoneByDescription, getHighPriorityPendingCount, queryMemoryIndexSync, incrementTaskStaleness, healAbandonedGoals, scanPipelineVerify, getPipelineStuckAnalysis, cleanStaleEntries } from './memory-index.js';
 import { schedulerPick, advanceTick, schedulerTaskDone, getSchedulerState, getSchedulerStatus, entryToSnapshot, consumeNeedsPickNext, type IncomingEvent as SchedulerEvent } from './scheduler.js';
 import { registerProcess, transitionProcess, suspendProcess, resumeProcess, completeProcess, incrementTicks, getCurrentProcess, getProcessTableStatus, syncFromTasks, initProcessTable, persistProcessTable } from './process-table.js';
 import { saveSuspendCheckpoint, loadSuspendCheckpoint, clearSuspendCheckpoint } from './cycle-state.js';
@@ -3568,10 +3568,14 @@ export class AgentLoop {
         if (staleTasks.length === 0) return;
         this.staleTasks = staleTasks;
 
-        // Escalation: >5 ticks → auto P0
+        // Escalation: first crossing of >5 ticks → P0. Stamp is applied
+        // atomically inside incrementTaskStaleness; we only emit the slog once.
+        // Issue #156: previously this branch unconditionally rewrote
+        // priority=0 every cycle, racing with upstream syncs (issue-autopilot,
+        // github-issue) that wrote the original priority back, causing 2↔0↔2
+        // oscillation in task-events.jsonl.
         for (const t of staleTasks) {
-          if (t.ticks > 5) {
-            updateTask(getMemoryRootDir(), t.id, { priority: 0 }).catch(() => {});
+          if (t.firstEscalation) {
             slog('CONSTRAINT', `Escalated to P0: ${t.summary.slice(0, 60)} (${t.ticks} ticks stale)`);
           }
         }

--- a/src/memory-index.ts
+++ b/src/memory-index.ts
@@ -612,11 +612,16 @@ export async function updateTask(
   }
 
   // Progress reset: any status transition or verify write resets staleness counter
+  // (and clears the staleness escalation stamp so a re-stalled task can re-escalate)
   if (patch.status !== undefined && patch.status !== prevStatus) {
     newPayload.ticksSinceLastProgress = 0;
+    delete newPayload.escalated_at;
+    delete newPayload.escalation_reason;
   }
   if (patch.verify !== undefined) {
     newPayload.ticksSinceLastProgress = 0;
+    delete newPayload.escalated_at;
+    delete newPayload.escalation_reason;
   }
 
   // Verify gate: task with verify_command must pass before terminal status
@@ -932,13 +937,13 @@ const STALENESS_THRESHOLD = 3;
  */
 export async function incrementTaskStaleness(
   memoryDir: string,
-): Promise<Array<{ id: string; summary: string; ticks: number }>> {
+): Promise<Array<{ id: string; summary: string; ticks: number; firstEscalation: boolean }>> {
   const tasks = queryMemoryIndexSync(memoryDir, {
     type: ['task', 'goal'],
     status: ['pending', 'in_progress'],
   });
 
-  const stale: Array<{ id: string; summary: string; ticks: number }> = [];
+  const stale: Array<{ id: string; summary: string; ticks: number; firstEscalation: boolean }> = [];
 
   for (const task of tasks) {
     const payload = (task.payload ?? {}) as Record<string, unknown>;
@@ -956,12 +961,35 @@ export async function incrementTaskStaleness(
       continue;
     }
 
+    // Issue #156: idempotent P0 escalation. Stamp `escalated_at` once when
+    // crossing the >5-ticks boundary; subsequent cycles see the stamp and
+    // skip re-writing priority. This stops the priority oscillation caused
+    // by external syncs (issue-autopilot, github-issue) writing the original
+    // priority back between cycles, only to be clobbered to 0 again here.
+    const alreadyEscalated = !!payload.escalated_at;
+    const shouldEscalateNow = newTicks > 5 && !alreadyEscalated;
+
+    const updatedPayload: Record<string, unknown> = {
+      ...payload,
+      ticksSinceLastProgress: newTicks,
+    };
+    if (shouldEscalateNow) {
+      updatedPayload.priority = 0;
+      updatedPayload.escalated_at = new Date().toISOString();
+      updatedPayload.escalation_reason = 'staleness';
+    }
+
     await updateMemoryIndexEntry(memoryDir, task.id, {
-      payload: { ...payload, ticksSinceLastProgress: newTicks },
+      payload: updatedPayload,
     });
 
     if (newTicks > STALENESS_THRESHOLD) {
-      stale.push({ id: task.id, summary: task.summary ?? task.id, ticks: newTicks });
+      stale.push({
+        id: task.id,
+        summary: task.summary ?? task.id,
+        ticks: newTicks,
+        firstEscalation: shouldEscalateNow,
+      });
     }
   }
 

--- a/tests/staleness-escalation-idempotency.test.ts
+++ b/tests/staleness-escalation-idempotency.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Staleness escalation idempotency — issue #156
+ *
+ * Verifies that `incrementTaskStaleness` only escalates a task to P0 once,
+ * preventing the priority oscillation observed when the OODA loop's stale-task
+ * branch unconditionally writes priority=0 every cycle and then upstream syncs
+ * (e.g. issue-autopilot, github-issue sync) write the original priority back.
+ *
+ * Filed-by-and-fixed-by: Kuro / instance 03bbc29a
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  appendMemoryIndexEntry,
+  updateMemoryIndexEntry,
+  queryMemoryIndexSync,
+  incrementTaskStaleness,
+  updateTask,
+  invalidateIndexCache,
+} from '../src/memory-index.js';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'stale-esc-'));
+  invalidateIndexCache();
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  invalidateIndexCache();
+});
+
+async function bumpTicks(dir: string, n: number) {
+  let last: Awaited<ReturnType<typeof incrementTaskStaleness>> = [];
+  for (let i = 0; i < n; i++) last = await incrementTaskStaleness(dir);
+  return last;
+}
+
+function getTask(id: string) {
+  return queryMemoryIndexSync(tmpDir, { id, limit: 1 })[0];
+}
+
+describe('issue #156 — staleness escalation idempotency', () => {
+  it('escalates exactly once and stamps escalated_at', async () => {
+    const e = await appendMemoryIndexEntry(tmpDir, {
+      type: 'task',
+      status: 'pending',
+      summary: 'sync gh issue 999 → task',
+      payload: { priority: 2 },
+    });
+
+    // Push past the >5 ticks threshold (6 cycles).
+    const stale = await bumpTicks(tmpDir, 6);
+    const escalated = stale.find(s => s.id === e.id);
+    expect(escalated, 'task should be in stale list after 6 ticks').toBeDefined();
+    expect(escalated!.firstEscalation).toBe(true);
+
+    const after = getTask(e.id);
+    const payload = after.payload as Record<string, unknown>;
+    expect(payload.priority).toBe(0);
+    expect(typeof payload.escalated_at).toBe('string');
+    const firstStamp = payload.escalated_at as string;
+
+    // One more tick: should NOT re-escalate.
+    const stale2 = await incrementTaskStaleness(tmpDir);
+    const found2 = stale2.find(s => s.id === e.id);
+    expect(found2!.firstEscalation).toBe(false);
+
+    const after2 = getTask(e.id);
+    const payload2 = after2.payload as Record<string, unknown>;
+    expect(payload2.escalated_at).toBe(firstStamp); // stamp unchanged
+  });
+
+  it('clears escalated_at when status transitions (allows re-escalation later)', async () => {
+    const e = await appendMemoryIndexEntry(tmpDir, {
+      type: 'task',
+      status: 'pending',
+      summary: 'task that gets reopened',
+      payload: { priority: 2 },
+    });
+
+    // Escalate.
+    await bumpTicks(tmpDir, 6);
+    expect((getTask(e.id).payload as Record<string, unknown>).escalated_at).toBeTruthy();
+
+    // Status transition resets ticks AND escalation stamp.
+    await updateTask(tmpDir, e.id, { status: 'in_progress' });
+    const after = getTask(e.id);
+    const payload = after.payload as Record<string, unknown>;
+    expect(payload.ticksSinceLastProgress).toBe(0);
+    expect(payload.escalated_at).toBeUndefined();
+  });
+
+  it('does not re-write payload on stale tasks already escalated (no oscillation)', async () => {
+    // Simulates the bug: external sync writes priority=2 back; staleness must
+    // NOT clobber it again on the next cycle (since we already escalated once).
+    const e = await appendMemoryIndexEntry(tmpDir, {
+      type: 'task',
+      status: 'pending',
+      summary: 'oscillation candidate',
+      payload: { priority: 2 },
+    });
+
+    await bumpTicks(tmpDir, 6); // first escalation: priority → 0
+    // External sync rewrites priority back to 2.
+    await updateMemoryIndexEntry(tmpDir, e.id, {
+      payload: { ...(getTask(e.id).payload as Record<string, unknown>), priority: 2 },
+    });
+    expect((getTask(e.id).payload as Record<string, unknown>).priority).toBe(2);
+
+    // Next staleness tick: must NOT re-escalate (escalated_at already set).
+    const stale = await incrementTaskStaleness(tmpDir);
+    const found = stale.find(s => s.id === e.id);
+    expect(found!.firstEscalation).toBe(false);
+    // Priority stays at 2 — no oscillation.
+    expect((getTask(e.id).payload as Record<string, unknown>).priority).toBe(2);
+  });
+});


### PR DESCRIPTION
Closes #156. Stamp `escalated_at` atomically on first >5-ticks crossing; subsequent cycles skip the priority rewrite. Status/verify transitions clear the stamp. Removes the unconditional `updateTask({priority:0})` race vs upstream syncs. Tests: `tests/staleness-escalation-idempotency.test.ts` (3 cases — single escalation / stamp clears on status change / no oscillation when external sync rewrites priority).

Filed and fixed by Kuro / instance 03bbc29a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)