### PR TITLE
fix(memory): sanitize review backlog scope guard (#83)

### DIFF
--- a/scripts/check-pr-lifecycle.ts
+++ b/scripts/check-pr-lifecycle.ts
@@ -80,6 +80,9 @@ function formatHuman(analysis: ReturnType<typeof analyzeBranchLifecycle>): strin
   if (analysis.pullRequest) {
     lines.push(`[pr-lifecycle] pr=#${analysis.pullRequest.number} ${analysis.pullRequest.title}`);
     lines.push(`[pr-lifecycle] allowed=${analysis.allowedIssueRefs.map(r => `#${r}`).join(', ') || '(none)'} refs=${analysis.issueRefs.map(r => `#${r}`).join(', ') || '(none)'}`);
+    if (analysis.unscopedCommitSubjects.length > 0) {
+      lines.push(`[pr-lifecycle] unscoped=${analysis.unscopedCommitSubjects.map(subject => JSON.stringify(subject)).join(', ')}`);
+    }
   }
   for (const guidance of analysis.guidance) lines.push(`[pr-lifecycle] ${guidance}`);
   return lines.join('\n') + '\n';

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -4304,7 +4304,7 @@ function extractDelegationSummaryInline(output: string, maxLen: number): string 
 // Review Backlog — persistent tracking of unreviewed delegation results
 // =============================================================================
 
-const BACKLOG_TTL_MS = 7 * 24 * 3600_000; // 7 days
+const BACKLOG_TTL_MS = 3 * 24 * 3600_000; // 3 days (Issue #83 follow-up: shorter TTL for un-acknowledged stale entries)
 
 /**
  * Detect failure-class delegation outputs that have zero learning value.
@@ -4328,7 +4328,7 @@ function isStaleFailureOutput(text: string): boolean {
   return false;
 }
 
-/** Remove backlog entries whose IDs appear in the response text. Also prune entries older than 7 days. */
+/** Remove backlog entries whose IDs appear in the response text. Also prune entries older than the backlog TTL. */
 export function clearReviewedDelegations(response: string, instanceId: string): void {
   try {
     const backlogPath = path.join(getInstanceDir(instanceId), 'review-backlog.jsonl');
@@ -4342,7 +4342,7 @@ export function clearReviewedDelegations(response: string, instanceId: string): 
     for (const line of lines) {
       try {
         const entry = JSON.parse(line);
-        // Prune expired entries (7-day TTL)
+        // Prune expired entries.
         if (now - new Date(entry.archivedAt).getTime() > BACKLOG_TTL_MS) continue;
         // Prune if response mentions this delegation ID
         if (entry.id && response.includes(entry.id)) continue;
@@ -4360,7 +4360,9 @@ export function clearReviewedDelegations(response: string, instanceId: string): 
   } catch { /* best effort */ }
 }
 
-/** Read review backlog entries (for prompt injection). Returns entries within TTL. */
+/** Read review backlog entries for prompt injection, newest first and capped to avoid stale noise. */
+const REVIEW_BACKLOG_RENDER_CAP = 30;
+
 export function getReviewBacklog(instanceId: string): Array<{ id: string; type?: string; summary: string; archivedAt: string }> {
   try {
     const backlogPath = path.join(getInstanceDir(instanceId), 'review-backlog.jsonl');
@@ -4372,12 +4374,13 @@ export function getReviewBacklog(instanceId: string): Array<{ id: string; type?:
     for (const line of lines) {
       try {
         const entry = JSON.parse(line);
-        if (now - new Date(entry.archivedAt).getTime() < BACKLOG_TTL_MS) {
-          entries.push(entry);
-        }
+        if (now - new Date(entry.archivedAt).getTime() >= BACKLOG_TTL_MS) continue;
+        if (entry.summary && isStaleFailureOutput(entry.summary)) continue;
+        entries.push(entry);
       } catch { continue; }
     }
-    return entries;
+    entries.sort((a, b) => new Date(b.archivedAt).getTime() - new Date(a.archivedAt).getTime());
+    return entries.slice(0, REVIEW_BACKLOG_RENDER_CAP);
   } catch { return []; }
 }
 

--- a/src/pr-lifecycle-governance.ts
+++ b/src/pr-lifecycle-governance.ts
@@ -93,6 +93,7 @@ export interface BranchLifecycleAnalysis {
   issueRefs: number[];
   allowedIssueRefs: number[];
   foreignIssueRefs: number[];
+  unscopedCommitSubjects: string[];
   hasReviewerSignal: boolean;
   canAcceptNewScope: boolean;
   shouldBlockPush: boolean;
@@ -110,6 +111,16 @@ export function analyzeBranchLifecycle(input: BranchLifecycleInput): BranchLifec
   const allowedIssueRefs = pr ? extractAllowedIssueRefs(pr) : [];
   const foreignIssueRefs = pr
     ? issueRefs.filter(ref => !allowedIssueRefs.includes(ref))
+    : [];
+  const hasExplicitIssueScope = pr ? allowedIssueRefs.some(ref => ref !== pr.number) : false;
+  const unscopedCommitSubjects = pr && hasExplicitIssueScope
+    ? input.commitsAhead
+      .filter(commit => !isMemoryScopedHead(commit))
+      .filter(commit => {
+        const refs = extractIssueRefs(`${commit.subject}\n${commit.body ?? ''}`);
+        return !refs.some(ref => allowedIssueRefs.includes(ref));
+      })
+      .map(commit => commit.subject)
     : [];
   const headIsMemoryChore = isMemoryScopedHead(input.commitsAhead[0]);
   const hasReviewerSignal = Boolean(
@@ -148,6 +159,11 @@ export function analyzeBranchLifecycle(input: BranchLifecycleInput): BranchLifec
       guidance.push(`PR #${pr.number} allows ${formatRefs(allowedIssueRefs)} but commits reference foreign issue(s): ${formatRefs(foreignIssueRefs)}.`);
       guidance.push('Split/cherry-pick unrelated commits into their own branch before pushing.');
     }
+  } else if (unscopedCommitSubjects.length > 0) {
+    status = 'scope-contaminated';
+    shouldBlockPush = true;
+    guidance.push(`PR #${pr.number} is issue-scoped to ${formatRefs(allowedIssueRefs)} but has unscoped non-memory commit(s): ${unscopedCommitSubjects.map(s => `"${s}"`).join(', ')}.`);
+    guidance.push('Amend or split commits so every non-memory commit on an issue-scoped PR references the PR issue.');
   } else {
     status = 'pending-review';
     guidance.push(`PR #${pr.number} is the active scope. Only amend this PR scope; do not start a new task on this branch.`);
@@ -167,6 +183,7 @@ export function analyzeBranchLifecycle(input: BranchLifecycleInput): BranchLifec
     issueRefs,
     allowedIssueRefs,
     foreignIssueRefs,
+    unscopedCommitSubjects,
     hasReviewerSignal,
     canAcceptNewScope: status === 'base' && !input.dirty,
     shouldBlockPush,

--- a/tests/pr-lifecycle-governance.test.ts
+++ b/tests/pr-lifecycle-governance.test.ts
@@ -69,6 +69,28 @@ describe('PR lifecycle governance', () => {
     expect(analysis.shouldBlockPush).toBe(false);
   });
 
+  it('blocks unscoped non-memory commits on issue-scoped PRs', () => {
+    const analysis = analyzeBranchLifecycle(input({
+      branch: 'fix/review-backlog-issue-83',
+      pullRequest: {
+        number: 155,
+        title: 'fix(memory): tighten review-backlog TTL + cap + read-side filter (#83)',
+        body: 'Fixes #83.',
+      },
+      commitsAhead: [
+        { sha: 'b', subject: '## Task: P0 correction gate: resolve local-commit-not-pushed' },
+        { sha: 'a', subject: 'fix(memory): tighten review-backlog TTL + cap + read-side filter (#83)' },
+      ],
+    }));
+
+    expect(analysis.status).toBe('scope-contaminated');
+    expect(analysis.unscopedCommitSubjects).toEqual([
+      '## Task: P0 correction gate: resolve local-commit-not-pushed',
+    ]);
+    expect(analysis.shouldBlockPush).toBe(true);
+    expect(analysis.guidance.join('\n')).toContain('unscoped non-memory commit');
+  });
+
   it('blocks feature branch push when branch is behind origin base', () => {
     const analysis = analyzeBranchLifecycle(input({
       branch: 'feat/kg-promotion-context-fabric',

--- a/tests/review-backlog.test.ts
+++ b/tests/review-backlog.test.ts
@@ -1,0 +1,91 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { getReviewBacklog } from '../src/memory.js';
+
+describe('review backlog prompt feed', () => {
+  let tmpDir: string;
+  let oldDataDir: string | undefined;
+
+  beforeEach(() => {
+    oldDataDir = process.env.MINI_AGENT_DATA_DIR;
+    tmpDir = mkdtempSync(path.join(os.tmpdir(), 'mini-agent-review-backlog-'));
+    process.env.MINI_AGENT_DATA_DIR = tmpDir;
+  });
+
+  afterEach(() => {
+    if (oldDataDir === undefined) {
+      delete process.env.MINI_AGENT_DATA_DIR;
+    } else {
+      process.env.MINI_AGENT_DATA_DIR = oldDataDir;
+    }
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeBacklog(instanceId: string, entries: unknown[]): void {
+    const instanceDir = path.join(tmpDir, 'instances', instanceId);
+    mkdirSync(instanceDir, { recursive: true });
+    writeFileSync(path.join(instanceDir, 'review-backlog.jsonl'), entries.map(entry => JSON.stringify(entry)).join('\n') + '\n');
+  }
+
+  it('returns the newest 30 entries in descending order', () => {
+    const now = Date.now();
+    const entries = Array.from({ length: 35 }, (_, index) => ({
+      id: `delegation-${index}`,
+      type: 'delegation',
+      summary: `useful result ${index}`,
+      archivedAt: new Date(now - index * 60_000).toISOString(),
+    })).reverse();
+
+    writeBacklog('kuro', entries);
+
+    const backlog = getReviewBacklog('kuro');
+
+    expect(backlog).toHaveLength(30);
+    expect(backlog[0].id).toBe('delegation-0');
+    expect(backlog[29].id).toBe('delegation-29');
+    expect(backlog.map(entry => entry.archivedAt)).toEqual(
+      [...backlog].map(entry => entry.archivedAt).sort((a, b) => Date.parse(b) - Date.parse(a)),
+    );
+  });
+
+  it('filters expired entries and failure-only noise before rendering', () => {
+    const now = Date.now();
+    writeBacklog('kuro', [
+      {
+        id: 'expired',
+        type: 'delegation',
+        summary: 'useful but too old',
+        archivedAt: new Date(now - 4 * 24 * 3600_000).toISOString(),
+      },
+      {
+        id: 'failed-shell',
+        type: 'delegation',
+        summary: '[FAILED shell] command exited 2',
+        archivedAt: new Date(now - 60_000).toISOString(),
+      },
+      {
+        id: 'dispatch-error',
+        type: 'delegation',
+        summary: 'dispatch error: provider unavailable',
+        archivedAt: new Date(now - 50_000).toISOString(),
+      },
+      {
+        id: 'empty-output',
+        type: 'delegation',
+        summary: '(no output)',
+        archivedAt: new Date(now - 40_000).toISOString(),
+      },
+      {
+        id: 'valid',
+        type: 'delegation',
+        summary: 'review produced a useful diagnosis',
+        archivedAt: new Date(now - 30_000).toISOString(),
+      },
+    ]);
+
+    expect(getReviewBacklog('kuro').map(entry => entry.id)).toEqual(['valid']);
+  });
+});


### PR DESCRIPTION
## Summary
- supersedes #155 with only the review-backlog #83 fix, excluding unrelated correction-gate changes
- caps prompt review backlog to newest 30 entries, shortens TTL to 3 days, and filters stale failure-only noise on read
- adds PR lifecycle governance to block unscoped non-memory commits on issue-scoped PRs, so this kind of mixed autonomous branch is caught before merge

Fixes #83.
Supersedes #155.

## Verification
- pnpm exec vitest run tests/review-backlog.test.ts
- pnpm exec vitest run tests/review-backlog.test.ts tests/pr-lifecycle-governance.test.ts
- pnpm typecheck
- pnpm build

## Notes
- Full pnpm test was run and existing failures remain in delegation-arbiter/self-research-autopilot expectations unrelated to this change: phantom-prompt now rejects short prompts, and self-research tests see runtime-workspace-wrong-branch in non-runtime worktrees.