### PR TITLE
fix(agent): stop wasteful retry on silent_exit_void HTTP-stall pattern

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -220,10 +220,26 @@ function classifyError(error: unknown): ErrorClassification {
 
   // Silent mid-duration exit — CLI returned without stderr after >= 2 minutes.
   // Before this patch, these fell through to UNKNOWN and got bucketed as `hang_no_diag`.
+  // 2026-05-07 (Issue #191): split silent_exit_void into two retryability classes.
+  //   - HTTP-stall (duration > 800s + stdout=empty): upstream provider held the SSE/stream
+  //     socket without progress until server-side timeout. Audit on 2026-05-06 showed 19 events
+  //     clustered tightly at 970–1007s, all retries (1/3, 2/3, 3/3) hit the same wall ⇒
+  //     burning 3000s+ per failure cycle. Mark non-retryable so the lane defers/switches.
+  //   - CLI internal hang (~260s, or stdout has any content): may recover on retry — keep retryable.
   if (duration && duration > 120_000 && exitCode !== null && !signal && !killed && !stderr.trim()) {
     const stdoutTail = stdout.trim().slice(-400).replace(/\x1b\[[0-9;]*m/g, '');
+    const stdoutEmpty = !stdoutTail;
     const stdoutHint = stdoutTail ? ` stdout_tail="${stdoutTail}"` : ' stdout=empty';
     const signalHint = signal ? ` signal=${signal}` : '';
+    const isHttpStall = stdoutEmpty && duration > 800_000;
+    if (isHttpStall) {
+      return {
+        type: 'TIMEOUT',
+        retryable: false,
+        message: `CLI 靜默中斷 HTTP-stall（exit ${exitCode}，${Math.round(duration / 1000)}s 無 stderr）.${stdoutHint}${signalHint}`,
+        modelGuidance: 'HTTP-stall pattern detected (>800s, no stdout, no stderr) — upstream provider held the stream socket without progress. Retrying immediately wastes another 1000s. Defer the task, switch provider lane if available, or escalate to user. Issue #191.'
+      };
+    }
     return {
       type: 'TIMEOUT',
       retryable: true,


### PR DESCRIPTION
Closes #191 (conditional on 2026-05-07 audit confirming reduced incidence — see falsifier).

## Summary
- Splits `silent_exit_void` classifier bucket in `src/agent.ts:223-244` by retry policy
- HTTP-stall (`duration > 800s` + `stdout=empty`) → `retryable=false`, defer/switch lane
- CLI internal hang (~260s, or any stdout content) → unchanged, `retryable=true`
- Stops 2 wasted retries per occurrence (3000s+ burned per failure cycle on 2026-05-06)

## Why now
Audit of `~/.mini-agent/instances/03bbc29a/logs/error/2026-05-06.jsonl` (issue body): 19 events clustered at 970–1007s, all attempts 1/3, 2/3, 3/3 hit identical wall. Tight cluster ⇒ structural server-side HTTP timeout, not random.

## Verification
- [x] `pnpm tsc --noEmit` clean
- [ ] After deploy, monitor `error-patterns.json` count for `silent_exit_void` over 48h: expect ≤ 1/3 of prior rate (since each occurrence now produces 1 attempt instead of 3)
- [ ] Spot-check first occurrence post-deploy: error-patterns entry for that event should map to `retryable=false` (visible in `lane defers vs retries` lane behavior)

## Falsifier
If 2026-05-07 audit shows ≥ 3 silent_exit_void events with `retryable=true` (i.e. CLI internal hang class, < 800s) → split is not the right axis, classifier needs a different distinguisher (e.g. by lane or by prompt-size). If 0 events of either class today → likely transient, patch is harmless but optional.

## Out of scope (deferred to follow-up issues)
- First-byte-timeout vs total-timeout split (Patch #2 in issue #191)
- `[CLI_HANG]` progress-watcher slog (Patch #3 in issue #191)