### PR TITLE
fix(loop): wire issue-autopilot reconcile into intake pipeline

### DIFF
--- a/src/loop.ts
+++ b/src/loop.ts
@@ -2235,6 +2235,15 @@ export class AgentLoop {
       try { await cleanStaleEntries(memDir); } catch { /* non-critical */ }
       // Goal Advancer: pull tasks from pipeline goals before scheduler picks
       try { await advanceGoals(memDir); } catch { /* non-critical */ }
+      // Issue autopilot: reconcile GitHub-closed issues so stale P0 entries drain (issue #151)
+      try {
+        const repo = process.env.MINI_AGENT_GITHUB_REPO;
+        if (repo) {
+          const { readOpenIssuesFromGitHub, syncGitHubIssuesToTasks } = await import('./issue-autopilot.js');
+          const issues = readOpenIssuesFromGitHub(repo, 50);
+          await syncGitHubIssuesToTasks(memDir, issues, { repo });
+        }
+      } catch { /* non-critical */ }
       try {
         const { closeResolvedCorrectionTasks, evaluateCorrectionGate, ensureCorrectionTask } = await import('./correction-gate.js');
         const correction = evaluateCorrectionGate(memDir);


### PR DESCRIPTION
Closes #151.

## What

Adds one ~10-line `try` block at `src/loop.ts:2237` (alongside the existing intake calls — `promoteNextIdea`, `cleanParkingLot`, `generateRecurringTasks`, `cleanStaleEntries`, `advanceGoals`) that pulls GitHub issue state every cycle and reconciles closed issues to local task entries via `syncGitHubIssuesToTasks`.

```ts
// Issue autopilot: reconcile GitHub-closed issues so stale P0 entries drain (issue #151)
try {
  const repo = process.env.MINI_AGENT_GITHUB_REPO;
  if (repo) {
    const { readOpenIssuesFromGitHub, syncGitHubIssuesToTasks } = await import('./issue-autopilot.js');
    const issues = readOpenIssuesFromGitHub(repo, 50);
    await syncGitHubIssuesToTasks(memDir, issues, { repo });
  }
} catch { /* non-critical */ }
```

## Why

PR #135 added the correct reconcile loop (`issue-autopilot.ts:90-107`) but the only callsite was `pnpm sync:github-issues` (manual CLI) — no cron entry, no loop integration. Result: closed issues stayed on the `P0 items pending` rail for 8+ hours (concrete evidence in #151: #132 closed at 09:48Z still rendering at 18:28Z; #83 same shape).

This is **Patch A** from the issue body (Alex's preferred wiring). Patch B (cron) was the fallback with 10-min lag; A self-heals every cycle.

## Cost / safety

- ~1-2s `gh issue list --state all` per cycle. `readOpenIssuesFromGitHub` already passes `--state all` (despite the name) so closed-issue reconcile path is exercised.
- Env-gated by `MINI_AGENT_GITHUB_REPO`: no-op when unset (cost-safe for non-GH deployments).
- Errors swallowed as non-critical, matches sibling intake calls.

## Verification

- `pnpm build` clean (no TS errors).
- `pnpm test tests/issue-autopilot.test.ts` 7/7 pass — reconcile semantics already covered (creates pending entries for open, sets `completed` + `closed_via=issue-autopilot-reconciliation` for closed, leaves terminal-status entries alone).

## Falsifier (from #151)

- (a) After merge, next cycle following any `gh issue close` MUST drop that issue from rendered `P0 items pending` block. Verify via cycle-prompt diff.
- (b) If reconcile runs but P0 still shows closed issues → `getP0TaskPreviews` and `syncGitHubIssuesToTasks` write to different stores; would be a separate bug to address.
- (c) Rate-limit / network failure on `gh issue list`: caught silently → falsifier (a) re-asserts. v2 could add slog + 5-min cache.