### PR TITLE
fix: block runtime repo memory commits

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Runtime checkout guard:
-# code/config commits must happen in isolated feature worktrees, not in the
-# protected runtime/deploy checkout. Memory/state commits remain allowed.
+# code/config and repo-local memory commits must happen outside the protected
+# runtime/deploy checkout. Runtime memory writes belong in MINI_AGENT_MEMORY_DIR.
 
 if ! command -v pnpm >/dev/null 2>&1; then
   echo "[runtime-workspace] pnpm not found; skipping guard" >&2

--- a/scripts/check-runtime-workspace.ts
+++ b/scripts/check-runtime-workspace.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env tsx
 import { execFileSync } from 'node:child_process';
 import path from 'node:path';
-import { isCodePath, isSafeRuntimeBranch, parseDirtyPaths } from '../src/workspace-isolation.js';
+import { isCodePath, isRuntimeRepoMemoryPath, isSafeRuntimeBranch, parseDirtyPaths } from '../src/workspace-isolation.js';
 
 const allow = process.env.MINI_AGENT_ALLOW_RUNTIME_WORKSPACE_WRITE === '1';
 const json = process.argv.includes('--json');
@@ -13,6 +13,7 @@ const protectedRoot = path.resolve(process.env.MINI_AGENT_RUNTIME_WORKSPACE ?? i
 const isProtectedRuntime = path.resolve(repoRoot) === protectedRoot;
 const paths = stagedOnly ? stagedPaths() : parseDirtyPaths(git(['status', '--porcelain']) ?? '');
 const blockingPaths = paths.filter(isCodePath);
+const runtimeMemoryPaths = paths.filter(isRuntimeRepoMemoryPath);
 
 const problems: string[] = [];
 if (isProtectedRuntime && !isSafeRuntimeBranch(branch)) {
@@ -20,6 +21,9 @@ if (isProtectedRuntime && !isSafeRuntimeBranch(branch)) {
 }
 if (isProtectedRuntime && blockingPaths.length > 0) {
   problems.push(`protected runtime workspace has code/config changes: ${blockingPaths.slice(0, 8).join(', ')}`);
+}
+if (isProtectedRuntime && runtimeMemoryPaths.length > 0) {
+  problems.push(`protected runtime workspace has repo-local memory changes: ${runtimeMemoryPaths.slice(0, 8).join(', ')}; write memory to MINI_AGENT_MEMORY_DIR instead`);
 }
 
 const result = {
@@ -32,6 +36,7 @@ const result = {
   stagedOnly,
   paths,
   blockingPaths,
+  runtimeMemoryPaths,
   problems,
 };
 

--- a/src/cycle-tasks.ts
+++ b/src/cycle-tasks.ts
@@ -15,6 +15,7 @@ import { slog } from './utils.js';
 import { eventBus } from './event-bus.js';
 import { notifyTelegram } from './telegram.js';
 import { getMemory } from './memory.js';
+import { evaluateWorkspaceIsolation } from './workspace-isolation.js';
 // markNextItemsDone removed — loop.ts now calls markTaskDoneByDescription from memory-index.ts directly
 import { getCurrentInstanceId, getInstanceDir } from './instance.js';
 import { CHAT_ROOM_INBOX_PATH } from './inbox-processor.js';
@@ -478,6 +479,12 @@ async function generateCommitMessage(diff: string, fileList: string, fallback: s
 
 export async function autoCommitMemoryFiles(action: string | null): Promise<void> {
   const cwd = process.cwd();
+  const isolation = evaluateWorkspaceIsolation(cwd);
+  if (isolation.protectedRuntimeWorkspace) {
+    slog('auto-commit', 'skipped: protected runtime workspace uses external memory repo');
+    return;
+  }
+
   const fallbackSummary = action
     ? action.replace(/\[.*?\]\s*/, '').slice(0, 80)
     : 'auto-save';

--- a/src/workspace-isolation.ts
+++ b/src/workspace-isolation.ts
@@ -8,6 +8,7 @@ export interface WorkspaceIsolationSnapshot {
   protectedRuntimeWorkspace: boolean;
   dirtyPaths: string[];
   codeDirtyPaths: string[];
+  runtimeMemoryDirtyPaths: string[];
 }
 
 export interface WorkspaceIsolationDecision extends WorkspaceIsolationSnapshot {
@@ -25,6 +26,7 @@ export function evaluateWorkspaceIsolation(cwd = process.cwd(), protectedRoot = 
   const branch = git(cwd, ['rev-parse', '--abbrev-ref', 'HEAD']) || null;
   const dirtyPaths = parseDirtyPaths(git(cwd, ['status', '--porcelain']) ?? '');
   const codeDirtyPaths = dirtyPaths.filter(isCodePath);
+  const runtimeMemoryDirtyPaths = dirtyPaths.filter(isRuntimeRepoMemoryPath);
   const protectedRuntimeWorkspace = isProtectedRuntimeWorkspace(cwd, repoRoot, protectedRoot);
   const warnings: string[] = [];
 
@@ -36,6 +38,7 @@ export function evaluateWorkspaceIsolation(cwd = process.cwd(), protectedRoot = 
       protectedRuntimeWorkspace,
       dirtyPaths,
       codeDirtyPaths,
+      runtimeMemoryDirtyPaths,
       ok: true,
       reason: 'isolated worktree',
       warnings,
@@ -50,6 +53,7 @@ export function evaluateWorkspaceIsolation(cwd = process.cwd(), protectedRoot = 
       protectedRuntimeWorkspace,
       dirtyPaths,
       codeDirtyPaths,
+      runtimeMemoryDirtyPaths,
       ok: false,
       reason: `protected runtime workspace is on branch ${branch ?? 'unknown'}; expected runtime/main`,
       warnings,
@@ -64,14 +68,31 @@ export function evaluateWorkspaceIsolation(cwd = process.cwd(), protectedRoot = 
       protectedRuntimeWorkspace,
       dirtyPaths,
       codeDirtyPaths,
+      runtimeMemoryDirtyPaths,
       ok: false,
       reason: `protected runtime workspace has code/config dirt: ${codeDirtyPaths.slice(0, 5).join(', ')}`,
       warnings,
     };
   }
 
-  if (dirtyPaths.length > 0) {
-    warnings.push(`runtime workspace has non-code dirt: ${dirtyPaths.slice(0, 5).join(', ')}`);
+  if (runtimeMemoryDirtyPaths.length > 0) {
+    return {
+      cwd,
+      repoRoot,
+      branch,
+      protectedRuntimeWorkspace,
+      dirtyPaths,
+      codeDirtyPaths,
+      runtimeMemoryDirtyPaths,
+      ok: false,
+      reason: `protected runtime workspace has repo-local memory dirt: ${runtimeMemoryDirtyPaths.slice(0, 5).join(', ')}`,
+      warnings,
+    };
+  }
+
+  const nonBlockingDirt = dirtyPaths.filter(p => !isCodePath(p) && !isRuntimeRepoMemoryPath(p));
+  if (nonBlockingDirt.length > 0) {
+    warnings.push(`runtime workspace has non-code dirt: ${nonBlockingDirt.slice(0, 5).join(', ')}`);
   }
 
   return {
@@ -81,6 +102,7 @@ export function evaluateWorkspaceIsolation(cwd = process.cwd(), protectedRoot = 
     protectedRuntimeWorkspace,
     dirtyPaths,
     codeDirtyPaths,
+    runtimeMemoryDirtyPaths,
     ok: true,
     reason: 'protected runtime workspace is safe for isolated delegation',
     warnings,
@@ -98,6 +120,10 @@ export function parseDirtyPaths(porcelain: string): string[] {
 
 export function isCodePath(filePath: string): boolean {
   return CODE_PATH_PATTERN.test(filePath) || CODE_FILE_PATTERN.test(filePath);
+}
+
+export function isRuntimeRepoMemoryPath(filePath: string): boolean {
+  return filePath === 'memory' || filePath.startsWith('memory/');
 }
 
 export function isSafeRuntimeBranch(branch: string | null | undefined): boolean {

--- a/tests/workspace-isolation.test.ts
+++ b/tests/workspace-isolation.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { isCodePath, isSafeRuntimeBranch, parseDirtyPaths } from '../src/workspace-isolation.js';
+import { isCodePath, isRuntimeRepoMemoryPath, isSafeRuntimeBranch, parseDirtyPaths } from '../src/workspace-isolation.js';
 
 describe('workspace isolation guard', () => {
   it('parses porcelain paths without losing renamed or untracked paths', () => {
@@ -17,7 +17,7 @@ describe('workspace isolation guard', () => {
     ]);
   });
 
-  it('treats source, config, and managed output paths as blocking dirt but allows memory dirt', () => {
+  it('treats source, config, and managed output paths as code dirt', () => {
     expect(isCodePath('src/auto-executor.ts')).toBe(true);
     expect(isCodePath('tests/auto-executor.test.ts')).toBe(true);
     expect(isCodePath('package.json')).toBe(true);
@@ -25,6 +25,12 @@ describe('workspace isolation guard', () => {
     expect(isCodePath('knowledge-graph/')).toBe(true);
     expect(isCodePath('memory/inner-notes.md')).toBe(false);
     expect(isCodePath('papers/')).toBe(false);
+  });
+
+  it('treats repo-local memory as blocked in protected runtime checkout', () => {
+    expect(isRuntimeRepoMemoryPath('memory/HEARTBEAT.md')).toBe(true);
+    expect(isRuntimeRepoMemoryPath('memory/topics/kg.md')).toBe(true);
+    expect(isRuntimeRepoMemoryPath('src/memory.ts')).toBe(false);
   });
 
   it('only treats runtime/main as safe for the protected runtime checkout', () => {


### PR DESCRIPTION
## Summary
- Stop `autoCommitMemoryFiles()` from committing repo-local `memory/` files when running in the protected runtime checkout.
- Treat repo-local `memory/` paths as blocked in the runtime workspace guard, so pre-commit rejects `memory/HEARTBEAT.md` style commits from `runtime/main`.
- Keep isolated feature worktrees unaffected; the guard only applies to the protected runtime checkout.
- Update pre-commit wording and workspace isolation tests.

## Verification
- `pnpm typecheck`
- `pnpm test --run tests/workspace-isolation.test.ts tests/deploy-script.test.ts`
- `pnpm build`
- `pnpm exec tsx scripts/check-pr-lifecycle.ts --json` reported `behindBase: 0` before push.