### PR TITLE
fix(memory): strip phantom tasks across all heartbeat render paths (#163 Defect B/C)

### DIFF
--- a/src/memory.ts
+++ b/src/memory.ts
@@ -3346,13 +3346,22 @@ export class InstanceMemory {
     // Everything else (Self-Governance, Strategic Direction, named priority sections) → heartbeat-strategy
 
     const hbDiff = options?.phase0Results?.heartbeatDiff;
+    // Issue #163 Defect B/C: isLight + hbDiff paths used raw heartbeat, leaking
+    // HTML-commented + [x]-completed phantom tasks. Strip noise like the else
+    // branch (L3367-3368) and minimal builder (L3723-3727) so all 4 render
+    // paths produce phantom-free output.
+    const hbStripped = (heartbeat ?? '')
+      .replace(/<!--[\s\S]*?-->\n?/g, '')
+      .split('\n')
+      .filter(l => !l.trim().startsWith('- [x]'))
+      .join('\n');
     if (isLight) {
       // Light mode: just active slice
-      const hbLight = heartbeat?.slice(0, 1500) ?? '';
+      const hbLight = hbStripped.slice(0, 1500);
       sections.push(`<heartbeat-active>\n${hbLight}\n</heartbeat-active>`);
     } else if (hbDiff) {
       // P0c: Compressed heartbeat — diff summary + essential sections (Active Tasks header)
-      const activeTasksMatch = heartbeat?.match(/## Active Tasks[\s\S]*?(?=\n## |$)/);
+      const activeTasksMatch = hbStripped.match(/## Active Tasks[\s\S]*?(?=\n## |$)/);
       const activeTasks = activeTasksMatch?.[0]?.slice(0, 1500) ?? '';
       const hbDiffContent = `## Changes Since Last Cycle\n${hbDiff}\n\n${activeTasks}`;
       eventBus.emit('log:info', {


### PR DESCRIPTION
## Summary
- Hoist heartbeat strip transform (HTML-comment regex + drop `- [x]` lines) ahead of the branch fork in `InstanceMemory.buildContext`, so `isLight` and `hbDiff` paths consume cleaned text — not just the `else` branch patched in #179.
- Closes the residual leak in #163: phantom `- [ ] P0 Cannot read properties of unde:generic` continued rendering in `<heartbeat-active>` after #179 merged.

## Why this is needed
PR #179 only patched the `else` branch of `buildContext`. Verified this cycle on issue #163:
- PR #179 state=MERGED, dist mtime `06:31`, server pid `32962` lstart `06:35:29` → patched binary running.
- Node simulation on the actual `HEARTBEAT.md` with the patch correctly removes the phantom.
- But live cycle context **still** rendered the phantom → another render path is not cleaned.

That render path is the `isLight` / `hbDiff` fork at `src/memory.ts:3354-3361`, which used raw `heartbeat` content. This PR fixes both.

## What changed
- `src/memory.ts` (+11 / −2): single hoisted `hbStripped` constant; `isLight` and `hbDiff` now slice / regex against it.
- The minimal builder (L3723-3727) and the previously-patched `else` branch already strip; this aligns the remaining two paths.
- Pure prefix transform — only removes noise lines, no semantic change.

## Verification
- `pnpm tsc --noEmit` → exit 0, typecheck clean on patched branch (run 2026-05-07T06:58Z).
- Build pipeline: `pnpm run build` produces dist with hoisted `hbStripped` constant present in compiled `dist/memory.js` (post-commit auto-rebuild hook covers this).
- Phantom-strip behavior verified by node simulation against live `HEARTBEAT.md`: `- [ ] P0 Cannot read properties of unde:generic` removed under both `isLight` and `hbDiff` paths.
- Pure-transform safety: only HTML-comment regex + `- [x]` drop applied; no semantic mutation. Smoke check passes (rendered context for non-phantom rows unchanged).

## Test plan
- [ ] Re-run with phantom-bearing `HEARTBEAT.md` and confirm `<heartbeat-active>` no longer contains commented or `[x]` lines under both `isLight` and `hbDiff` modes.
- [ ] Live cycle: phantom `- [ ] P0 Cannot read properties of unde:generic` disappears from rendered context after deploy.
- [ ] No regressions in cycles that previously rendered correctly under the `else` branch.

Refs: #163, #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)
