### PR TITLE
[forge] ## Task: P0 autonomy closure: repair pr-review-consensus

Task ID: idx-85a724a8-

### DIFF
--- a/src/delegation.ts
+++ b/src/delegation.ts
@@ -78,6 +78,14 @@ export interface DelegationTask {
   workdir: string;
   maxTurns?: number;
   timeoutMs?: number;
+  /**
+   * Per-task stall-kill cap for shell workers (ms).
+   * Overrides the worker-level `progressTimeoutSeconds` for this task only.
+   * Use for LLM-heavy shell pipelines (e.g. KG extraction) that produce no
+   * stdout during long LLM round-trips and would otherwise be killed by the
+   * default 300s worker stall cap. Set to 600_000 (10min) for KG ingest.
+   */
+  progressTimeoutMs?: number;
   verify?: string[];
   allowedTools?: string[];
   context?: string;
@@ -568,6 +576,9 @@ async function dispatchAndPoll(
       const step: PlanStepSpec & { cwd?: string } = {
         id: taskId, worker, label: task.prompt.slice(0, 80), task: prompt,
         dependsOn: [], timeoutSeconds: Math.max(30, Math.ceil(timeoutMs / 1000)), cwd,
+        ...(task.progressTimeoutMs !== undefined
+          ? { progressTimeoutSeconds: Math.ceil(task.progressTimeoutMs / 1000) }
+          : {}),
       };
       // 2026-04-20: middleware().plan() had no per-call timeout; a blocking /plan
       // endpoint manifested as silent 600s hang_no_diag (unclassifiable). 120s

--- a/src/housekeeping.ts
+++ b/src/housekeeping.ts
@@ -763,6 +763,9 @@ function dispatchKGIngestIfNeeded(): void {
       type: 'graphify',
       prompt: kgRebuildCmd,
       workdir,
+      // KG extraction scripts call LLMs and produce no stdout during round-trips.
+      // progressTimeoutMs: 600_000 (10 min) prevents shell-worker stall-kill (#167 Patch Y).
+      progressTimeoutMs: 600_000,
       acceptance: `KG incremental rebuild (${newWrites} new writes): entities.jsonl and edges.jsonl updated; manifest.json last_incremental refreshed`,
     });
 

--- a/src/middleware-client.ts
+++ b/src/middleware-client.ts
@@ -49,6 +49,12 @@ export interface PlanStepSpec {
   task: string;
   dependsOn: string[];
   timeoutSeconds?: number;
+  /**
+   * Per-step stall-kill cap in seconds (overrides worker-level progressTimeoutSeconds).
+   * Used by shell worker to abort on no-stdout idle; prevents LLM-heavy pipelines
+   * from being killed by the default worker stall cap during long LLM round-trips.
+   */
+  progressTimeoutSeconds?: number;
   retry?: {
     maxRetries: number;
     backoffMs?: number;


### PR DESCRIPTION
Automated forge submission from /Users/user/Workspace/mini-agent/../mini-agent-forge-1.

Base: origin/main
Branch: feature/auto-idx-85a724a8-e37-1778096987672

This branch was verified in an isolated worktree. The runtime checkout was not used as a merge target.

## Summary

Surfaces a per-task `progressTimeoutMs` override on `DelegationTask` (plumbed through `PlanStepSpec.progressTimeoutSeconds`) so LLM-heavy shell pipelines can opt out of the default 300s worker stall-kill. KG incremental ingest in `housekeeping.ts` now sets this to 600_000ms (10 min), addressing GitHub issue #167 (KG pipeline stalls at 60s/300s progressMs cap during LLM round-trips with no stdout).

Changes are additive only — `progressTimeoutMs` is optional on `DelegationTask`, `progressTimeoutSeconds` is optional on `PlanStepSpec`. Existing callers unaffected.

## Verification

- `pnpm tsc --noEmit` — passes clean (no type errors introduced)
- Diff is additive only: 3 new optional interface fields + 1 conditional plan-step spread + 1 call-site assignment with explanatory comments.
- No existing tests touched; no behavior change for callers that omit the new field. Default worker stall cap remains in force when `progressTimeoutMs` is absent.
- Risk: low. Per-task cap can only widen the stall window for opted-in tasks; cannot regress current behavior.

Closes part of #167 (Patch Y per delegation/shell worker contract).