### PR TITLE
fix: hold provider quota failures until reset

### DIFF
--- a/src/auto-executor.ts
+++ b/src/auto-executor.ts
@@ -17,6 +17,7 @@ import { spawnSync } from 'node:child_process';
 import path from 'node:path';
 import { getMemoryRootDir, resolveMemoryPath } from './memory-paths.js';
 import { evaluateWorkspaceIsolation } from './workspace-isolation.js';
+import { classifyProviderResourceHold } from './provider-resource-guard.js';
 
 // =============================================================================
 // Config
@@ -203,6 +204,29 @@ function ensureListener(): void {
       const memoryDir = getMemoryRootDir();
       checkGoalClosure(memoryDir, taskId);
     } else {
+      const outputPreview = typeof event.data.outputPreview === 'string' ? event.data.outputPreview : '';
+      const resourceHold = classifyProviderResourceHold(outputPreview);
+      if (resourceHold) {
+        const memoryDir = getMemoryRootDir();
+        const current = queryMemoryIndexSync(memoryDir, { id: taskId, limit: 1 })[0];
+        const payload = (current?.payload ?? {}) as Record<string, unknown>;
+        updateMemoryIndexEntry(memoryDir, taskId, {
+          status: 'hold',
+          payload: {
+            ...payload,
+            holdCondition: {
+              type: 'date-after',
+              value: resourceHold.resumeAt,
+            },
+            provider_resource_hold: resourceHold,
+          },
+        }).catch(() => {});
+        failCounts.delete(taskId);
+        dispatchedSet.delete(taskId);
+        slog('AUTO-EXEC', `task ${taskId.slice(0, 16)} held for provider quota until ${resourceHold.resumeAt}`);
+        return;
+      }
+
       const count = (failCounts.get(taskId) ?? 0) + 1;
       failCounts.set(taskId, count);
       if (count >= MAX_FAILURES_PER_TASK) {

--- a/src/delegation-failure-diagnostics.ts
+++ b/src/delegation-failure-diagnostics.ts
@@ -23,7 +23,7 @@ export interface DelegationFailureDiagnosis {
   signature: string;
   code: string;
   status: DelegationFailureStatus;
-  category: 'missing_environment' | 'shell_prompt_injection' | 'command_failed' | 'middleware_failed' | 'unknown';
+  category: 'missing_environment' | 'provider_quota' | 'shell_prompt_injection' | 'command_failed' | 'middleware_failed' | 'unknown';
   summary: string;
   recommendedAction: string;
   reportPath: string;
@@ -103,6 +103,18 @@ function buildDiagnosis(memoryDir: string, record: DelegationFailureRecord): Del
       category: 'missing_environment',
       summary: 'The repeated failure is caused by missing local environment, credential, or linked dependency.',
       recommendedAction: 'Fix the missing environment input, then mark this failure resolved or rerun the origin task.',
+      reportPath,
+    };
+  }
+
+  if (/out of extra usage|usage limit|rate[_ -]?limit|quota/.test(lower)) {
+    return {
+      signature: record.signature,
+      code,
+      status: 'resolved',
+      category: 'provider_quota',
+      summary: 'The repeated failure is provider quota/resource exhaustion, not a task defect.',
+      recommendedAction: 'Hold the origin task with a date-after provider resource condition and retry after reset.',
       reportPath,
     };
   }

--- a/src/provider-resource-guard.ts
+++ b/src/provider-resource-guard.ts
@@ -1,0 +1,45 @@
+export interface ProviderResourceHold {
+  type: 'provider-quota';
+  provider: 'claude' | 'codex' | 'unknown';
+  resumeAt: string;
+  reason: string;
+}
+
+export function classifyProviderResourceHold(
+  output: string,
+  now = new Date(),
+): ProviderResourceHold | null {
+  const lower = output.toLowerCase();
+  if (!/out of extra usage|usage limit|rate[_ -]?limit|quota/.test(lower)) return null;
+
+  const provider = lower.includes('claude') ? 'claude'
+    : lower.includes('codex') ? 'codex'
+      : 'unknown';
+  const resumeAt = parseResetTime(output, now)
+    ?? new Date(now.getTime() + 60 * 60_000);
+
+  return {
+    type: 'provider-quota',
+    provider,
+    resumeAt: resumeAt.toISOString(),
+    reason: `${provider} provider quota/resource exhausted; retry after ${resumeAt.toISOString()}`,
+  };
+}
+
+function parseResetTime(output: string, now: Date): Date | null {
+  const match = output.match(/resets?\s+(\d{1,2})(?::(\d{2}))?\s*(am|pm)?/i);
+  if (!match) return null;
+
+  let hour = Number(match[1]);
+  const minute = match[2] ? Number(match[2]) : 0;
+  const meridiem = match[3]?.toLowerCase();
+  if (!Number.isFinite(hour) || !Number.isFinite(minute) || hour > 23 || minute > 59) return null;
+
+  if (meridiem === 'pm' && hour < 12) hour += 12;
+  if (meridiem === 'am' && hour === 12) hour = 0;
+
+  const reset = new Date(now);
+  reset.setHours(hour, minute, 0, 0);
+  if (reset <= now) reset.setDate(reset.getDate() + 1);
+  return reset;
+}

--- a/tests/delegation-failure-diagnostics.test.ts
+++ b/tests/delegation-failure-diagnostics.test.ts
@@ -83,6 +83,31 @@ describe('delegation failure diagnostics', () => {
     }));
   });
 
