### PR TITLE
fix: keep runtime memory external and route around held providers

### DIFF
--- a/plugins/chat-room-inbox.sh
+++ b/plugins/chat-room-inbox.sh
@@ -105,7 +105,8 @@ except: pass
     fi
 
     # Fallback: JSONL (truncated but functional)
-    CONV_FILE="$PROJECT_DIR/memory/conversations/$TODAY.jsonl"
+    MEMORY_DIR="${MINI_AGENT_MEMORY_DIR:-${MINI_AGENT_MEMORY:-$PROJECT_DIR/memory}}"
+    CONV_FILE="$MEMORY_DIR/conversations/$TODAY.jsonl"
     if [ -f "$CONV_FILE" ]; then
         tail -8 "$CONV_FILE" 2>/dev/null | while IFS= read -r line; do
             from=$(echo "$line" | sed -n 's/.*"from":"\([^"]*\)".*/\1/p')

--- a/plugins/github-issues.sh
+++ b/plugins/github-issues.sh
@@ -4,6 +4,7 @@
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+MEMORY_DIR="${MINI_AGENT_MEMORY_DIR:-${MINI_AGENT_MEMORY:-$PROJECT_DIR/memory}}"
 CACHE_FILE="${TMPDIR:-/tmp}/mini-agent-github-issues.cache"
 CACHE_TTL=60  # seconds
 mkdir -p "$(dirname "$CACHE_FILE")" 2>/dev/null || true
@@ -47,7 +48,7 @@ output="=== Open Issues: $count ==="
 # ─── Issue Autopilot：把 open issue 寫入 memory index，讓 scheduler 能接手 ───
 if [ "${MINI_AGENT_GITHUB_ISSUE_AUTOPILOT:-1}" != "0" ]; then
   if [ -f "$PROJECT_DIR/dist/issue-autopilot-cli.js" ]; then
-    sync_output=$(MINI_AGENT_MEMORY_DIR="$PROJECT_DIR/memory" node "$PROJECT_DIR/dist/issue-autopilot-cli.js" --json --limit 50 2>/dev/null | sed -n '/^{/,$p')
+    sync_output=$(MINI_AGENT_MEMORY_DIR="$MEMORY_DIR" node "$PROJECT_DIR/dist/issue-autopilot-cli.js" --json --limit 50 2>/dev/null | sed -n '/^{/,$p')
     if [ -n "$sync_output" ]; then
       sync_summary=$(echo "$sync_output" | jq -r '"Issue Autopilot: scanned=\(.scanned) created=\(.created) updated=\(.updated) skipped=\(.skipped)"' 2>/dev/null)
       if [ -n "$sync_summary" ]; then

--- a/plugins/handoff-watcher.sh
+++ b/plugins/handoff-watcher.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # Handoff Watcher — 顯示 memory/handoffs/ 中的任務狀態（含 To + Depends-on 檢查）
-cd "$(dirname "$0")/../memory/handoffs" 2>/dev/null || exit 0
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+MEMORY_DIR="${MINI_AGENT_MEMORY_DIR:-${MINI_AGENT_MEMORY:-$PROJECT_DIR/memory}}"
+cd "$MEMORY_DIR/handoffs" 2>/dev/null || exit 0
 
 found=0
 for f in *.md; do

--- a/plugins/self-awareness.sh
+++ b/plugins/self-awareness.sh
@@ -5,7 +5,7 @@
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
-MEMORY_DIR="${MINI_AGENT_MEMORY:-$PROJECT_DIR/memory}"
+MEMORY_DIR="${MINI_AGENT_MEMORY_DIR:-${MINI_AGENT_MEMORY:-$PROJECT_DIR/memory}}"
 TOPICS_DIR="$MEMORY_DIR/topics"
 INSTANCE_ID="${MINI_AGENT_INSTANCE:-unknown}"
 BEHAVIOR_LOG="$HOME/.mini-agent/instances/$INSTANCE_ID/logs/behavior/$(date +%Y-%m-%d).jsonl"

