### PR TITLE
fix: close abandoned PR review handoffs

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -8,7 +8,8 @@
  * 4. autoTrackPrReviewNeeds — PR without reviewer signal → handoffs/active.md + inbox
  * 5. autoTrackPrReviewConsensus — review claims → handoff consensus status
  * 6. autoTrackMergedPrClosures — merged PR → close handoff loop
- * 7. autoTrackNewIssues — 新 issue → handoffs/active.md
+ * 7. autoTrackAbandonedPrClosures — closed/unmerged PR → close stale review handoffs
+ * 8. autoTrackNewIssues — 新 issue → handoffs/active.md
  *
  * 全部 try-catch 靜默失敗，不影響 OODA cycle。
  */
@@ -22,6 +23,7 @@ import { promisify } from 'node:util';
 import { slog } from './utils.js';
 import { writeInboxItem } from './inbox.js';
 import {
+  closeAbandonedPrHandoffs,
   closeMergedPrHandoffs,
   decidePrReviewAssignment,
   decidePrConflictAction,
@@ -752,6 +754,53 @@ function isRecentlyMerged(mergedAt?: string | null): boolean {
 }
 
 // =============================================================================
+// 9. Closed/unmerged PR → close stale review handoff loop
+// =============================================================================
+
+interface PrClosureView {
+  number: number;
+  title: string;
+  state: string;
+  closedAt?: string | null;
+  mergedAt?: string | null;
+}
+
+export async function autoTrackAbandonedPrClosures(): Promise<void> {
+  const activePath = resolveMemoryPath('handoffs', 'active.md');
+  if (!fs.existsSync(activePath)) return;
+
+  let activeContent: string;
+  try {
+    activeContent = fs.readFileSync(activePath, 'utf-8');
+  } catch {
+    return;
+  }
+
+  const handoffs = parsePrReviewHandoffs(activeContent);
+  const prNumbers = [...new Set(handoffs.map(h => h.prNumber))].slice(0, 20);
+  if (prNumbers.length === 0) return;
+
+  const closed: PrClosureView[] = [];
+  for (const prNumber of prNumbers) {
+    try {
+      const { stdout } = await gh(['pr', 'view', String(prNumber), '--json', 'number,title,state,closedAt,mergedAt'], 10000);
+      const pr = JSON.parse(stdout) as PrClosureView;
+      if (pr.state === 'CLOSED' && !pr.mergedAt) closed.push(pr);
+    } catch {
+      // Best-effort janitor: one failed lookup should not stop the cycle.
+    }
+  }
+  if (closed.length === 0) return;
+
+  const today = new Date().toISOString().slice(5, 10);
+  const result = closeAbandonedPrHandoffs(activeContent, closed, today);
+  if (result.content !== activeContent) {
+    fs.writeFileSync(activePath, result.content, 'utf-8');
+    slog('github', `closed ${result.updated} abandoned PR review handoff(s)`);
+  }
+}
+
+// =============================================================================
 // 7. 新 issue → handoffs/active.md
 // =============================================================================
 
@@ -831,6 +880,7 @@ export async function githubAutoActions(): Promise<void> {
   await autoMergeInternallyApprovedPR().catch(() => {});
   await autoHandleConflictingPRs().catch(() => {});
   await autoTrackMergedPrClosures().catch(() => {});
+  await autoTrackAbandonedPrClosures().catch(() => {});
   await autoTrackNewIssues().catch(() => {});
 }
 

--- a/src/pr-lifecycle-governance.ts
+++ b/src/pr-lifecycle-governance.ts
@@ -321,6 +321,47 @@ export function closeMergedPrHandoffs(
   return { content: content + '\n', updated, appended };
 }
 
+export function closeAbandonedPrHandoffs(
+  activeContent: string,
+  prs: Array<{ number: number; title: string }>,
+  today: string,
+): HandoffClosureResult {
+  let content = activeContent.trimEnd();
+  let updated = 0;
+  let appended = 0;
+
+  for (const pr of prs) {
+    const marker = `PR #${pr.number}`;
+    const lines = content.split('\n');
+    let found = false;
+
+    const nextLines = lines.map(line => {
+      if (!line.includes(marker) || !line.trim().startsWith('|')) return line;
+      found = true;
+
+      const cols = line.split('|');
+      if (cols.length < 8) return line;
+
+      const status = cols[4].trim().toLowerCase();
+      const done = cols[6].trim();
+      if (['done', 'merged', 'completed', 'closed', 'abandoned'].includes(status) && done !== '-' && done !== '—') return line;
+
+      cols[4] = ' closed ';
+      cols[6] = ` ${today} `;
+      updated++;
+      return cols.join('|');
+    });
+
+    content = nextLines.join('\n');
+    if (!found) {
+      content += `\n| github | kuro | ${marker} ${escapeHandoffTableText(pr.title)} | closed | ${today} | ${today} |`;
+      appended++;
+    }
+  }
+
+  return { content: content + '\n', updated, appended };
+}
+
 export function decidePrConflictAction(pr: PrConflictInput): PrConflictDecision {
   const labels = new Set((pr.labels ?? []).map(l => l.toLowerCase()));
   if (pr.mergeable !== 'CONFLICTING') {

--- a/tests/pr-lifecycle-governance.test.ts
+++ b/tests/pr-lifecycle-governance.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   analyzeBranchLifecycle,
+  closeAbandonedPrHandoffs,
   closeMergedPrHandoffs,
   decidePrConflictAction,
   decidePrReviewAssignment,
@@ -254,6 +255,26 @@ describe('PR lifecycle governance', () => {
     expect(result.content).toContain('| github | akari | PR #98 fix: gate PR branch scope contamination | merged | 05-06 | 05-07 |');
     expect(result.content).toContain('| github | codex | PR #98 fix: gate PR branch scope contamination | merged | 05-06 | 05-07 |');
     expect(result.content).toContain('| github | kuro | PR #99 fix: another / task | merged | 05-07 | 05-07 |');
+  });
+
+  it('closes abandoned PR review handoff rows', () => {
+    const active = [
+      '# Active Handoffs',
+      '',
+      '| From | To | Task | Status | Created | Done |',
+      '|------|----|------|--------|---------|------|',
+      '| github | codex | PR #155 fix(memory): old follow-up | changes-requested | 05-06 | - |',
+      '| github | claude-code | PR #155 fix(memory): old follow-up | changes-requested | 05-06 | - |',
+    ].join('\n');
+
+    const result = closeAbandonedPrHandoffs(active, [
+      { number: 155, title: 'fix(memory): old follow-up' },
+    ], '05-07');
+
+    expect(result.updated).toBe(2);
+    expect(result.appended).toBe(0);
+    expect(result.content).toContain('| github | codex | PR #155 fix(memory): old follow-up | closed | 05-06 | 05-07 |');
+    expect(result.content).toContain('| github | claude-code | PR #155 fix(memory): old follow-up | closed | 05-06 | 05-07 |');
   });
 
   it('attempts branch update for approved narrow verified conflicts', () => {


### PR DESCRIPTION
## Summary
- mark closed/unmerged PR review handoffs as closed so stale review rows do not permanently block autonomy closure health
- wire the abandoned PR handoff janitor into GitHub automation
- add lifecycle test coverage

## Verification
- pnpm exec vitest run tests/pr-lifecycle-governance.test.ts tests/autonomy-closure-health.test.ts
- pnpm typecheck
- pnpm build

Refs #83