### PR TITLE
feat(classifier): add midband_no_diag (60-599s) sub-bucket

### DIFF
--- a/src/feedback-loops.ts
+++ b/src/feedback-loops.ts
@@ -172,6 +172,12 @@ export function extractErrorSubtype(errorMsg: string): string {
     // returned quickly (overload/rate-limit pattern); distinct from genuine no_diag.
     // 61 occurrences today, all in 1-19s band — clear bimodal gap from hang_no_diag (≥600s).
     if (durMatch && Number(durMatch[1]) < 60) return 'transient_no_diag';
+    // 2026-05-06 (later same day): mid-band 60-599s = partial-stream failure
+    // (request started, response began, then errored mid-flight). Distinct from
+    // both transient (fail-fast) and hang (full timeout). Splitting this off
+    // leaves `no_diag` to mean "no dur= suffix at all" — a different class of
+    // upstream classifyError bug. count=34 in no_diag today motivated this split.
+    if (durMatch && Number(durMatch[1]) < 600) return 'midband_no_diag';
     return 'no_diag';
   }
   // 2026-04-20: agent.ts:224 silent_exit message template (shipped 3039f4a3) — complete the label


### PR DESCRIPTION
## What
Adds `midband_no_diag` for `dur=` 60-599s in `extractErrorSubtype`, completing the no_diag cascade.

## Why
`UNKNOWN:no_diag::callClaude` count=34 today. Today's earlier `transient_no_diag` (4da68cde) covered `<60s`; `hang_no_diag` covers `>=600s`. The 60-599s mid-band — partial-stream failures — was still collapsing into the opaque `no_diag` fallthrough bucket alongside truly-untagged events, so no_diag couldn't be triaged.

After this PR, no_diag means strictly "no `dur=` suffix on the error" → upstream classifyError didn't tag it → a different class of bug.

## Cascade now
| bucket | dur | meaning |
|---|---|---|
| fast_death_no_diag | <1s | auth/config |
| transient_no_diag | <60s | fail-fast / Anthropic overload |
| **midband_no_diag** | **60-599s** | **partial-stream failure (NEW)** |
| hang_no_diag | >=600s | full timeout |
| no_diag | (no dur=) | upstream classifyError gap |

## Migration
Existing today-entries auto-reclassify through the orphan-key drop in `detectErrorPatterns` (lines 241-247) — old `UNKNOWN:no_diag::callClaude` count adjusts naturally as new buckets emerge.

## Supersedes
Unmerged `kuro/medium-no-diag-bucket` (66bb6dfe) used different boundaries (`medium_no_diag` for `>=1s`) before `transient_no_diag` (4da68cde) shipped — that branch is now stale.

## Verification
- [x] tsc clean on changed file
- [ ] Wait one detect cycle; verify `midband_no_diag` keys appear in `error-patterns.json` and old `no_diag` count drops