### PR TITLE
fix: release stale autonomy closure holds

### DIFF
--- a/src/autonomy-closure-health.ts
+++ b/src/autonomy-closure-health.ts
@@ -110,10 +110,13 @@ export async function ensureAutonomyClosureTask(
   if (!recommendation) return null;
 
   if (existing) {
+    const existingPayload = (existing.payload ?? {}) as Record<string, unknown>;
+    const shouldReleaseStaleHold = existing.status === 'hold' && !existingPayload.holdCondition;
     const refreshed = await updateMemoryIndexEntry(memoryDir, existing.id, {
+      ...(shouldReleaseStaleHold ? { status: 'pending' } : {}),
       summary: recommendation.title,
       payload: {
-        ...((existing.payload ?? {}) as Record<string, unknown>),
+        ...existingPayload,
         origin: AUTONOMY_CLOSURE_ORIGIN,
         priority: recommendation.priority,
         assignee: 'kuro',
@@ -124,6 +127,7 @@ export async function ensureAutonomyClosureTask(
         blocking_stages: snapshot.blockingStages,
         warning_stages: snapshot.warningStages,
         closure_refreshed_at: new Date().toISOString(),
+        ...(shouldReleaseStaleHold ? { closure_unheld_reason: 'refreshed stale autonomy closure hold without unblock condition' } : {}),
       },
       tags: ['autonomy-closure', snapshot.status],
     });

--- a/tests/autonomy-closure-health.test.ts
+++ b/tests/autonomy-closure-health.test.ts
@@ -144,4 +144,87 @@ describe('autonomy closure health', () => {
     expect(task?.payload?.acceptance_criteria).toContain('1 task(s) exhausted autonomous retries');
     expect(task?.payload?.closure_refreshed_at).toEqual(expect.any(String));
   });
+
+  it('releases a stale autonomy closure hold when it has no unblock condition', async () => {
+    writeFileSync(
+      path.join(tmpDir, 'state/task-events.jsonl'),
+      [
+        JSON.stringify({
+          id: 'idx-existing',
+          ts: '2026-05-07T00:00:00.000Z',
+          type: 'task',
+          status: 'hold',
+          summary: 'P0 autonomy closure: repair old-stage',
+          refs: [],
+          tags: ['autonomy-closure'],
+          payload: {
+            origin: 'autonomy-closure',
+            priority: 0,
+            staleWarning: 'old provider failure',
+          },
+        }),
+        JSON.stringify({
+          id: 'idx-exhausted',
+          ts: '2026-05-07T00:00:00.000Z',
+          type: 'task',
+          status: 'hold',
+          summary: 'P1 failing autonomous issue repair',
+          refs: [],
+          payload: {
+            origin: 'github-issue',
+            priority: 1,
+            verify_command: 'pnpm test',
+            auto_executor_failures: 3,
+          },
+        }),
+      ].join('\n') + '\n',
+      'utf-8',
+    );
+    writeFileSync(path.join(tmpDir, 'index/relations.jsonl'), '', 'utf-8');
+
+    const task = await ensureAutonomyClosureTask(tmpDir, evaluateAutonomyClosure(tmpDir, { repoRoot }));
+
+    expect(task?.status).toBe('pending');
+    expect(task?.payload?.closure_unheld_reason).toBe('refreshed stale autonomy closure hold without unblock condition');
+  });
+
+  it('keeps a timed provider resource hold in hold status', async () => {
+    writeFileSync(
+      path.join(tmpDir, 'state/task-events.jsonl'),
+      JSON.stringify({
+        id: 'idx-existing',
+        ts: '2026-05-07T00:00:00.000Z',
+        type: 'task',
+        status: 'hold',
+        summary: 'P0 autonomy closure: repair old-stage',
+        refs: [],
+        tags: ['autonomy-closure'],
+        payload: {
+          origin: 'autonomy-closure',
+          priority: 0,
+          holdCondition: { type: 'date-after', value: '2026-05-07T02:40:00.000Z' },
+        },
+      }) + '\n' + JSON.stringify({
+        id: 'idx-exhausted',
+        ts: '2026-05-07T00:00:00.000Z',
+        type: 'task',
+        status: 'hold',
+        summary: 'P1 failing autonomous issue repair',
+        refs: [],
+        payload: {
+          origin: 'github-issue',
+          priority: 1,
+          verify_command: 'pnpm test',
+          auto_executor_failures: 3,
+        },
+      }) + '\n',
+      'utf-8',
+    );
+    writeFileSync(path.join(tmpDir, 'index/relations.jsonl'), '', 'utf-8');
+
+    const task = await ensureAutonomyClosureTask(tmpDir, evaluateAutonomyClosure(tmpDir, { repoRoot }));
+
+    expect(task?.status).toBe('hold');
+    expect(task?.payload?.closure_unheld_reason).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary
- refresh stale autonomy closure repair tasks back to pending when they are held without an unblock condition
- preserve timed provider resource holds so quota resets still gate retries correctly

## Verification
- pnpm exec vitest run tests/autonomy-closure-health.test.ts tests/provider-resource-guard.test.ts
- pnpm typecheck
- pnpm build

Refs #83