### PR TITLE
fix(runtime): autocorrect protected checkout drift

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "janitor:workspaces": "tsx scripts/workspace-janitor.ts",
     "janitor:workspaces:apply": "tsx scripts/workspace-janitor.ts --apply",
     "check:runtime-workspace": "tsx scripts/check-runtime-workspace.ts",
+    "autocorrect:runtime-workspace": "tsx scripts/runtime-workspace-autocorrect.ts",
     "setup:external-memory": "tsx scripts/setup-external-memory.ts",
     "memory:repo:setup": "tsx scripts/setup-memory-repo.ts --init",
     "memory:repo:check": "tsx scripts/setup-memory-repo.ts --check",

--- a/scripts/runtime-workspace-autocorrect.ts
+++ b/scripts/runtime-workspace-autocorrect.ts
@@ -1,0 +1,34 @@
+#!/usr/bin/env tsx
+import { autocorrectRuntimeWorkspace } from '../src/runtime-workspace-autocorrect.js';
+
+const apply = process.argv.includes('--apply');
+const json = process.argv.includes('--json');
+const repoArg = readArg('--repo');
+const baseArg = readArg('--base');
+const noPr = process.argv.includes('--no-pr');
+
+const result = autocorrectRuntimeWorkspace(process.cwd(), {
+  apply,
+  repo: repoArg,
+  baseBranch: baseArg,
+  createPr: !noPr,
+});
+
+if (json) {
+  process.stdout.write(JSON.stringify({ apply, result }, null, 2) + '\n');
+} else {
+  process.stdout.write(`[runtime-autocorrect] status=${result.status} reason=${result.reason}\n`);
+  if (result.branch) process.stdout.write(`[runtime-autocorrect] branch=${result.branch}\n`);
+  if (result.worktree) process.stdout.write(`[runtime-autocorrect] worktree=${result.worktree}\n`);
+  if (result.prUrl) process.stdout.write(`[runtime-autocorrect] pr=${result.prUrl}\n`);
+}
+
+if (result.status === 'failed' || result.status === 'blocked') process.exit(1);
+
+function readArg(name: string): string | undefined {
+  const argv = process.argv.slice(2);
+  const index = argv.indexOf(name);
+  if (index >= 0) return argv[index + 1];
+  const prefix = `${name}=`;
+  return argv.find(arg => arg.startsWith(prefix))?.slice(prefix.length);
+}

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -1111,6 +1111,13 @@ async function execClaude(fullPrompt: string, opts?: ExecOptions): Promise<strin
         if (slot) slot.pid = null;
       }
       chatStreamParser?.end();
