### PR TITLE
fix: auto-detect repo for issue autopilot

### DIFF
--- a/src/issue-autopilot-cli.ts
+++ b/src/issue-autopilot-cli.ts
@@ -1,10 +1,9 @@
 #!/usr/bin/env node
 import path from 'node:path';
-import { execFileSync } from 'node:child_process';
-import { readOpenIssuesFromGitHub, syncGitHubIssuesToTasks } from './issue-autopilot.js';
+import { detectGitHubRepo, readOpenIssuesFromGitHub, syncGitHubIssuesToTasks } from './issue-autopilot.js';
 
 const args = new Set(process.argv.slice(2));
-const repo = readArg('--repo') ?? process.env.MINI_AGENT_GITHUB_REPO ?? detectRepo();
+const repo = readArg('--repo') ?? process.env.MINI_AGENT_GITHUB_REPO ?? detectGitHubRepo();
 const memoryDir = path.resolve(readArg('--memory') ?? process.env.MINI_AGENT_MEMORY_DIR ?? 'memory');
 const limit = Number(readArg('--limit') ?? process.env.MINI_AGENT_GITHUB_ISSUE_LIMIT ?? '50');
 const dryRun = args.has('--dry-run');
@@ -45,18 +44,4 @@ function readArg(name: string): string | undefined {
   if (index >= 0) return argv[index + 1];
   const prefix = `${name}=`;
   return argv.find(arg => arg.startsWith(prefix))?.slice(prefix.length);
-}
-
-function detectRepo(): string | undefined {
-  try {
-    const url = execFileSync('git', ['config', '--get', 'remote.origin.url'], {
-      encoding: 'utf-8',
-      stdio: ['ignore', 'pipe', 'ignore'],
-      timeout: 5000,
-    }).trim();
-    const match = url.match(/github\.com[:/]([^/]+\/[^/.]+)(?:\.git)?$/);
-    return match?.[1];
-  } catch {
-    return undefined;
-  }
 }

--- a/src/issue-autopilot.ts
+++ b/src/issue-autopilot.ts
@@ -166,6 +166,25 @@ export function readOpenIssuesFromGitHub(repo: string, limit = 50): GitHubIssueS
   return JSON.parse(output) as GitHubIssueSummary[];
 }
 
+export function detectGitHubRepo(cwd = process.cwd()): string | undefined {
+  try {
+    const url = execFileSync('git', ['config', '--get', 'remote.origin.url'], {
+      cwd,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 5000,
+    }).trim();
+    return parseGitHubRepoUrl(url);
+  } catch {
+    return undefined;
+  }
+}
+
+function parseGitHubRepoUrl(url: string): string | undefined {
+  const match = url.match(/github\.com[:/]([^/\s]+\/[^/\s]+?)(?:\.git)?$/);
+  return match?.[1];
+}
+
 function normalizeLabels(labels: GitHubIssueSummary['labels']): string[] {
   return (labels ?? [])
     .map(label => typeof label === 'string' ? label : label.name)

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -2237,13 +2237,15 @@ export class AgentLoop {
       try { await advanceGoals(memDir); } catch { /* non-critical */ }
       // Issue autopilot: reconcile GitHub-closed issues so stale P0 entries drain (issue #151)
       try {
-        const repo = process.env.MINI_AGENT_GITHUB_REPO;
+        const { detectGitHubRepo, readOpenIssuesFromGitHub, syncGitHubIssuesToTasks } = await import('./issue-autopilot.js');
+        const repo = process.env.MINI_AGENT_GITHUB_REPO ?? detectGitHubRepo();
         if (repo) {
-          const { readOpenIssuesFromGitHub, syncGitHubIssuesToTasks } = await import('./issue-autopilot.js');
           const issues = readOpenIssuesFromGitHub(repo, 50);
           await syncGitHubIssuesToTasks(memDir, issues, { repo });
+        } else {
+          slog('ISSUE-AUTOPILOT', 'skipped: no GitHub repo detected');
         }
-      } catch { /* non-critical */ }
+      } catch (e) { slog('WARN', `issue autopilot failed: ${e}`); }
       try {
         const { closeResolvedCorrectionTasks, evaluateCorrectionGate, ensureCorrectionTask } = await import('./correction-gate.js');
         let correction = evaluateCorrectionGate(memDir);

--- a/tests/issue-autopilot.test.ts
+++ b/tests/issue-autopilot.test.ts
@@ -1,9 +1,10 @@
+import { execFileSync } from 'node:child_process';
 import { mkdtempSync, rmSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { issueTaskId, planIssueTask, syncGitHubIssuesToTasks } from '../src/issue-autopilot.js';
+import { detectGitHubRepo, issueTaskId, planIssueTask, syncGitHubIssuesToTasks } from '../src/issue-autopilot.js';
 import { appendMemoryIndexEntry, queryMemoryIndexSync } from '../src/memory-index.js';
 
 let tmpDir: string;
@@ -17,6 +18,20 @@ afterEach(() => {
 });
 
 describe('issue autopilot', () => {
+  it('detects the GitHub repo from an SSH origin remote', () => {
+    execFileSync('git', ['init'], { cwd: tmpDir, stdio: 'ignore' });
+    execFileSync('git', ['remote', 'add', 'origin', 'git@github.com:miles990/mini-agent.git'], { cwd: tmpDir, stdio: 'ignore' });
+
+    expect(detectGitHubRepo(tmpDir)).toBe('miles990/mini-agent');
+  });
+
+  it('detects the GitHub repo from an HTTPS origin remote', () => {
+    execFileSync('git', ['init'], { cwd: tmpDir, stdio: 'ignore' });
+    execFileSync('git', ['remote', 'add', 'origin', 'https://github.com/miles990/mini-agent.git'], { cwd: tmpDir, stdio: 'ignore' });
+
+    expect(detectGitHubRepo(tmpDir)).toBe('miles990/mini-agent');
+  });
+
   it('plans stable priority tasks from GitHub issues', () => {
     const plan = planIssueTask({
       number: 100,


### PR DESCRIPTION
## Summary
- Share GitHub repo detection between the issue-autopilot CLI and runtime loop
- Let the runtime sync open GitHub issues even when MINI_AGENT_GITHUB_REPO is not configured
- Add SSH/HTTPS origin remote coverage for repo detection

## Verification
- pnpm exec vitest run tests/issue-autopilot.test.ts
- pnpm typecheck
- pnpm build
- node dist/issue-autopilot-cli.js --repo miles990/mini-agent --memory /Users/user/Workspace/mini-agent-memory/memory --json

## Notes
- Full pnpm test was also run; current suite has pre-existing environment/test-harness failures in delegation-arbiter phantom-prompt handling and self-research correction-gate suppression when run from an isolated feature worktree. The targeted issue-autopilot path passes.