+  it('classifies provider quota exhaustion as a resolved resource hold class', async () => {
+    const first = recordDelegationFailure(tmpDir, {
+      taskId: 'del-1',
+      taskType: 'code',
+      prompt: 'Run provider task',
+      output: "Claude Code returned an error result: You're out of extra usage · resets 2:40am (Asia/Taipei)",
+    });
+    const task = await createTask(tmpDir, {
+      title: 'Diagnose provider quota failure',
+      origin: 'kuro',
+      status: 'pending',
+    });
+    markDelegationFailureDiagnosticCreated(tmpDir, first.record.signature, task.id);
+
+    const diagnosis = await diagnoseDelegationFailure(tmpDir, first.record.signature);
+
+    expect(diagnosis).toEqual(expect.objectContaining({
+      status: 'resolved',
+      category: 'provider_quota',
+    }));
+    expect(queryMemoryIndexSync(tmpDir, { id: task.id })[0]).toEqual(expect.objectContaining({
+      status: 'completed',
+    }));
+  });
+
   it('diagnoses pending linked failures in batches', async () => {
     const first = recordDelegationFailure(tmpDir, {
       taskId: 'del-1',

--- a/tests/provider-resource-guard.test.ts
+++ b/tests/provider-resource-guard.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { classifyProviderResourceHold } from '../src/provider-resource-guard.js';
+
+describe('provider resource guard', () => {
+  it('classifies Claude usage exhaustion with reset time', () => {
+    const result = classifyProviderResourceHold(
+      "Claude Code returned an error result: You're out of extra usage · resets 2:40am (Asia/Taipei)",
+      new Date('2026-05-06T16:30:00.000Z'),
+    );
+
+    expect(result).toEqual(expect.objectContaining({
+      type: 'provider-quota',
+      provider: 'claude',
+      resumeAt: '2026-05-06T18:40:00.000Z',
+    }));
+  });
+
+  it('uses a conservative one-hour hold when no reset time is present', () => {
+    const result = classifyProviderResourceHold(
+      'provider failed: rate_limit quota exceeded',
+      new Date('2026-05-06T16:30:00.000Z'),
+    );
+
+    expect(result).toEqual(expect.objectContaining({
+      type: 'provider-quota',
+      provider: 'unknown',
+      resumeAt: '2026-05-06T17:30:00.000Z',
+    }));
+  });
+
+  it('ignores normal command failures', () => {
+    expect(classifyProviderResourceHold('Shell error: Command exited 1')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- classify provider quota/resource exhaustion separately from task defects
- hold auto-executed tasks with date-after until provider reset instead of blind retry/manual hold
- mark repeated provider quota diagnostics as resolved resource holds

## Verification
- pnpm exec vitest run tests/provider-resource-guard.test.ts tests/delegation-failure-diagnostics.test.ts tests/autonomy-closure-health.test.ts
- pnpm typecheck
- pnpm build

Refs #83