### PR TITLE
fix(runtime-autocorrect): idempotent retry when push succeeds but PR create fails (#170)

### DIFF
--- a/src/runtime-workspace-autocorrect.ts
+++ b/src/runtime-workspace-autocorrect.ts
@@ -82,16 +82,25 @@ export function autocorrectRuntimeWorkspace(repoRoot = process.cwd(), opts: {
 
   try {
     git(root, ['fetch', 'origin', baseBranch]);
-    ensureWorktree(root, worktree, branch, `origin/${baseBranch}`);
-    if (mode === 'tracked-dirty') {
-      moveTrackedDirtyToWorktree(root, worktree);
-    } else {
-      git(worktree, ['cherry-pick', `origin/${baseBranch}..${snapshot.headSha}`]);
+    // Idempotency: if the remote branch already exists from a prior partial run,
+    // skip the cherry-pick + push step. This handles the case where `gh pr create`
+    // (or any later step) failed mid-sequence and the loop retries the autocorrect.
+    const remoteBranchExists = !!safeGit(root, ['ls-remote', '--heads', 'origin', branch]);
+    if (!remoteBranchExists) {
+      ensureWorktree(root, worktree, branch, `origin/${baseBranch}`);
+      if (mode === 'tracked-dirty') {
+        moveTrackedDirtyToWorktree(root, worktree);
+      } else {
+        git(worktree, ['cherry-pick', `origin/${baseBranch}..${snapshot.headSha}`]);
+      }
+      git(worktree, ['push', '-u', 'origin', branch]);
     }
-    git(worktree, ['push', '-u', 'origin', branch]);
     let prUrl: string | undefined;
     if (opts.createPr ?? true) {
-      prUrl = createPullRequest(worktree, repo, baseBranch, branch, snapshot.ahead);
+      // Idempotency: re-use an existing PR for this branch if one is already open.
+      // Otherwise the second pass would fail with "a pull request for branch X already exists".
+      prUrl = findExistingPullRequest(repo, branch)
+        ?? createPullRequest(existsSync(worktree) ? worktree : root, repo, baseBranch, branch, snapshot.ahead);
     }
     git(root, ['reset', '--hard', `origin/${baseBranch}`]);
     return {
@@ -149,6 +158,28 @@ function ensureWorktree(repoRoot: string, worktree: string, branch: string, base
   }
   mkdirSync(path.dirname(worktree), { recursive: true });
   git(repoRoot, ['worktree', 'add', worktree, '-b', branch, baseRef]);
+}
+
+function findExistingPullRequest(repo: string, branch: string): string | undefined {
+  try {
+    const out = execFileSync('gh', [
+      'pr', 'list',
+      '--repo', repo,
+      '--head', branch,
+      '--state', 'open',
+      '--json', 'url',
+      '--limit', '1',
+    ], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 30_000,
+    }).trim();
+    if (!out) return undefined;
+    const parsed = JSON.parse(out) as Array<{ url?: string }>;
+    return parsed[0]?.url || undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 function createPullRequest(worktree: string, repo: string, baseBranch: string, branch: string, ahead: number): string | undefined {

--- a/tests/runtime-workspace-autocorrect.test.ts
+++ b/tests/runtime-workspace-autocorrect.test.ts
@@ -97,6 +97,43 @@ describe('runtime workspace autocorrect', () => {
       reason: expect.stringContaining('untracked changes'),
     }));
   });
+
+  it('is idempotent: re-uses existing remote branch and PR when retry runs after partial failure', () => {
+    const remote = path.join(tmpDir, 'idem-remote.git');
+    const repo = path.join(tmpDir, 'idem-mini-agent');
+    git(tmpDir, ['init', '--bare', remote]);
+    git(tmpDir, ['clone', remote, repo]);
+    git(repo, ['config', 'user.email', 'test@example.com']);
+    git(repo, ['config', 'user.name', 'Test User']);
+    writeFileSync(path.join(repo, 'README.md'), 'base\n');
+    git(repo, ['add', 'README.md']);
+    git(repo, ['commit', '-m', 'init']);
+    git(repo, ['branch', '-M', 'runtime/main']);
+    git(repo, ['push', '-u', 'origin', 'runtime/main:main']);
+    git(repo, ['fetch', 'origin', 'main']);
+    git(repo, ['branch', '--set-upstream-to=origin/main', 'runtime/main']);
+
+    writeFileSync(path.join(repo, 'README.md'), 'base\nruntime local\n');
+    git(repo, ['commit', '-am', 'diag: runtime local change']);
+    const localHead = gitOut(repo, ['rev-parse', 'HEAD']);
+    const expectedBranch = `fix/runtime-autocorrect-${localHead.slice(0, 8)}`;
+
+    // Simulate a prior partial run: branch already pushed to origin, but runtime
+    // was never reset (e.g. because gh pr create failed mid-sequence).
+    execFileSync('git', ['push', 'origin', `HEAD:refs/heads/${expectedBranch}`], { cwd: repo, stdio: 'ignore' });
+
+    // Retry the autocorrect — must NOT throw on cherry-pick / push, must still reset runtime.
+    const result = autocorrectRuntimeWorkspace(repo, {
+      apply: true,
+      createPr: false,
+      worktreeParent: tmpDir,
+    });
+
+    expect(result.status).toBe('created-worktree');
+    expect(result.branch).toBe(expectedBranch);
+    expect(gitOut(repo, ['rev-parse', 'HEAD'])).toBe(gitOut(repo, ['rev-parse', 'origin/main']));
+    expect(gitOut(repo, ['status', '--short', '--branch'])).toContain('runtime/main...origin/main');
+  });
 });
 
 function git(cwd: string, args: string[]): void {


### PR DESCRIPTION
## Summary

Closes #170.

When `autocorrectRuntimeWorkspace` partially succeeds — `git push -u origin <branch>` lands but a later step (typically `gh pr create`, but any error in the `try` block qualifies) throws — the function returns `status: 'failed'` and the runtime checkout is **never reset**. The agent loop sees the same `pending-push` state next cycle and re-enters autocorrect, which then dies on:

1. `git cherry-pick` — commits are already on the (existing) branch (`nothing to commit / cherry-pick is now empty`)
2. `gh pr create` — a PR already exists for that branch

Net effect: runtime/main stays diverged, autocorrect failure is logged on every cycle, and human intervention (`git reset --hard origin/main` on the runtime checkout) is the only escape.

## Fix

Two surgical idempotency checks in `src/runtime-workspace-autocorrect.ts`:

1. **Skip cherry-pick + push if remote branch already exists.** Probed via `git ls-remote --heads origin <branch>` before `ensureWorktree`. When the branch is already on origin, we trust the prior push and proceed straight to PR creation.
2. **Reuse existing PR if found.** New `findExistingPullRequest()` helper calls `gh pr list --repo … --head <branch> --state open --json url --limit 1`. If an open PR is found, its URL is returned and `createPullRequest` is skipped.

Either way the final `git reset --hard origin/${baseBranch}` on the runtime checkout still executes — that's the loop-breaking step.

## Verification

- `pnpm tsc --noEmit` clean (with `node_modules` linked from sibling worktree).
- `pnpm vitest run tests/runtime-workspace-autocorrect.test.ts` → **4 passed** including the new idempotency case.
- New test (`is idempotent: re-uses existing remote branch and PR when retry runs after partial failure`) simulates a prior partial run by pre-pushing the autocorrect branch via `git push origin HEAD:refs/heads/<branch>`, then asserts the retry:
  - does not throw on cherry-pick
  - returns `status: 'created-worktree'`
  - resets runtime/main back to origin/main (`status --branch` shows `runtime/main...origin/main`, no ahead/behind)

## Out of scope (Concern E from #169 review)

PR body still doesn't include the original commit messages — left for a follow-up issue so this PR stays narrow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)