--- a/plugins/self-healing.sh
+++ b/plugins/self-healing.sh
@@ -7,6 +7,7 @@
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+MEMORY_DIR="${MINI_AGENT_MEMORY_DIR:-${MINI_AGENT_MEMORY:-$PROJECT_DIR/memory}}"
 HEALED=0
 
 # macOS-compatible timeout — background + kill (perl alarm can't kill docker)
@@ -95,21 +96,21 @@ fi
 
 # --- Check 4: Critical Memory Files ---
 for f in SOUL.md MEMORY.md HEARTBEAT.md; do
-  if [ ! -f "$PROJECT_DIR/memory/$f" ]; then
-    (cd "$PROJECT_DIR" && git checkout HEAD -- "memory/$f" 2>/dev/null)
-    if [ -f "$PROJECT_DIR/memory/$f" ]; then
-      heal_report "HEALED" "memory/$f was missing → restored from git"
-    else
-      heal_report "FAILED" "memory/$f missing and cannot restore from git"
-    fi
+  if [ ! -f "$MEMORY_DIR/$f" ]; then
+    heal_report "FAILED" "$MEMORY_DIR/$f missing"
   fi
 done
 
-# --- Check 5: Uncommitted Memory Changes (data loss risk) ---
-if [ -d "$PROJECT_DIR/.git" ]; then
-  DIRTY=$(cd "$PROJECT_DIR" && git status --short memory/ skills/ plugins/ 2>/dev/null | wc -l | tr -d ' ')
+# --- Check 5: Uncommitted Knowledge Changes (data loss risk) ---
+if [ -d "$MEMORY_DIR/.git" ]; then
+  DIRTY=$(cd "$MEMORY_DIR" && git status --short 2>/dev/null | wc -l | tr -d ' ')
   if [ "$DIRTY" -gt 15 ]; then
-    heal_report "FAILED" "${DIRTY} uncommitted changes in memory/skills/plugins — data loss risk"
+    heal_report "FAILED" "${DIRTY} uncommitted changes in external memory repo — data loss risk"
+  fi
+elif [ -d "$PROJECT_DIR/.git" ]; then
+  DIRTY=$(cd "$PROJECT_DIR" && git status --short skills/ plugins/ 2>/dev/null | wc -l | tr -d ' ')
+  if [ "$DIRTY" -gt 15 ]; then
+    heal_report "FAILED" "${DIRTY} uncommitted changes in skills/plugins — data loss risk"
   fi
 fi
 

--- a/plugins/state-watcher.sh
+++ b/plugins/state-watcher.sh
@@ -5,7 +5,7 @@
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
-MEMORY_DIR="${MINI_AGENT_MEMORY:-$PROJECT_DIR/memory}"
+MEMORY_DIR="${MINI_AGENT_MEMORY_DIR:-${MINI_AGENT_MEMORY:-$PROJECT_DIR/memory}}"
 SNAPSHOT_FILE="$MEMORY_DIR/.state-snapshot.json"
 
 # ─── 收集當前狀態 ─────────────────────────────

--- a/plugins/task-tracker.sh
+++ b/plugins/task-tracker.sh
@@ -5,7 +5,7 @@
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
-MEMORY_DIR="${MINI_AGENT_MEMORY:-$PROJECT_DIR/memory}"
+MEMORY_DIR="${MINI_AGENT_MEMORY_DIR:-${MINI_AGENT_MEMORY:-$PROJECT_DIR/memory}}"
 
 # ─── HEARTBEAT.md（任務清單）───────────────────
 HEARTBEAT="$MEMORY_DIR/HEARTBEAT.md"

--- a/scripts/comfort-zone-audit.sh
+++ b/scripts/comfort-zone-audit.sh
@@ -68,14 +68,15 @@ fi
 
 # HEARTBEAT tasks
 HEARTBEAT=""
-if [[ -f "$PROJECT_DIR/memory/HEARTBEAT.md" ]]; then
-  HEARTBEAT=$(head -60 "$PROJECT_DIR/memory/HEARTBEAT.md" 2>/dev/null)
+MEMORY_DIR="${MINI_AGENT_MEMORY_DIR:-${MINI_AGENT_MEMORY:-$PROJECT_DIR/memory}}"
+if [[ -f "$MEMORY_DIR/HEARTBEAT.md" ]]; then
+  HEARTBEAT=$(head -60 "$MEMORY_DIR/HEARTBEAT.md" 2>/dev/null)
 fi
 
 # SOUL identity (brief)
 SOUL_BRIEF=""
