### PR TITLE
fix: surface test failures as autonomy repairs

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "memory:repo:check": "tsx scripts/setup-memory-repo.ts --check",
     "memory:kg:promote": "tsx scripts/kg-promote-memory.ts",
     "check:autonomy-closure": "tsx scripts/autonomy-closure-health.ts",
+    "check:test-health": "tsx scripts/test-health-autopilot.ts",
     "setup": "pnpm install && pnpm build && npm link",
     "prepare": "git config core.hooksPath .githooks 2>/dev/null || true",
     "check:pr-lifecycle": "tsx scripts/check-pr-lifecycle.ts"

--- a/scripts/test-health-autopilot.ts
+++ b/scripts/test-health-autopilot.ts
@@ -1,0 +1,41 @@
+#!/usr/bin/env tsx
+import { spawnSync } from 'node:child_process';
+import { getMemoryRootDir } from '../src/memory-paths.js';
+import { ensureAutonomyClosureTask, evaluateAutonomyClosure } from '../src/autonomy-closure-health.js';
+import { buildTestHealthSnapshot, summarizeTestHealth, writeTestHealthSnapshot } from '../src/test-health-autopilot.js';
+
+const argv = process.argv.slice(2);
+const json = argv.includes('--json');
+const ensure = argv.includes('--ensure');
+const separator = argv.indexOf('--');
+const command = separator >= 0 ? argv.slice(separator + 1) : ['pnpm', 'exec', 'vitest', 'run'];
+while (command[0] === '--') command.shift();
+
+if (command.length === 0) {
+  process.stderr.write('usage: pnpm check:test-health [--json] [--ensure] [-- command ...]\n');
+  process.exit(2);
+}
+
+const result = spawnSync(command[0], command.slice(1), {
+  cwd: process.cwd(),
+  encoding: 'utf-8',
+  stdio: ['ignore', 'pipe', 'pipe'],
+});
+const output = `${result.stdout ?? ''}${result.stderr ?? ''}`;
+const exitCode = result.status ?? 1;
+const memoryDir = getMemoryRootDir();
+const snapshot = buildTestHealthSnapshot(command.join(' '), exitCode, output);
+writeTestHealthSnapshot(memoryDir, snapshot);
+
+const closure = evaluateAutonomyClosure(memoryDir);
+const task = ensure ? await ensureAutonomyClosureTask(memoryDir, closure) : null;
+
+if (json) {
+  console.log(JSON.stringify({ snapshot, closure, task }, null, 2));
+} else {
+  process.stdout.write(output);
+  console.log(`[test-health] ${summarizeTestHealth(snapshot)}`);
+  if (task) console.log(`[test-health] queued repair task: ${task.id} ${task.summary ?? ''}`);
+}
+
+process.exit(exitCode);

