### PR TITLE
fix: refresh git index before runtime dirty checks

### DIFF
--- a/scripts/check-runtime-workspace.ts
+++ b/scripts/check-runtime-workspace.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env tsx
 import { execFileSync } from 'node:child_process';
 import path from 'node:path';
-import { isCodePath, isRuntimeRepoMemoryPath, isSafeRuntimeBranch, parseDirtyPaths } from '../src/workspace-isolation.js';
+import { isCodePath, isRuntimeRepoMemoryPath, isSafeRuntimeBranch, parseDirtyPaths, refreshGitIndex } from '../src/workspace-isolation.js';
 
 const allow = process.env.MINI_AGENT_ALLOW_RUNTIME_WORKSPACE_WRITE === '1';
 const json = process.argv.includes('--json');
@@ -11,6 +11,7 @@ const repoRoot = git(['rev-parse', '--show-toplevel']) || cwd;
 const branch = git(['rev-parse', '--abbrev-ref', 'HEAD']) || null;
 const protectedRoot = path.resolve(process.env.MINI_AGENT_RUNTIME_WORKSPACE ?? inferRuntimeWorkspace(repoRoot));
 const isProtectedRuntime = path.resolve(repoRoot) === protectedRoot;
+refreshGitIndex(repoRoot);
 const paths = stagedOnly ? stagedPaths() : parseDirtyPaths(git(['status', '--porcelain']) ?? '');
 const blockingPaths = paths.filter(isCodePath);
 const runtimeMemoryPaths = paths.filter(isRuntimeRepoMemoryPath);

--- a/src/correction-gate.ts
+++ b/src/correction-gate.ts
@@ -11,7 +11,7 @@ import {
   type ActiveHoldMatch,
   type CorrectionHold,
 } from './correction-holds.js';
-import { evaluateWorkspaceIsolation, isCodePath, isSafeRuntimeBranch } from './workspace-isolation.js';
+import { evaluateWorkspaceIsolation, isCodePath, isSafeRuntimeBranch, refreshGitIndex } from './workspace-isolation.js';
 
 export type CorrectionReasonType =
   | 'pending-pledge'
@@ -348,6 +348,7 @@ function readShipTruth(repoRoot: string): ShipTruthState {
   }
 
   try {
+    refreshGitIndex(repoRoot);
     const status = execSync('git status --porcelain=v2 --branch', {
       cwd: repoRoot,
       encoding: 'utf-8',

--- a/src/runtime-workspace-autocorrect.ts
+++ b/src/runtime-workspace-autocorrect.ts
@@ -1,7 +1,7 @@
 import { execFileSync } from 'node:child_process';
 import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
-import { isSafeRuntimeBranch } from './workspace-isolation.js';
+import { isSafeRuntimeBranch, refreshGitIndex } from './workspace-isolation.js';
 
 export type RuntimeAutocorrectStatus =
   | 'not-needed'
@@ -125,6 +125,7 @@ export function autocorrectRuntimeWorkspace(repoRoot = process.cwd(), opts: {
 
 function readGitSnapshot(repoRoot: string): GitSnapshot | null {
   if (!existsSync(path.join(repoRoot, '.git'))) return null;
+  refreshGitIndex(repoRoot);
   const status = git(repoRoot, ['status', '--porcelain=v2', '--branch']);
   let branch: string | null = null;
   let headSha: string | null = null;

--- a/src/workspace-isolation.ts
+++ b/src/workspace-isolation.ts
@@ -24,6 +24,7 @@ const CODE_FILE_PATTERN = /^(package\.json|pnpm-lock\.yaml|tsconfig\.json|agent-
 export function evaluateWorkspaceIsolation(cwd = process.cwd(), protectedRoot = process.env.MINI_AGENT_RUNTIME_WORKSPACE): WorkspaceIsolationDecision {
   const repoRoot = git(cwd, ['rev-parse', '--show-toplevel']) || null;
   const branch = git(cwd, ['rev-parse', '--abbrev-ref', 'HEAD']) || null;
+  refreshGitIndex(cwd);
   const dirtyPaths = parseDirtyPaths(git(cwd, ['status', '--porcelain']) ?? '');
   const codeDirtyPaths = dirtyPaths.filter(isCodePath);
   const runtimeMemoryDirtyPaths = dirtyPaths.filter(isRuntimeRepoMemoryPath);
@@ -128,6 +129,18 @@ export function isRuntimeRepoMemoryPath(filePath: string): boolean {
 
 export function isSafeRuntimeBranch(branch: string | null | undefined): boolean {
   return Boolean(branch && SAFE_RUNTIME_BRANCHES.has(branch));
+}
+
+export function refreshGitIndex(cwd = process.cwd()): void {
+  try {
+    execFileSync('git', ['update-index', '-q', '--refresh'], {
+      cwd,
+      stdio: ['ignore', 'ignore', 'ignore'],
+      timeout: 8000,
+    });
+  } catch {
+    // Best effort only: callers still fall back to git status for real dirt.
+  }
 }
 
 function parseDirtyPath(line: string): string {

--- a/tests/correction-gate.test.ts
+++ b/tests/correction-gate.test.ts
@@ -107,6 +107,34 @@ describe('correction gate', () => {
     }));
   });
 
+  it('does not flag protected runtime checkout when a file is only stat-dirty', () => {
+    const memoryDir = mkdtempSync(path.join(os.tmpdir(), 'mini-agent-correction-gate-memory-'));
+    try {
+      execGit(['init'], tmpDir);
+      execGit(['config', 'user.email', 'test@example.com'], tmpDir);
+      execGit(['config', 'user.name', 'Test User'], tmpDir);
+      writeFileSync(path.join(tmpDir, 'src-file.ts'), 'export const value = 1;\n', 'utf-8');
+      execGit(['add', 'src-file.ts'], tmpDir);
+      execGit(['commit', '-m', 'init'], tmpDir);
+      execGit(['branch', '-M', 'runtime/main'], tmpDir);
+      process.env.MINI_AGENT_RUNTIME_WORKSPACE = execFileSync('git', ['rev-parse', '--show-toplevel'], {
+        cwd: tmpDir,
+        encoding: 'utf-8',
+      }).trim();
+
+      writeFileSync(path.join(tmpDir, 'src-file.ts'), 'export const value = 1;\n', 'utf-8');
+
+      const snapshot = evaluateCorrectionGate(memoryDir, tmpDir);
+
+      expect(snapshot.needsCorrection).toBe(false);
+      expect(snapshot.shipTruth.dirty).toBe(false);
+      expect(snapshot.shipTruth.dirtyPaths).toEqual([]);
+    } finally {
+      delete process.env.MINI_AGENT_RUNTIME_WORKSPACE;
+      rmSync(memoryDir, { recursive: true, force: true });
+    }
+  });
+
   it('flags protected runtime checkout when it is on main instead of runtime/main', () => {
     try {
       execGit(['init'], tmpDir);


### PR DESCRIPTION
## Summary
- refresh Git index before protected runtime dirty checks classify workspace state
- apply the refresh in workspace isolation, correction gate, runtime autocorrect, and runtime workspace check CLI
- add a regression test for content-identical stat-dirty files in protected runtime checkout

## Root cause
`src/memory.ts` was reported dirty even though its blob hash matched `HEAD`. The file had a newer mtime/ctime, so Git status could report stat dirt until the index was refreshed. This was a false dirty signal, not a real code diff.

## Verification
- `pnpm exec vitest run tests/correction-gate.test.ts tests/workspace-isolation.test.ts tests/runtime-workspace-autocorrect.test.ts`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test` (78 files, 630 passed, 2 skipped)