-if [[ -f "$PROJECT_DIR/memory/SOUL.md" ]]; then
-  SOUL_BRIEF=$(head -40 "$PROJECT_DIR/memory/SOUL.md" 2>/dev/null)
+if [[ -f "$MEMORY_DIR/SOUL.md" ]]; then
+  SOUL_BRIEF=$(head -40 "$MEMORY_DIR/SOUL.md" 2>/dev/null)
 fi
 
 # Build the data payload

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -7,8 +7,12 @@ set -e
 DEPLOY_DIR="/Users/user/Workspace/mini-agent"
 LOG_FILE="$HOME/.mini-agent/deploy.log"
 LOCK_DIR="$HOME/.mini-agent/deploy.lock"
+DEFAULT_MEMORY_DIR="$(dirname "$DEPLOY_DIR")/mini-agent-memory/memory"
 
 mkdir -p "$HOME/.mini-agent"
+mkdir -p "$DEFAULT_MEMORY_DIR"
+export MINI_AGENT_MEMORY_DIR="${MINI_AGENT_MEMORY_DIR:-$DEFAULT_MEMORY_DIR}"
+export MINI_AGENT_MEMORY="${MINI_AGENT_MEMORY:-$MINI_AGENT_MEMORY_DIR}"
 
 log() {
     echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1" | tee -a "$LOG_FILE"

--- a/src/delegation.ts
+++ b/src/delegation.ts
@@ -38,6 +38,7 @@ import { createDefaultMiddlewarePeers } from './middleware-peer-agent.js';
 import type { BrainRequest } from './brain-types.js';
 import { getCachedAvailableBrainActors, isBrainRuntimeDelegationEnabled, refreshBrainHealth } from './brain-health.js';
 import { readActorOutcomeStatsSync } from './actor-outcome-stats.js';
+import { filterActorsForProviderResourceHolds } from './provider-resource-guard.js';
 import {
   getDelegationFailureCode,
   markDelegationFailureDiagnosticCreated,
@@ -274,11 +275,14 @@ export function spawnDelegation(task: DelegationTask): string {
   );
   const workdir = task.workdir.replace(/^~/, process.env.HOME ?? '');
   const memDir = getMemoryRootDir();
+  const availableActors = isBrainRuntimeDelegationEnabled()
+    ? filterActorsForProviderResourceHolds(getCachedAvailableBrainActors(), memDir)
+    : undefined;
   const arbitration = decideArbitration(
     workItem,
     isBrainRuntimeDelegationEnabled()
       ? {
-          availableActors: getCachedAvailableBrainActors(),
+          availableActors,
           actorStats: readActorOutcomeStatsSync(memDir, { intent: workItem.intent, limit: 300 }),
         }
       : undefined,

--- a/src/provider-resource-guard.ts
+++ b/src/provider-resource-guard.ts
@@ -1,3 +1,6 @@
+import type { ActorId } from './brain-types.js';
+import { queryMemoryIndexSync } from './memory-index.js';
+
 export interface ProviderResourceHold {
   type: 'provider-quota';
   provider: 'claude' | 'codex' | 'unknown';
@@ -26,6 +29,34 @@ export function classifyProviderResourceHold(
   };
 }
 
+export function readActiveProviderResourceHolds(
+  memoryDir: string,
+  now = new Date(),
+): ProviderResourceHold[] {
+  const holds: ProviderResourceHold[] = [];
+  for (const entry of queryMemoryIndexSync(memoryDir, { type: ['task'], status: ['hold'] })) {
+    const hold = parseProviderResourceHold(entry.payload?.provider_resource_hold);
+    if (!hold) continue;
+    const resumeAt = Date.parse(hold.resumeAt);
+    if (!Number.isFinite(resumeAt) || resumeAt <= now.getTime()) continue;
+    holds.push(hold);
+  }
+  return holds;
+}
+
+export function filterActorsForProviderResourceHolds(
+  actors: ActorId[],
+  memoryDir: string,
+  now = new Date(),
+): ActorId[] {
+  const heldProviders = new Set(readActiveProviderResourceHolds(memoryDir, now).map(hold => hold.provider));
+  if (heldProviders.size === 0) return actors;
+  return actors.filter(actor => {
+    if (heldProviders.has('unknown') && (actor === 'claude' || actor === 'codex')) return false;
+    return !heldProviders.has(actor as ProviderResourceHold['provider']);
+  });
+}
+
 function parseResetTime(output: string, now: Date): Date | null {
   const match = output.match(/resets?\s+(\d{1,2})(?::(\d{2}))?\s*(am|pm)?/i);
   if (!match) return null;
@@ -42,4 +73,18 @@ function parseResetTime(output: string, now: Date): Date | null {
   reset.setHours(hour, minute, 0, 0);
   if (reset <= now) reset.setDate(reset.getDate() + 1);
   return reset;
+}
+
+function parseProviderResourceHold(value: unknown): ProviderResourceHold | null {
+  if (!value || typeof value !== 'object') return null;
+  const raw = value as Record<string, unknown>;
+  if (raw.type !== 'provider-quota') return null;
+  if (raw.provider !== 'claude' && raw.provider !== 'codex' && raw.provider !== 'unknown') return null;
+  if (typeof raw.resumeAt !== 'string' || typeof raw.reason !== 'string') return null;
+  return {
+    type: 'provider-quota',
+    provider: raw.provider,
+    resumeAt: raw.resumeAt,
+    reason: raw.reason,
+  };
 }

--- a/tests/deploy-script.test.ts
+++ b/tests/deploy-script.test.ts
@@ -30,4 +30,16 @@ describe('deploy script workspace janitor hook', () => {
     expect(script).toContain('Skipping workspace janitor because deploy checkout has unresolved conflicts');
     expect(script).toContain('Workspace janitor failed (non-fatal)');
   });
+
+  it('exports external memory paths before starting the runtime service', () => {
+    const script = readFileSync(path.join(process.cwd(), 'scripts', 'deploy.sh'), 'utf-8');
+    const defaultMemoryIndex = script.indexOf('DEFAULT_MEMORY_DIR="$(dirname "$DEPLOY_DIR")/mini-agent-memory/memory"');
+    const exportIndex = script.indexOf('export MINI_AGENT_MEMORY_DIR="${MINI_AGENT_MEMORY_DIR:-$DEFAULT_MEMORY_DIR}"');
+    const startIndex = script.indexOf('node "$DEPLOY_DIR/dist/cli.js" up -d');
+
+    expect(defaultMemoryIndex).toBeGreaterThan(-1);
+    expect(exportIndex).toBeGreaterThan(defaultMemoryIndex);
+    expect(exportIndex).toBeLessThan(startIndex);
+    expect(script).toContain('export MINI_AGENT_MEMORY="${MINI_AGENT_MEMORY:-$MINI_AGENT_MEMORY_DIR}"');
+  });
 });

--- a/tests/plugin-memory-paths.test.ts
+++ b/tests/plugin-memory-paths.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('plugin memory path policy', () => {
+  it('does not force Issue Autopilot writes into the runtime checkout memory directory', () => {
+    const script = readFileSync(path.join(process.cwd(), 'plugins', 'github-issues.sh'), 'utf-8');
+
+    expect(script).toContain('MEMORY_DIR="${MINI_AGENT_MEMORY_DIR:-${MINI_AGENT_MEMORY:-$PROJECT_DIR/memory}}"');
+    expect(script).toContain('MINI_AGENT_MEMORY_DIR="$MEMORY_DIR" node "$PROJECT_DIR/dist/issue-autopilot-cli.js"');
+    expect(script).not.toContain('MINI_AGENT_MEMORY_DIR="$PROJECT_DIR/memory"');
+  });
+
+  it('reads handoffs from the configured memory root', () => {
+    const script = readFileSync(path.join(process.cwd(), 'plugins', 'handoff-watcher.sh'), 'utf-8');
+
+    expect(script).toContain('MEMORY_DIR="${MINI_AGENT_MEMORY_DIR:-${MINI_AGENT_MEMORY:-$PROJECT_DIR/memory}}"');
+    expect(script).toContain('cd "$MEMORY_DIR/handoffs"');
+    expect(script).not.toContain('../memory/handoffs');
+  });
+});

--- a/tests/provider-resource-guard.test.ts
+++ b/tests/provider-resource-guard.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from 'vitest';
-import { classifyProviderResourceHold } from '../src/provider-resource-guard.js';
+import { mkdtempSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { appendMemoryIndexEntry } from '../src/memory-index.js';
+import {
+  classifyProviderResourceHold,
+  filterActorsForProviderResourceHolds,
+  readActiveProviderResourceHolds,
+} from '../src/provider-resource-guard.js';
 
 describe('provider resource guard', () => {
   it('classifies Claude usage exhaustion with reset time', () => {
@@ -30,5 +38,62 @@ describe('provider resource guard', () => {
 
   it('ignores normal command failures', () => {
     expect(classifyProviderResourceHold('Shell error: Command exited 1')).toBeNull();
+  });
+
+  it('reads active provider holds from held tasks', async () => {
+    const memoryDir = mkdtempSync(path.join(os.tmpdir(), 'mini-agent-provider-hold-'));
+    try {
+      await appendMemoryIndexEntry(memoryDir, {
+        type: 'task',
+        status: 'hold',
+        summary: 'Hold Codex while quota is exhausted',
+        refs: [],
+        payload: {
+          provider_resource_hold: {
+            type: 'provider-quota',
+            provider: 'codex',
+            resumeAt: '2026-05-06T18:40:00.000Z',
+            reason: 'codex provider quota/resource exhausted',
+          },
+        },
+      });
+
+      const holds = readActiveProviderResourceHolds(memoryDir, new Date('2026-05-06T18:30:00.000Z'));
+
+      expect(holds).toHaveLength(1);
+      expect(holds[0]).toEqual(expect.objectContaining({ provider: 'codex' }));
+    } finally {
+      rmSync(memoryDir, { recursive: true, force: true });
+    }
+  });
+
+  it('removes held providers from actor selection candidates', async () => {
+    const memoryDir = mkdtempSync(path.join(os.tmpdir(), 'mini-agent-provider-hold-'));
+    try {
+      await appendMemoryIndexEntry(memoryDir, {
+        type: 'task',
+        status: 'hold',
+        summary: 'Hold Claude while quota is exhausted',
+        refs: [],
+        payload: {
+          provider_resource_hold: {
+            type: 'provider-quota',
+            provider: 'claude',
+            resumeAt: '2026-05-06T18:40:00.000Z',
+            reason: 'claude provider quota/resource exhausted',
+          },
+        },
+      });
+
+      const actors = filterActorsForProviderResourceHolds(
+        ['claude', 'codex', 'akari', 'kuro'],
+        memoryDir,
+        new Date('2026-05-06T18:30:00.000Z'),
+      );
+
+      expect(actors).toEqual(['codex', 'akari', 'kuro']);
+    } finally {
+      rmSync(memoryDir, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary
- export an external memory directory during deploy so runtime children inherit the same memory root
- update perception/plugins and audits to respect MINI_AGENT_MEMORY_DIR before falling back to repo-local memory
- route around Claude/Codex provider quota holds when selecting actors for delegation
- add regression coverage for plugin memory paths, deploy memory export, and provider hold filtering

## Why
Runtime checkout was repeatedly dirtied by repo-local memory writes such as `memory/handoffs/active.md`. Claude/Codex lanes also kept being selected while prior quota/resource holds were still active.

## Verification
- `pnpm exec vitest run tests/provider-resource-guard.test.ts tests/plugin-memory-paths.test.ts tests/deploy-script.test.ts tests/brain-arbiter.test.ts tests/brain-health.test.ts`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test` (79 files, 636 passed, 2 skipped)