### PR TITLE
fix(correction-gate): support findActiveHold for runtime-workspace-wrong-branch (#189)

### DIFF
--- a/src/correction-gate.ts
+++ b/src/correction-gate.ts
@@ -118,9 +118,22 @@ export function evaluateCorrectionGate(memoryDir: string, repoRoot = process.cwd
   const workspaceIsolation = evaluateWorkspaceIsolation(repoRoot);
 
   if (workspaceIsolation.protectedRuntimeWorkspace && shipTruth.repoPresent && !isSafeRuntimeBranch(shipTruth.branch)) {
-    const message = `runtime workspace 在錯誤分支 ${shipTruth.branch ?? 'unknown'} — protected runtime checkout 只能在 runtime/main；功能修改要用 isolated worktree + PR。`;
-    reasons.push({ type: 'runtime-workspace-wrong-branch', severity: 'high', message });
-    guidance.push(message);
+    const match = findActiveHold(holds, 'runtime-workspace-wrong-branch', {
+      branch: shipTruth.branch,
+      sha: shipTruth.headSha,
+    }, { repoRoot });
+
+    if (match) {
+      // Documented external hold (e.g., active PR work on a feature branch) — track for visibility, do NOT dispatch P0.
+      acknowledgedHolds.push(match);
+      guidance.push(
+        `runtime workspace 在 ${shipTruth.branch ?? 'unknown'} 但有 active hold (${match.matchedBy}): ${match.hold.reason}`,
+      );
+    } else {
+      const message = `runtime workspace 在錯誤分支 ${shipTruth.branch ?? 'unknown'} — protected runtime checkout 只能在 runtime/main；功能修改要用 isolated worktree + PR。`;
+      reasons.push({ type: 'runtime-workspace-wrong-branch', severity: 'high', message });
+      guidance.push(message);
+    }
   }
 
   if (workspaceIsolation.protectedRuntimeWorkspace && (shipTruth.state === 'pending-push' || shipTruth.state === 'diverged')) {

--- a/tests/correction-gate.test.ts
+++ b/tests/correction-gate.test.ts
@@ -159,6 +159,40 @@ describe('correction gate', () => {
     }
   });
 
+  it('acknowledges an active runtime-workspace-wrong-branch hold instead of emitting a correction reason', () => {
+    try {
+      execGit(['init'], tmpDir);
+      execGit(['config', 'user.email', 'test@example.com'], tmpDir);
+      execGit(['config', 'user.name', 'Test User'], tmpDir);
+      writeFileSync(path.join(tmpDir, 'README.md'), 'runtime guard fixture\n', 'utf-8');
+      execGit(['add', 'README.md'], tmpDir);
+      execGit(['commit', '-m', 'init'], tmpDir);
+      execGit(['branch', '-M', 'fix/issue-189-active-pr'], tmpDir);
+      process.env.MINI_AGENT_RUNTIME_WORKSPACE = execFileSync('git', ['rev-parse', '--show-toplevel'], {
+        cwd: tmpDir,
+        encoding: 'utf-8',
+      }).trim();
+
+      appendCorrectionHold(tmpDir, {
+        id: 'hold-runtime-branch',
+        correction_reason_type: 'runtime-workspace-wrong-branch',
+        reason: 'active PR work; will rebase/merge before runtime restart',
+        unblock_when: { kind: 'timeout', until: '2099-01-01T00:00:00Z' },
+        created_at: '2026-05-07T00:00:00Z',
+        created_by: 'test',
+      });
+      invalidateIndexCache();
+
+      const snapshot = evaluateCorrectionGate(tmpDir, tmpDir);
+
+      expect(snapshot.reasons.map(r => r.type)).not.toContain('runtime-workspace-wrong-branch');
+      expect(snapshot.acknowledgedHolds.map(h => h.hold.id)).toContain('hold-runtime-branch');
+      expect(snapshot.guidance.join('\n')).toContain('active hold');
+    } finally {
+      delete process.env.MINI_AGENT_RUNTIME_WORKSPACE;
+    }
+  });
+
   it('classifies only managed/code dirt as blocking runtime dirt', () => {
     expect(getBlockingRuntimeDirtyPaths([
       'memory/inner-notes.md',


### PR DESCRIPTION
## Summary
- The `runtime-workspace-wrong-branch` gate was the only high-severity correction reason without a `findActiveHold` escape valve. Sibling gates (`local-commit-not-pushed`, `dirty-runtime-workspace`, `low-responsiveness`) all consult the holds ledger before pushing P0.
- Without it, the gate fired every cycle whenever runtime checkout was on a non-`runtime/main` branch (e.g. while an active PR was awaiting merge before runtime restart), causing scheduler re-injection across many cycles — same re-injection shape as #186 / #188.
- This PR mirrors the sibling pattern: lookup an active hold keyed on gate type + branch/sha; on hit → `acknowledgedHolds` + guidance line; on miss → existing P0 reason. Behavior unchanged when no hold is recorded.

## Verification
- [x] `npm run typecheck` clean
- [x] `npx vitest run tests/correction-gate.test.ts` — 12/12 pass (1 new + 11 existing, including the original `flags protected runtime checkout when it is on main instead of runtime/main` regression test)
- [ ] After merge: append a `runtime-workspace-wrong-branch` hold for the active PR, observe gate routes to `acknowledgedHolds` instead of pushing P0 in scheduler logs.

Closes #189