### PR TITLE
chore(handoffs): drain stale PR #139 review consensus

### DIFF
--- a/memory/handoffs/active.md
+++ b/memory/handoffs/active.md
@@ -113,8 +113,8 @@
 | github | kuro | PR #137 fix(ledger): surface unacked agent commitments | merged | 05-06 | 05-06 |
 | github | kuro | PR #136 fix: hard guard runtime workspace isolation | merged | 05-06 | 05-06 |
 | github | claude-code | PR #140 feat(soft-gate): synthesize Decision block from prose (#132) | merged | 05-06 | 05-06 |
-| github | codex | PR #139 [forge] ## Task: P1 GitHub issue #124: correction-gate: low-responsiveness fires on stal | changes-requested | 05-06 | - |
-| github | claude-code | PR #139 [forge] ## Task: P1 GitHub issue #124: correction-gate: low-responsiveness fires on stal | changes-requested | 05-06 | - |
+| github | codex | PR #139 [forge] ## Task: P1 GitHub issue #124: correction-gate: low-responsiveness fires on stal | closed-on-github | 05-06 | - |
+| github | claude-code | PR #139 [forge] ## Task: P1 GitHub issue #124: correction-gate: low-responsiveness fires on stal | closed-on-github | 05-06 | - |
 | github | kuro | #141 delegation: phantom-prompt + masked-forge-error allows fail-ejkd7t-shaped repeats | needs-triage | 05-06 | — |
 | github | kuro | PR #142 fix: externalize runtime memory state | merged | 05-06 | 05-06 |
 | github | akari | PR #143 test(delegation): pin phantom-prompt classifier spec for #141 | needs-review | 05-06 | - |


### PR DESCRIPTION
## Summary
PR #139 closed on GitHub but `memory/handoffs/active.md` still listed it as `changes-requested` → `parsePrReviewHandoffs` blocked `pr-review-consensus` stage every cycle → emitted phantom `P0 repair pr-review-consensus`.

Mark stale rows as `closed-on-github` so they fall outside `REVIEW_STATUSES` and are filtered out.

## Verification
`evaluateAutonomyClosure` (`pnpm check:autonomy-closure -- --json`):
- before: status=blocked score=70 blocking=[pr-review-consensus]
- after: status=degraded score=84 blocking=[]

## Followup (not in this PR)
Upstream sync from live `gh pr view` state into handoff cleanup, otherwise recurs whenever a PR closes without a row update.

## Test plan
- [x] `pnpm check:autonomy-closure -- --json` returns blocking=[]
- [ ] Reviewer confirms no other phantom-P0 paths regress