+      // Issue #77 diagnostic: capture spawn-level error attributes to disambiguate
+      // silent_exit_void modes (CLI internal stall ~260s vs HTTP timeout ~1000s).
+      const _eDur = Date.now() - startTs;
+      const _ec = (err as { code?: string }).code;
+      const _en = (err as { errno?: number | string }).errno;
+      const _es = (err as { syscall?: string }).syscall;
+      slog('CLAUDE', `spawn-error after ${Math.round(_eDur/1000)}s code=${_ec ?? 'n/a'} errno=${_en ?? 'n/a'} syscall=${_es ?? 'n/a'} toolCalls=${toolCallCount} msg="${(err.message || '').slice(0, 200).replace(/\n/g, ' ')}"`);
       // Forensic flush — spawn-level error (fork failure, etc). Fail-open.
       try {
         const now = Date.now();

--- a/src/correction-gate.ts
+++ b/src/correction-gate.ts
@@ -198,13 +198,28 @@ export async function ensureCorrectionTask(memoryDir: string, snapshot = evaluat
   const primary = snapshot.reasons.find(r => r.severity === 'high') ?? snapshot.reasons[0];
   if (!primary) return null;
 
+  const runtimeAutocorrect = primary.type === 'local-commit-not-pushed'
+    ? [
+      'Run runtime autocorrect before manual edits: `pnpm exec tsx scripts/runtime-workspace-autocorrect.ts --apply`.',
+      'Expected loop: preserve change in isolated worktree branch, open PR, review, merge, deploy, and confirm runtime/main is clean.',
+    ].join(' ')
+    : primary.type === 'dirty-runtime-workspace'
+      ? [
+        'Do not edit protected runtime checkout directly.',
+        'Move the change into an isolated worktree/PR, then clean runtime/main and verify `git status --short --branch` is clean.',
+      ].join(' ')
+      : '';
+
   const task = await createTask(memoryDir, {
     title: `P0 correction gate: resolve ${primary.type}`,
     origin: 'scheduler',
     priority: 0,
-    verify_command: 'pnpm typecheck && pnpm test',
+    verify_command: primary.type === 'local-commit-not-pushed'
+      ? 'pnpm exec tsx scripts/runtime-workspace-autocorrect.ts --apply && pnpm typecheck && pnpm test'
+      : 'pnpm typecheck && pnpm test',
     acceptance_criteria: [
       primary.message,
+      runtimeAutocorrect,
       'Resolve the active correction reason or write a falsifiable blocker.',
       `Current suppressed actions: ${snapshot.suppressedActions.join(', ') || 'none'}.`,
       `Ship truth state: ${snapshot.shipTruth.state}.`,

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -2246,7 +2246,20 @@ export class AgentLoop {
       } catch { /* non-critical */ }
       try {
         const { closeResolvedCorrectionTasks, evaluateCorrectionGate, ensureCorrectionTask } = await import('./correction-gate.js');
-        const correction = evaluateCorrectionGate(memDir);
+        let correction = evaluateCorrectionGate(memDir);
+        if (
+          correction.shipTruth.state === 'pending-push' &&
+          process.env.MINI_AGENT_AUTOCORRECT_RUNTIME_WORKSPACE !== '0'
+        ) {
+          try {
+            const { autocorrectRuntimeWorkspace } = await import('./runtime-workspace-autocorrect.js');
+            const result = autocorrectRuntimeWorkspace(process.cwd(), { apply: true });
+            slog('CORRECTION', `runtime autocorrect ${result.status}: ${result.reason}${result.prUrl ? ` ${result.prUrl}` : ''}`);
+            correction = evaluateCorrectionGate(memDir);
+          } catch (e) {
+            slog('WARN', `runtime autocorrect failed: ${e}`);
+          }
+        }
         if (correction.needsCorrection) {
           const correctionTask = await ensureCorrectionTask(memDir, correction);
           slog('CORRECTION', `active reasons=${correction.reasons.map(r => r.type).join(',')} task=${correctionTask?.id.slice(0, 12) ?? 'existing'}`);

--- a/src/runtime-workspace-autocorrect.ts
+++ b/src/runtime-workspace-autocorrect.ts
@@ -1,0 +1,182 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync } from 'node:fs';
+import path from 'node:path';
+import { isSafeRuntimeBranch } from './workspace-isolation.js';
+
+export type RuntimeAutocorrectStatus =
+  | 'not-needed'
+  | 'created-pr'
+  | 'created-worktree'
+  | 'blocked'
+  | 'failed';
+
+export interface RuntimeAutocorrectResult {
+  status: RuntimeAutocorrectStatus;
+  reason: string;
+  branch?: string;
+  worktree?: string;
+  prUrl?: string;
+  resetRuntime?: boolean;
+}
+
+interface GitSnapshot {
+  branch: string | null;
+  headSha: string | null;
+  ahead: number;
+  behind: number;
+  dirty: boolean;
+}
+
+export function autocorrectRuntimeWorkspace(repoRoot = process.cwd(), opts: {
+  apply?: boolean;
+  repo?: string;
+  baseBranch?: string;
+  worktreeParent?: string;
+  createPr?: boolean;
+} = {}): RuntimeAutocorrectResult {
+  const root = path.resolve(repoRoot);
+  const baseBranch = opts.baseBranch ?? 'main';
+  const repo = opts.repo ?? process.env.MINI_AGENT_GITHUB_REPO ?? 'miles990/mini-agent';
+  const snapshot = readGitSnapshot(root);
+
+  if (!snapshot) return { status: 'not-needed', reason: 'not a git repository' };
+  if (!isSafeRuntimeBranch(snapshot.branch)) {
+    return {
+      status: 'blocked',
+      reason: `runtime checkout is on ${snapshot.branch ?? 'unknown'}; expected runtime/main before autocorrect`,
+    };
+  }
+  if (snapshot.behind > 0) {
+    return {
+      status: 'blocked',
+      reason: `runtime checkout is behind origin/${baseBranch}; sync base before autocorrect`,
+    };
+  }
+  if (snapshot.dirty) {
+    return {
+      status: 'blocked',
+      reason: 'runtime checkout has uncommitted changes; preserve them manually or commit before autocorrect',
+    };
+  }
+  if (snapshot.ahead <= 0) return { status: 'not-needed', reason: 'runtime checkout is clean' };
+  if (!snapshot.headSha) return { status: 'failed', reason: 'could not read runtime HEAD sha' };
+
+  const shortSha = snapshot.headSha.slice(0, 8);
+  const branch = `fix/runtime-autocorrect-${shortSha}`;
+  const worktreeParent = path.resolve(opts.worktreeParent ?? path.dirname(root));
+  const worktree = path.join(worktreeParent, `${path.basename(root)}-autocorrect-${shortSha}`);
+
+  if (!opts.apply) {
+    return {
+      status: 'created-worktree',
+      reason: `would move ${snapshot.ahead} runtime-local commit(s) to ${branch}`,
+      branch,
+      worktree,
+      resetRuntime: true,
+    };
+  }
+
+  try {
+    git(root, ['fetch', 'origin', baseBranch]);
+    ensureWorktree(root, worktree, branch, `origin/${baseBranch}`);
+    git(worktree, ['cherry-pick', `origin/${baseBranch}..${snapshot.headSha}`]);
+    git(worktree, ['push', '-u', 'origin', branch]);
+    let prUrl: string | undefined;
+    if (opts.createPr ?? true) {
+      prUrl = createPullRequest(worktree, repo, baseBranch, branch, snapshot.ahead);
+    }
+    git(root, ['reset', '--hard', `origin/${baseBranch}`]);
+    return {
+      status: prUrl ? 'created-pr' : 'created-worktree',
+      reason: `moved ${snapshot.ahead} runtime-local commit(s) out of protected checkout`,
+      branch,
+      worktree,
+      prUrl,
+      resetRuntime: true,
+    };
+  } catch (error) {
+    return {
+      status: 'failed',
+      reason: error instanceof Error ? error.message.split('\n')[0] : String(error),
+      branch,
+      worktree,
+    };
+  }
+}
+
+function readGitSnapshot(repoRoot: string): GitSnapshot | null {
+  if (!existsSync(path.join(repoRoot, '.git'))) return null;
+  const status = git(repoRoot, ['status', '--porcelain=v2', '--branch']);
+  let branch: string | null = null;
+  let headSha: string | null = null;
+  let ahead = 0;
+  let behind = 0;
+  let dirty = false;
+  for (const line of status.split('\n')) {
+    if (line.startsWith('# branch.head ')) branch = line.slice('# branch.head '.length).trim();
+    if (line.startsWith('# branch.oid ')) {
+      const oid = line.slice('# branch.oid '.length).trim();
+      headSha = oid && oid !== '(initial)' ? oid : null;
+    }
+    if (line.startsWith('# branch.ab ')) {
+      ahead = Number(line.match(/\+(\d+)/)?.[1] ?? 0);
+      behind = Number(line.match(/-(\d+)/)?.[1] ?? 0);
+    }
+    if (line && !line.startsWith('#')) dirty = true;
+  }
+  return { branch, headSha, ahead, behind, dirty };
+}
+
+function ensureWorktree(repoRoot: string, worktree: string, branch: string, baseRef: string): void {
+  if (existsSync(worktree)) {
+    const existingBranch = safeGit(worktree, ['rev-parse', '--abbrev-ref', 'HEAD']);
+    if (existingBranch === branch) return;
+    throw new Error(`autocorrect worktree already exists with branch ${existingBranch ?? 'unknown'}: ${worktree}`);
+  }
+  mkdirSync(path.dirname(worktree), { recursive: true });
+  git(repoRoot, ['worktree', 'add', worktree, '-b', branch, baseRef]);
+}
+
+function createPullRequest(worktree: string, repo: string, baseBranch: string, branch: string, ahead: number): string | undefined {
+  const title = `fix(runtime): preserve local runtime commit ${branch.replace('fix/runtime-autocorrect-', '')}`;
+  const body = [
+    '## Summary',
+    `- autocorrected ${ahead} commit(s) that were made on protected runtime/main`,
+    '- moved the change into an isolated worktree branch so review/merge/deploy can proceed normally',
+    '- reset the runtime checkout back to origin/main after preserving the change',
+    '',
+    '## Verification',
+    '- pending isolated PR review',
+  ].join('\n');
+  const out = execFileSync('gh', [
+    'pr', 'create',
+    '--repo', repo,
+    '--base', baseBranch,
+    '--head', branch,
+    '--title', title,
+    '--body', body,
+  ], {
+    cwd: worktree,
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    timeout: 30_000,
+  }).trim();
+  return out || undefined;
+}
+
+function safeGit(cwd: string, args: string[]): string | null {
+  try {
+    return git(cwd, args).trim();
+  } catch {
+    return null;
+  }
+}
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync('git', args, {
+    cwd,
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    timeout: 60_000,
+  }).trim();
+}

--- a/tests/runtime-workspace-autocorrect.test.ts
+++ b/tests/runtime-workspace-autocorrect.test.ts
@@ -1,0 +1,78 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { autocorrectRuntimeWorkspace } from '../src/runtime-workspace-autocorrect.js';
+
+describe('runtime workspace autocorrect', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(path.join(os.tmpdir(), 'mini-agent-runtime-autocorrect-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('moves runtime-local commits into an isolated worktree branch and resets runtime', () => {
+    const remote = path.join(tmpDir, 'remote.git');
+    const repo = path.join(tmpDir, 'mini-agent');
+    git(tmpDir, ['init', '--bare', remote]);
+    git(tmpDir, ['clone', remote, repo]);
+    git(repo, ['config', 'user.email', 'test@example.com']);
+    git(repo, ['config', 'user.name', 'Test User']);
+    writeFileSync(path.join(repo, 'README.md'), 'base\n');
+    git(repo, ['add', 'README.md']);
+    git(repo, ['commit', '-m', 'init']);
+    git(repo, ['branch', '-M', 'runtime/main']);
+    git(repo, ['push', '-u', 'origin', 'runtime/main:main']);
+    git(repo, ['fetch', 'origin', 'main']);
+    git(repo, ['branch', '--set-upstream-to=origin/main', 'runtime/main']);
+
+    writeFileSync(path.join(repo, 'README.md'), 'base\nruntime local\n');
+    git(repo, ['commit', '-am', 'diag: runtime local change']);
+    const localHead = gitOut(repo, ['rev-parse', 'HEAD']);
+
+    const result = autocorrectRuntimeWorkspace(repo, {
+      apply: true,
+      createPr: false,
+      worktreeParent: tmpDir,
+    });
+
+    expect(result).toEqual(expect.objectContaining({
+      status: 'created-worktree',
+      resetRuntime: true,
+    }));
+    expect(result.branch).toBe(`fix/runtime-autocorrect-${localHead.slice(0, 8)}`);
+    expect(gitOut(repo, ['rev-parse', 'HEAD'])).toBe(gitOut(repo, ['rev-parse', 'origin/main']));
+    expect(gitOut(repo, ['status', '--short', '--branch'])).toContain('runtime/main...origin/main');
+    expect(gitOut(result.worktree!, ['rev-parse', 'HEAD'])).toBe(localHead);
+  });
+
+  it('blocks when runtime checkout has uncommitted changes', () => {
+    const repo = path.join(tmpDir, 'repo');
+    git(tmpDir, ['init', '-b', 'runtime/main', repo]);
+    git(repo, ['config', 'user.email', 'test@example.com']);
+    git(repo, ['config', 'user.name', 'Test User']);
+    writeFileSync(path.join(repo, 'README.md'), 'base\n');
+    git(repo, ['add', 'README.md']);
+    git(repo, ['commit', '-m', 'init']);
+    writeFileSync(path.join(repo, 'README.md'), 'dirty\n');
+
+    expect(autocorrectRuntimeWorkspace(repo, { apply: true })).toEqual(expect.objectContaining({
+      status: 'blocked',
+      reason: expect.stringContaining('uncommitted changes'),
+    }));
+  });
+});
+
+function git(cwd: string, args: string[]): void {
+  execFileSync('git', args, { cwd, stdio: 'ignore' });
+}
+
+function gitOut(cwd: string, args: string[]): string {
+  return execFileSync('git', args, { cwd, encoding: 'utf-8' }).trim();
+}


### PR DESCRIPTION
## Summary
- preserve the runtime-local spawn-error diagnostic commit by moving it into this isolated PR
- add runtime workspace autocorrect: pending-push runtime/main commits are moved into an isolated worktree branch, pushed as PR, then runtime/main is reset to origin/main
- wire the correction gate loop to run autocorrect automatically for pending-push ship truth, and make P0 correction tasks point at the same command

Refs #77.

## Verification
- pnpm exec vitest run tests/runtime-workspace-autocorrect.test.ts tests/correction-gate.test.ts
- pnpm typecheck
- pnpm build

## Operational effect
- protected runtime checkout should stay clean after accidental local commits
- future local runtime commits become normal PR work instead of lingering as hidden deployment drift