### PR TITLE
fix(runtime): autocorrect tracked workspace dirt

### DIFF
--- a/src/runtime-workspace-autocorrect.ts
+++ b/src/runtime-workspace-autocorrect.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process';
-import { existsSync, mkdirSync } from 'node:fs';
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { isSafeRuntimeBranch } from './workspace-isolation.js';
 
@@ -25,6 +25,7 @@ interface GitSnapshot {
   ahead: number;
   behind: number;
   dirty: boolean;
+  hasUntracked: boolean;
 }
 
 export function autocorrectRuntimeWorkspace(repoRoot = process.cwd(), opts: {
@@ -52,16 +53,17 @@ export function autocorrectRuntimeWorkspace(repoRoot = process.cwd(), opts: {
       reason: `runtime checkout is behind origin/${baseBranch}; sync base before autocorrect`,
     };
   }
-  if (snapshot.dirty) {
+  const mode = snapshot.ahead > 0 ? 'commits' : snapshot.dirty ? 'tracked-dirty' : 'clean';
+  if (snapshot.dirty && snapshot.hasUntracked) {
     return {
       status: 'blocked',
-      reason: 'runtime checkout has uncommitted changes; preserve them manually or commit before autocorrect',
+      reason: 'runtime checkout has untracked changes; commit, move, or ignore them before autocorrect',
     };
   }
-  if (snapshot.ahead <= 0) return { status: 'not-needed', reason: 'runtime checkout is clean' };
+  if (mode === 'clean') return { status: 'not-needed', reason: 'runtime checkout is clean' };
   if (!snapshot.headSha) return { status: 'failed', reason: 'could not read runtime HEAD sha' };
 
-  const shortSha = snapshot.headSha.slice(0, 8);
+  const shortSha = mode === 'tracked-dirty' ? `dirty-${Date.now().toString(36)}` : snapshot.headSha.slice(0, 8);
   const branch = `fix/runtime-autocorrect-${shortSha}`;
   const worktreeParent = path.resolve(opts.worktreeParent ?? path.dirname(root));
   const worktree = path.join(worktreeParent, `${path.basename(root)}-autocorrect-${shortSha}`);
@@ -69,7 +71,9 @@ export function autocorrectRuntimeWorkspace(repoRoot = process.cwd(), opts: {
   if (!opts.apply) {
     return {
       status: 'created-worktree',
-      reason: `would move ${snapshot.ahead} runtime-local commit(s) to ${branch}`,
+      reason: mode === 'tracked-dirty'
+        ? `would move tracked runtime dirt to ${branch}`
+        : `would move ${snapshot.ahead} runtime-local commit(s) to ${branch}`,
       branch,
       worktree,
       resetRuntime: true,
@@ -79,7 +83,11 @@ export function autocorrectRuntimeWorkspace(repoRoot = process.cwd(), opts: {
   try {
     git(root, ['fetch', 'origin', baseBranch]);
     ensureWorktree(root, worktree, branch, `origin/${baseBranch}`);
-    git(worktree, ['cherry-pick', `origin/${baseBranch}..${snapshot.headSha}`]);
+    if (mode === 'tracked-dirty') {
+      moveTrackedDirtyToWorktree(root, worktree);
+    } else {
+      git(worktree, ['cherry-pick', `origin/${baseBranch}..${snapshot.headSha}`]);
+    }
     git(worktree, ['push', '-u', 'origin', branch]);
     let prUrl: string | undefined;
     if (opts.createPr ?? true) {
@@ -88,7 +96,9 @@ export function autocorrectRuntimeWorkspace(repoRoot = process.cwd(), opts: {
     git(root, ['reset', '--hard', `origin/${baseBranch}`]);
     return {
       status: prUrl ? 'created-pr' : 'created-worktree',
-      reason: `moved ${snapshot.ahead} runtime-local commit(s) out of protected checkout`,
+      reason: mode === 'tracked-dirty'
+        ? 'moved tracked runtime dirt out of protected checkout'
+        : `moved ${snapshot.ahead} runtime-local commit(s) out of protected checkout`,
       branch,
       worktree,
       prUrl,
@@ -112,6 +122,7 @@ function readGitSnapshot(repoRoot: string): GitSnapshot | null {
   let ahead = 0;
   let behind = 0;
   let dirty = false;
+  let hasUntracked = false;
   for (const line of status.split('\n')) {
     if (line.startsWith('# branch.head ')) branch = line.slice('# branch.head '.length).trim();
     if (line.startsWith('# branch.oid ')) {
@@ -122,9 +133,12 @@ function readGitSnapshot(repoRoot: string): GitSnapshot | null {
       ahead = Number(line.match(/\+(\d+)/)?.[1] ?? 0);
       behind = Number(line.match(/-(\d+)/)?.[1] ?? 0);
     }
-    if (line && !line.startsWith('#')) dirty = true;
+    if (line && !line.startsWith('#')) {
+      dirty = true;
+      if (line.startsWith('? ')) hasUntracked = true;
+    }
   }
-  return { branch, headSha, ahead, behind, dirty };
+  return { branch, headSha, ahead, behind, dirty, hasUntracked };
 }
 
 function ensureWorktree(repoRoot: string, worktree: string, branch: string, baseRef: string): void {
@@ -164,6 +178,15 @@ function createPullRequest(worktree: string, repo: string, baseBranch: string, b
   return out || undefined;
 }
 
+function moveTrackedDirtyToWorktree(repoRoot: string, worktree: string): void {
+  const patch = gitRaw(repoRoot, ['diff', '--binary', 'HEAD']);
+  if (!patch.trim()) throw new Error('runtime dirty state has no tracked diff to preserve');
+  const patchPath = path.join(worktree, '.runtime-autocorrect.patch');
+  writeFileSync(patchPath, patch, 'utf-8');
+  git(worktree, ['apply', '--index', patchPath]);
+  git(worktree, ['commit', '-m', 'fix(runtime): preserve tracked runtime workspace changes']);
+}
+
 function safeGit(cwd: string, args: string[]): string | null {
   try {
     return git(cwd, args).trim();
@@ -173,10 +196,14 @@ function safeGit(cwd: string, args: string[]): string | null {
 }
 
 function git(cwd: string, args: string[]): string {
+  return gitRaw(cwd, args).trim();
+}
+
+function gitRaw(cwd: string, args: string[]): string {
   return execFileSync('git', args, {
     cwd,
     encoding: 'utf-8',
     stdio: ['ignore', 'pipe', 'pipe'],
     timeout: 60_000,
-  }).trim();
+  });
 }

--- a/tests/runtime-workspace-autocorrect.test.ts
+++ b/tests/runtime-workspace-autocorrect.test.ts
@@ -52,19 +52,49 @@ describe('runtime workspace autocorrect', () => {
     expect(gitOut(result.worktree!, ['rev-parse', 'HEAD'])).toBe(localHead);
   });
 
-  it('blocks when runtime checkout has uncommitted changes', () => {
-    const repo = path.join(tmpDir, 'repo');
+  it('moves tracked runtime dirt into an isolated worktree branch and resets runtime', () => {
+    const remote = path.join(tmpDir, 'dirty-remote.git');
+    const repo = path.join(tmpDir, 'dirty-mini-agent');
+    git(tmpDir, ['init', '--bare', remote]);
+    git(tmpDir, ['clone', remote, repo]);
+    git(repo, ['config', 'user.email', 'test@example.com']);
+    git(repo, ['config', 'user.name', 'Test User']);
+    writeFileSync(path.join(repo, 'README.md'), 'base\n');
+    git(repo, ['add', 'README.md']);
+    git(repo, ['commit', '-m', 'init']);
+    git(repo, ['branch', '-M', 'runtime/main']);
+    git(repo, ['push', '-u', 'origin', 'runtime/main:main']);
+    git(repo, ['fetch', 'origin', 'main']);
+    git(repo, ['branch', '--set-upstream-to=origin/main', 'runtime/main']);
+
+    writeFileSync(path.join(repo, 'README.md'), 'base\ntracked dirty\n');
+
+    const result = autocorrectRuntimeWorkspace(repo, {
+      apply: true,
+      createPr: false,
+      worktreeParent: tmpDir,
+    });
+
+    expect(result.status).toBe('created-worktree');
+    expect(gitOut(repo, ['rev-parse', 'HEAD'])).toBe(gitOut(repo, ['rev-parse', 'origin/main']));
+    expect(gitOut(repo, ['status', '--short', '--branch'])).toContain('runtime/main...origin/main');
+    expect(gitOut(result.worktree!, ['show', '--format=', '--name-only', 'HEAD'])).toContain('README.md');
+    expect(gitOut(result.worktree!, ['show', 'HEAD:README.md'])).toContain('tracked dirty');
+  });
+
+  it('blocks when runtime checkout has untracked changes', () => {
+    const repo = path.join(tmpDir, 'repo-untracked');
     git(tmpDir, ['init', '-b', 'runtime/main', repo]);
     git(repo, ['config', 'user.email', 'test@example.com']);
     git(repo, ['config', 'user.name', 'Test User']);
     writeFileSync(path.join(repo, 'README.md'), 'base\n');
     git(repo, ['add', 'README.md']);
     git(repo, ['commit', '-m', 'init']);
-    writeFileSync(path.join(repo, 'README.md'), 'dirty\n');
+    writeFileSync(path.join(repo, 'new-file.txt'), 'untracked\n');
 
     expect(autocorrectRuntimeWorkspace(repo, { apply: true })).toEqual(expect.objectContaining({
       status: 'blocked',
-      reason: expect.stringContaining('uncommitted changes'),
+      reason: expect.stringContaining('untracked changes'),
     }));
   });
 });


### PR DESCRIPTION
## Summary
- extend runtime workspace autocorrect beyond pending local commits
- move tracked uncommitted runtime dirt into an isolated worktree branch using a binary patch, commit it, push PR, then reset runtime/main to origin/main
- keep untracked files blocked so autocorrect does not delete or guess ownership of unknown files

## Verification
- pnpm exec vitest run tests/runtime-workspace-autocorrect.test.ts tests/correction-gate.test.ts
- pnpm typecheck
- pnpm build