--- a/src/autonomy-closure-health.ts
+++ b/src/autonomy-closure-health.ts
@@ -5,10 +5,12 @@ import { createTask, queryMemoryIndexSync, updateMemoryIndexEntry, type MemoryIn
 import { evaluatePrReviewConsensus, parsePrReviewHandoffs, readPrReviewClaimsSync } from './pr-review-runner.js';
 import { evaluateRuntimeMemoryPlacement } from './memory-paths.js';
 import { eventBus } from './event-bus.js';
+import { readTestHealthSnapshot, summarizeTestHealth } from './test-health-autopilot.js';
 
 export type AutonomyClosureStage =
   | 'runtime-workspace'
   | 'task-execution'
+  | 'test-health'
   | 'issue-autopilot'
   | 'pr-review-consensus'
   | 'ship-and-deploy'
@@ -60,6 +62,7 @@ export function evaluateAutonomyClosure(
   const stages: AutonomyClosureStageResult[] = [
     runtimeWorkspaceStage(correction),
     taskExecutionStage(openTasks),
+    testHealthStage(memoryDir),
     issueAutopilotStage(openTasks),
     prReviewConsensusStage(memoryDir),
     shipAndDeployStage(correction),
@@ -250,6 +253,37 @@ function taskExecutionStage(openTasks: MemoryIndexEntry[]): AutonomyClosureStage
     status: 'ok',
     summary: `${openTasks.length} open task(s), none exhausted`,
     evidence: openTasks.slice(0, 5).map(formatTaskEvidence),
+  };
+}
+
+function testHealthStage(memoryDir: string): AutonomyClosureStageResult {
+  const snapshot = readTestHealthSnapshot(memoryDir);
+  if (!snapshot) {
+    return {
+      stage: 'test-health',
+      status: 'ok',
+      summary: 'no recorded test failure',
+      evidence: [],
+    };
+  }
+  if (snapshot.status === 'failed') {
+    return {
+      stage: 'test-health',
+      status: 'blocked',
+      summary: summarizeTestHealth(snapshot),
+      evidence: [
+        `checkedAt=${snapshot.checkedAt}`,
+        `exitCode=${snapshot.exitCode}`,
+        ...snapshot.failedFiles.slice(0, 5).map(f => `${f.file}${f.failedCount ? ` (${f.failedCount} failed)` : ''}`),
+      ],
+      repair: 'Run the failing test files in isolation, fix the root cause or stale test expectation, then rerun pnpm check:test-health.',
+    };
+  }
+  return {
+    stage: 'test-health',
+    status: 'ok',
+    summary: summarizeTestHealth(snapshot),
+    evidence: [`checkedAt=${snapshot.checkedAt}`, `exitCode=${snapshot.exitCode}`],
   };
 }
 

--- a/src/correction-gate.ts
+++ b/src/correction-gate.ts
@@ -11,7 +11,7 @@ import {
   type ActiveHoldMatch,
   type CorrectionHold,
 } from './correction-holds.js';
-import { isCodePath, isSafeRuntimeBranch } from './workspace-isolation.js';
+import { evaluateWorkspaceIsolation, isCodePath, isSafeRuntimeBranch } from './workspace-isolation.js';
 
 export type CorrectionReasonType =
   | 'pending-pledge'
@@ -115,14 +115,15 @@ export function evaluateCorrectionGate(memoryDir: string, repoRoot = process.cwd
   }
 
   const shipTruth = readShipTruth(repoRoot);
+  const workspaceIsolation = evaluateWorkspaceIsolation(repoRoot);
 
-  if (shipTruth.repoPresent && !isSafeRuntimeBranch(shipTruth.branch)) {
+  if (workspaceIsolation.protectedRuntimeWorkspace && shipTruth.repoPresent && !isSafeRuntimeBranch(shipTruth.branch)) {
     const message = `runtime workspace 在錯誤分支 ${shipTruth.branch ?? 'unknown'} — protected runtime checkout 只能在 runtime/main；功能修改要用 isolated worktree + PR。`;
     reasons.push({ type: 'runtime-workspace-wrong-branch', severity: 'high', message });
     guidance.push(message);
   }
 
-  if (shipTruth.state === 'pending-push' || shipTruth.state === 'diverged') {
+  if (workspaceIsolation.protectedRuntimeWorkspace && (shipTruth.state === 'pending-push' || shipTruth.state === 'diverged')) {
     const match = findActiveHold(holds, 'local-commit-not-pushed', {
       branch: shipTruth.branch,
       sha: shipTruth.headSha,
@@ -141,7 +142,7 @@ export function evaluateCorrectionGate(memoryDir: string, repoRoot = process.cwd
     }
   }
 
-  if (shipTruth.state === 'dirty') {
+  if (workspaceIsolation.protectedRuntimeWorkspace && shipTruth.state === 'dirty') {
     const blockingDirtyPaths = getBlockingRuntimeDirtyPaths(shipTruth.dirtyPaths);
     const match = findActiveHold(holds, 'dirty-runtime-workspace', {
       branch: shipTruth.branch,

--- a/src/self-research-autopilot.ts
+++ b/src/self-research-autopilot.ts
@@ -16,6 +16,7 @@ import { evaluateCorrectionGate } from './correction-gate.js';
 export interface SelfResearchAutopilotOptions {
   triggerReason?: string | null;
   now?: Date;
+  repoRoot?: string;
 }
 
 export interface SelfResearchAutopilotResult {
@@ -44,7 +45,7 @@ export async function maybeQueueSelfResearch(
     return { queued: false, reason: 'not-idle-trigger' };
   }
 
-  const correction = evaluateCorrectionGate(memoryDir);
+  const correction = evaluateCorrectionGate(memoryDir, opts.repoRoot);
   if (correction.needsCorrection) {
     return { queued: false, reason: `suppressed-by-correction:${correction.reasons[0]?.type ?? 'unknown'}` };
   }

--- a/src/test-health-autopilot.ts
+++ b/src/test-health-autopilot.ts
@@ -1,0 +1,90 @@
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+export interface TestHealthFailure {
+  file: string;
+  failedCount?: number;
+}
+
+export interface TestHealthSnapshot {
+  status: 'passed' | 'failed';
+  command: string;
+  exitCode: number;
+  checkedAt: string;
+  failedFiles: TestHealthFailure[];
+  failedTests: string[];
+  outputTail: string;
+}
+
+const SNAPSHOT_PATH = path.join('state', 'latest-test-health.json');
+
+export function buildTestHealthSnapshot(
+  command: string,
+  exitCode: number,
+  output: string,
+  now = new Date(),
+): TestHealthSnapshot {
+  const failedFiles = parseFailedFiles(output);
+  const failedTests = parseFailedTests(output);
+  return {
+    status: exitCode === 0 ? 'passed' : 'failed',
+    command,
+    exitCode,
+    checkedAt: now.toISOString(),
+    failedFiles,
+    failedTests,
+    outputTail: tail(output, 6000),
+  };
+}
+
+export function readTestHealthSnapshot(memoryDir: string): TestHealthSnapshot | null {
+  try {
+    return JSON.parse(readFileSync(testHealthSnapshotPath(memoryDir), 'utf-8')) as TestHealthSnapshot;
+  } catch {
+    return null;
+  }
+}
+
+export function writeTestHealthSnapshot(memoryDir: string, snapshot: TestHealthSnapshot): void {
+  const file = testHealthSnapshotPath(memoryDir);
+  mkdirSync(path.dirname(file), { recursive: true });
+  writeFileSync(file, JSON.stringify(snapshot, null, 2) + '\n', 'utf-8');
+}
+
+export function summarizeTestHealth(snapshot: TestHealthSnapshot): string {
+  if (snapshot.status === 'passed') return `tests passed: ${snapshot.command}`;
+  const files = snapshot.failedFiles.map(f => f.file).slice(0, 3).join(', ') || 'unknown files';
+  return `tests failed: ${snapshot.command}; ${snapshot.failedFiles.length} file(s): ${files}`;
+}
+
+function testHealthSnapshotPath(memoryDir: string): string {
+  return path.join(memoryDir, SNAPSHOT_PATH);
+}
+
+function parseFailedFiles(output: string): TestHealthFailure[] {
+  const latest = new Map<string, TestHealthFailure>();
+  for (const line of output.split(/\r?\n/)) {
+    const summary = line.match(/[❯✓]\s+(tests\/\S+\.test\.ts)\s+\([^)]*\|\s+(\d+)\s+failed\)/);
+    if (summary) {
+      latest.set(summary[1], { file: summary[1], failedCount: Number(summary[2]) });
+      continue;
+    }
+    const fail = line.match(/\bFAIL\s+(tests\/\S+\.test\.ts)\b/);
+    if (fail && !latest.has(fail[1])) latest.set(fail[1], { file: fail[1] });
+  }
+  return [...latest.values()].sort((a, b) => a.file.localeCompare(b.file));
+}
+
+function parseFailedTests(output: string): string[] {
+  const tests = new Set<string>();
+  for (const line of output.split(/\r?\n/)) {
+    const match = line.match(/\bFAIL\s+(.+?)\s+>/);
+    if (match) tests.add(match[1].trim());
+  }
+  return [...tests].slice(0, 20);
+}
+
+function tail(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text;
+  return text.slice(text.length - maxChars);
+}

--- a/tests/correction-gate.test.ts
+++ b/tests/correction-gate.test.ts
@@ -108,19 +108,27 @@ describe('correction gate', () => {
   });
 
   it('flags protected runtime checkout when it is on main instead of runtime/main', () => {
-    execGit(['init'], tmpDir);
-    execGit(['config', 'user.email', 'test@example.com'], tmpDir);
-    execGit(['config', 'user.name', 'Test User'], tmpDir);
-    writeFileSync(path.join(tmpDir, 'README.md'), 'runtime guard fixture\n', 'utf-8');
-    execGit(['add', 'README.md'], tmpDir);
-    execGit(['commit', '-m', 'init'], tmpDir);
-    execGit(['branch', '-M', 'main'], tmpDir);
+    try {
+      execGit(['init'], tmpDir);
+      execGit(['config', 'user.email', 'test@example.com'], tmpDir);
+      execGit(['config', 'user.name', 'Test User'], tmpDir);
+      writeFileSync(path.join(tmpDir, 'README.md'), 'runtime guard fixture\n', 'utf-8');
+      execGit(['add', 'README.md'], tmpDir);
+      execGit(['commit', '-m', 'init'], tmpDir);
+      execGit(['branch', '-M', 'main'], tmpDir);
+      process.env.MINI_AGENT_RUNTIME_WORKSPACE = execFileSync('git', ['rev-parse', '--show-toplevel'], {
+        cwd: tmpDir,
+        encoding: 'utf-8',
+      }).trim();
 
-    const snapshot = evaluateCorrectionGate(tmpDir, tmpDir);
+      const snapshot = evaluateCorrectionGate(tmpDir, tmpDir);
 
-    expect(snapshot.needsCorrection).toBe(true);
-    expect(snapshot.reasons.map(r => r.type)).toContain('runtime-workspace-wrong-branch');
-    expect(snapshot.guidance.join('\n')).toContain('只能在 runtime/main');
+      expect(snapshot.needsCorrection).toBe(true);
+      expect(snapshot.reasons.map(r => r.type)).toContain('runtime-workspace-wrong-branch');
+      expect(snapshot.guidance.join('\n')).toContain('只能在 runtime/main');
+    } finally {
+      delete process.env.MINI_AGENT_RUNTIME_WORKSPACE;
+    }
   });
 
   it('classifies only managed/code dirt as blocking runtime dirt', () => {

--- a/tests/delegation-arbiter.test.ts
+++ b/tests/delegation-arbiter.test.ts
@@ -65,6 +65,16 @@ import {
 } from '../src/delegation.js';
 import { prepareForgeWorkspace } from '../src/forge.js';
 
+function validPrompt(text: string): string {
+  return [
+    '## Task:',
+    text,
+    '',
+    '## Context:',
+    'This is an explicit test envelope that should pass the phantom-prompt pre-dispatch guard.',
+  ].join('\n');
+}
+
 beforeEach(() => {
   delete process.env.MINI_AGENT_DELEGATION_RUNTIME;
   vi.mocked(prepareForgeWorkspace).mockReset();
@@ -126,7 +136,7 @@ describe('delegation arbitration mapping', () => {
 
   it('acquires a write lease for workspace-write delegations', () => {
     const id = spawnDelegation({
-      prompt: 'Update src/agent.ts',
+      prompt: validPrompt('Update src/agent.ts'),
       workdir: '/repo',
       type: 'code',
     });
@@ -145,7 +155,7 @@ describe('delegation arbitration mapping', () => {
     vi.mocked(prepareForgeWorkspace).mockReturnValueOnce({ cwd: '/repo-forge/create-1', worktree: '/repo-forge/create-1' });
 
     const id = spawnDelegation({
-      prompt: 'Create docs/guide.md',
+      prompt: validPrompt('Create docs/guide.md'),
       workdir: '/repo',
       type: 'create',
     });
@@ -166,7 +176,7 @@ describe('delegation arbitration mapping', () => {
     });
 
     const id = spawnDelegation({
-      prompt: 'Update src/agent.ts',
+      prompt: validPrompt('Update src/agent.ts'),
       workdir: process.cwd(),
       type: 'code',
     });
@@ -178,12 +188,12 @@ describe('delegation arbitration mapping', () => {
 
   it('blocks overlapping write scopes instead of dispatching them', () => {
     const first = spawnDelegation({
-      prompt: 'Update src/agent.ts',
+      prompt: validPrompt('Update src/agent.ts'),
       workdir: '/repo',
       type: 'code',
     });
     const second = spawnDelegation({
-      prompt: 'Refactor src/agent.ts',
+      prompt: validPrompt('Refactor src/agent.ts'),
       workdir: '/repo',
       type: 'code',
     });
@@ -196,7 +206,7 @@ describe('delegation arbitration mapping', () => {
 
   it('blocks external writes before dispatch', () => {
     const id = spawnDelegation({
-      prompt: 'P0 deploy this and push main',
+      prompt: validPrompt('P0 deploy this and push main after verification evidence is complete'),
       workdir: '/repo',
       type: 'shell',
     });
@@ -208,7 +218,7 @@ describe('delegation arbitration mapping', () => {
   it('can execute delegations through BrainRuntime when enabled', async () => {
     process.env.MINI_AGENT_DELEGATION_RUNTIME = 'true';
     const id = spawnDelegation({
-      prompt: 'Review the runtime adapter',
+      prompt: validPrompt('Review the runtime adapter and return verification evidence for the delegated run'),
       workdir: '/repo',
       type: 'review',
     });
@@ -234,7 +244,7 @@ describe('delegation arbitration mapping', () => {
   it('includes Akari peer critique for architecture delegations through BrainRuntime', async () => {
     process.env.MINI_AGENT_DELEGATION_RUNTIME = 'true';
     const id = spawnDelegation({
-      prompt: 'Ask Akari to critique the multi-brain runtime',
+      prompt: validPrompt('Ask Akari to critique the multi-brain runtime and summarize actionable design risk'),
       workdir: '/repo',
       type: 'akari',
     });

--- a/tests/self-research-autopilot.test.ts
+++ b/tests/self-research-autopilot.test.ts
@@ -21,6 +21,7 @@ describe('self research autopilot', () => {
     const result = await maybeQueueSelfResearch(tmpDir, {
       triggerReason: 'heartbeat',
       now: new Date('2026-05-05T00:00:00.000Z'),
+      repoRoot: tmpDir,
     });
 
     expect(result.queued).toBe(true);
@@ -60,6 +61,7 @@ describe('self research autopilot', () => {
     const result = await maybeQueueSelfResearch(tmpDir, {
       triggerReason: 'heartbeat',
       now: new Date('2026-05-05T00:00:00.000Z'),
+      repoRoot: tmpDir,
     });
 
     expect(result).toEqual({ queued: false, reason: 'active-tasks-present' });
@@ -83,6 +85,7 @@ describe('self research autopilot', () => {
     const result = await maybeQueueSelfResearch(tmpDir, {
       triggerReason: 'heartbeat',
       now: new Date('2026-05-05T00:00:00.000Z'),
+      repoRoot: tmpDir,
     });
 
     expect(result.queued).toBe(true);
@@ -130,6 +133,7 @@ describe('self research autopilot', () => {
     const result = await maybeQueueSelfResearch(tmpDir, {
       triggerReason: 'heartbeat',
       now: new Date('2026-05-05T00:00:00.000Z'),
+      repoRoot: tmpDir,
     });
 
     expect(result).toEqual({
@@ -143,6 +147,7 @@ describe('self research autopilot', () => {
     const first = await maybeQueueSelfResearch(tmpDir, {
       triggerReason: 'heartbeat',
       now: new Date('2026-05-05T00:00:00.000Z'),
+      repoRoot: tmpDir,
     });
     expect(first.queued).toBe(true);
 
@@ -156,6 +161,7 @@ describe('self research autopilot', () => {
     const second = await maybeQueueSelfResearch(tmpDir, {
       triggerReason: 'heartbeat',
       now: new Date('2026-05-05T12:00:00.000Z'),
+      repoRoot: tmpDir,
     });
 
     expect(second).toEqual({ queued: false, reason: 'daily-proposal-already-exists' });
@@ -165,6 +171,7 @@ describe('self research autopilot', () => {
     const result = await maybeQueueSelfResearch(tmpDir, {
       triggerReason: 'telegram-user',
       now: new Date('2026-05-05T00:00:00.000Z'),
+      repoRoot: tmpDir,
     });
 
     expect(result).toEqual({ queued: false, reason: 'not-idle-trigger' });

--- a/tests/test-health-autopilot.test.ts
+++ b/tests/test-health-autopilot.test.ts
@@ -1,0 +1,66 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { evaluateAutonomyClosure } from '../src/autonomy-closure-health.js';
+import { buildTestHealthSnapshot, writeTestHealthSnapshot } from '../src/test-health-autopilot.js';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(path.join(os.tmpdir(), 'mini-agent-test-health-'));
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('test health autopilot', () => {
+  it('extracts failed vitest files into a durable snapshot', () => {
+    const snapshot = buildTestHealthSnapshot('pnpm exec vitest run', 1, [
+      ' ❯ tests/delegation-arbiter.test.ts (11 tests | 7 failed) 11ms',
+      ' FAIL  tests/delegation-arbiter.test.ts > delegation arbitration mapping > acquires a write lease',
+      ' ❯ tests/self-research-autopilot.test.ts (6 tests | 5 failed) 109ms',
+    ].join('\n'), new Date('2026-05-07T00:00:00.000Z'));
+
+    expect(snapshot.status).toBe('failed');
+    expect(snapshot.failedFiles).toEqual([
+      { file: 'tests/delegation-arbiter.test.ts', failedCount: 7 },
+      { file: 'tests/self-research-autopilot.test.ts', failedCount: 5 },
+    ]);
+    expect(snapshot.failedTests).toEqual([
+      'tests/delegation-arbiter.test.ts',
+    ]);
+  });
+
+  it('makes a recorded test failure block autonomy closure', () => {
+    const snapshot = buildTestHealthSnapshot('pnpm exec vitest run', 1, [
+      ' ❯ tests/delegation-arbiter.test.ts (11 tests | 7 failed) 11ms',
+    ].join('\n'), new Date('2026-05-07T00:00:00.000Z'));
+    writeTestHealthSnapshot(tmpDir, snapshot);
+
+    const closure = evaluateAutonomyClosure(tmpDir, { repoRoot: tmpDir });
+    const stage = closure.stages.find(s => s.stage === 'test-health');
+
+    expect(stage).toEqual(expect.objectContaining({
+      status: 'blocked',
+      summary: expect.stringContaining('tests failed'),
+    }));
+    expect(closure.blockingStages).toContain('test-health');
+    expect(closure.recommendedTask?.title).toBe('P0 autonomy closure: repair test-health');
+  });
+
+  it('treats a passing recorded test run as healthy', () => {
+    const snapshot = buildTestHealthSnapshot('pnpm exec vitest run', 0, '✓ all tests passed', new Date('2026-05-07T00:00:00.000Z'));
+    writeTestHealthSnapshot(tmpDir, snapshot);
+
+    const closure = evaluateAutonomyClosure(tmpDir, { repoRoot: tmpDir });
+    const stage = closure.stages.find(s => s.stage === 'test-health');
+
+    expect(stage).toEqual(expect.objectContaining({
+      status: 'ok',
+      summary: 'tests passed: pnpm exec vitest run',
+    }));
+  });
+});


### PR DESCRIPTION
## Summary
- Add a test-health autopilot that records the latest test run into memory/state/latest-test-health.json
- Add a test-health stage to autonomy closure so failed tests become P0 repair work
- Fix stale tests that conflicted with phantom-prompt envelopes and isolated-worktree correction behavior
- Limit runtime workspace correction to the protected runtime checkout instead of all feature worktrees

## Verification
- pnpm exec vitest run tests/delegation-arbiter.test.ts tests/self-research-autopilot.test.ts tests/test-health-autopilot.test.ts tests/autonomy-closure-health.test.ts
- pnpm exec vitest run tests/correction-gate.test.ts tests/self-research-autopilot.test.ts tests/test-health-autopilot.test.ts tests/autonomy-closure-health.test.ts
- pnpm typecheck
- pnpm build
- pnpm test
- MINI_AGENT_MEMORY_DIR=/tmp/mini-agent-test-health-smoke pnpm check:test-health -- -- pnpm exec vitest run tests/test-health-autopilot.test.ts
- MINI_AGENT_MEMORY_DIR=/tmp/mini-agent-test-health-fail-smoke pnpm check:test-health --ensure --json -- -- node -e "process.exit(7)" (expected exit 7; queued P0 autonomy closure repair test-health)
