### PR TITLE
fix: refresh autonomy closure repair tasks

### DIFF
--- a/src/autonomy-closure-health.ts
+++ b/src/autonomy-closure-health.ts
@@ -105,10 +105,30 @@ export async function ensureAutonomyClosureTask(
     type: ['task'],
     status: ACTIVE_STATUSES,
   }).find(isAutonomyClosureTask);
-  if (existing) return existing;
 
   const recommendation = snapshot.recommendedTask;
   if (!recommendation) return null;
+
+  if (existing) {
+    const refreshed = await updateMemoryIndexEntry(memoryDir, existing.id, {
+      summary: recommendation.title,
+      payload: {
+        ...((existing.payload ?? {}) as Record<string, unknown>),
+        origin: AUTONOMY_CLOSURE_ORIGIN,
+        priority: recommendation.priority,
+        assignee: 'kuro',
+        verify_command: recommendation.verifyCommand,
+        acceptance_criteria: recommendation.acceptanceCriteria,
+        closure_status: snapshot.status,
+        closure_score: snapshot.score,
+        blocking_stages: snapshot.blockingStages,
+        warning_stages: snapshot.warningStages,
+        closure_refreshed_at: new Date().toISOString(),
+      },
+      tags: ['autonomy-closure', snapshot.status],
+    });
+    return refreshed ?? existing;
+  }
 
   const task = await createTask(memoryDir, {
     title: recommendation.title,

--- a/tests/autonomy-closure-health.test.ts
+++ b/tests/autonomy-closure-health.test.ts
@@ -98,4 +98,50 @@ describe('autonomy closure health', () => {
     expect(closed).toHaveLength(1);
     expect(queryMemoryIndexSync(tmpDir, { id: 'idx-existing', limit: 1 })[0].status).toBe('completed');
   });
+
+  it('refreshes an existing repair task with the latest closure snapshot', async () => {
+    writeFileSync(
+      path.join(tmpDir, 'state/task-events.jsonl'),
+      [
+        JSON.stringify({
+          id: 'idx-existing',
+          ts: '2026-05-07T00:00:00.000Z',
+          type: 'task',
+          status: 'pending',
+          summary: 'P0 autonomy closure: repair old-stage',
+          refs: [],
+          tags: ['autonomy-closure'],
+          payload: {
+            origin: 'autonomy-closure',
+            priority: 0,
+            acceptance_criteria: 'old stale blocker',
+          },
+        }),
+        JSON.stringify({
+          id: 'idx-exhausted',
+          ts: '2026-05-07T00:00:00.000Z',
+          type: 'task',
+          status: 'hold',
+          summary: 'P1 failing autonomous issue repair',
+          refs: [],
+          payload: {
+            origin: 'github-issue',
+            priority: 1,
+            verify_command: 'pnpm test',
+            auto_executor_failures: 3,
+          },
+        }),
+      ].join('\n') + '\n',
+      'utf-8',
+    );
+    writeFileSync(path.join(tmpDir, 'index/relations.jsonl'), '', 'utf-8');
+
+    const snapshot = evaluateAutonomyClosure(tmpDir, { repoRoot });
+    const task = await ensureAutonomyClosureTask(tmpDir, snapshot);
+
+    expect(task?.id).toBe('idx-existing');
+    expect(task?.summary).toBe('P0 autonomy closure: repair task-execution');
+    expect(task?.payload?.acceptance_criteria).toContain('1 task(s) exhausted autonomous retries');
+    expect(task?.payload?.closure_refreshed_at).toEqual(expect.any(String));
+  });
 });


### PR DESCRIPTION
## Summary
- refresh existing autonomy closure repair task summary, score, stages, and acceptance criteria from the latest health snapshot
- keep one repair task instead of duplicating stale tasks

## Verification
- pnpm exec vitest run tests/autonomy-closure-health.test.ts
- pnpm typecheck
- pnpm build

Refs #83