### PR TITLE
fix(janitor): delete squash-merged local branches

### DIFF
--- a/scripts/workspace-janitor.ts
+++ b/scripts/workspace-janitor.ts
@@ -28,6 +28,7 @@ const worktrees = readWorktrees();
 const protectedRoot = path.resolve(process.env.MINI_AGENT_RUNTIME_WORKSPACE ?? inferRuntimeWorkspace(root));
 
 const actions: JanitorAction[] = [];
+const removableWorktreeBranches = new Set<string>();
 
 if (path.resolve(root) === protectedRoot && !isSafeRuntimeBranch(currentBranch)) {
   actions.push({
@@ -41,6 +42,7 @@ for (const wt of worktrees) {
   if (!wt.branch) continue;
   if (path.resolve(wt.path) === protectedRoot) continue;
   if (wt.branch === base && isDisposableBaseWorktree(wt.path) && isWorktreeClean(wt.path)) {
+    removableWorktreeBranches.add(wt.branch);
     actions.push({
       type: 'remove-worktree',
       target: wt.path,
@@ -51,6 +53,7 @@ for (const wt of worktrees) {
   }
   if (openPrBranches.has(wt.branch)) continue;
   if (mergedPrBranches.has(wt.branch) && isWorktreeClean(wt.path)) {
+    removableWorktreeBranches.add(wt.branch);
     actions.push({
       type: 'remove-worktree',
       target: wt.path,
@@ -63,7 +66,7 @@ for (const wt of worktrees) {
 for (const branch of readLocalBranches()) {
   if (branch === 'runtime/main') continue;
   if (openPrBranches.has(branch)) continue;
-  if (isBranchCheckedOut(branch, worktrees)) continue;
+  if (isBranchCheckedOut(branch, worktrees) && !removableWorktreeBranches.has(branch)) continue;
   if (mergedPrBranches.has(branch) || isMergedToBase(branch, base)) {
     const githubMerged = mergedPrBranches.has(branch);
     actions.push({

--- a/tests/workspace-janitor.test.ts
+++ b/tests/workspace-janitor.test.ts
@@ -1,0 +1,76 @@
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+describe('workspace janitor', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(path.join(os.tmpdir(), 'mini-agent-workspace-janitor-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('schedules branch deletion after removing a clean squash-merged PR worktree', () => {
+    const repoDir = path.join(tmpDir, 'repo');
+    const worktreeDir = path.join(tmpDir, 'repo-fix');
+    const binDir = path.join(tmpDir, 'bin');
+    mkdirSync(repoDir);
+    mkdirSync(binDir);
+
+    git(repoDir, ['init', '-b', 'main']);
+    git(repoDir, ['config', 'user.email', 'test@example.com']);
+    git(repoDir, ['config', 'user.name', 'Test']);
+    writeFileSync(path.join(repoDir, 'README.md'), 'base\n');
+    git(repoDir, ['add', 'README.md']);
+    git(repoDir, ['commit', '-m', 'init']);
+    git(repoDir, ['branch', 'fix/squash']);
+    git(repoDir, ['worktree', 'add', worktreeDir, 'fix/squash']);
+
+    const ghPath = path.join(binDir, 'gh');
+    writeFileSync(ghPath, [
+      '#!/bin/sh',
+      'case "$*" in',
+      '  *"--state merged"*) printf \'[{"headRefName":"fix/squash"}]\\n\' ;;',
+      '  *"--state open"*) printf \'[]\\n\' ;;',
+      '  *) exit 1 ;;',
+      'esac',
+      '',
+    ].join('\n'));
+    chmodSync(ghPath, 0o755);
+
+    const out = execFileSync(path.join(process.cwd(), 'node_modules/.bin/tsx'), [path.join(process.cwd(), 'scripts/workspace-janitor.ts'), '--json'], {
+      cwd: repoDir,
+      encoding: 'utf-8',
+      env: {
+        ...process.env,
+        PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ''}`,
+        MINI_AGENT_RUNTIME_WORKSPACE: path.join(tmpDir, 'runtime'),
+      },
+    });
+    const parsed = JSON.parse(out) as { actions: Array<{ type: string; target: string; command?: string[] }> };
+
+    expect(parsed.actions).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        type: 'remove-worktree',
+        target: expect.stringContaining('repo-fix'),
+      }),
+      expect.objectContaining({
+        type: 'delete-local-branch',
+        target: 'fix/squash',
+        command: ['git', 'branch', '-D', 'fix/squash'],
+      }),
+    ]));
+    expect(parsed.actions.findIndex(action => action.type === 'remove-worktree')).toBeLessThan(
+      parsed.actions.findIndex(action => action.type === 'delete-local-branch'),
+    );
+  });
+});
+
+function git(cwd: string, args: string[]): void {
+  execFileSync('git', args, { cwd, stdio: 'ignore' });
+}


### PR DESCRIPTION
## Summary
- lets workspace janitor schedule local branch deletion in the same pass as clean merged worktree removal
- keeps force deletion scoped to branches whose PR is already merged on GitHub, covering squash merges that are not ancestors of main
- adds a regression test with a temp git repo and fake gh output

## Verification
- pnpm exec vitest run tests/workspace-janitor.test.ts
- pnpm typecheck
- pnpm build