### PR TITLE
feat(github): observable pr-review-claims silent-skip paths (#195)

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -431,11 +431,17 @@ export function autofixPrVerificationSection(body?: string | null): PrVerificati
 export async function autoProduceInternalPrReviewClaims(): Promise<void> {
   const memoryDir = getMemoryRootDir();
   const activePath = path.join(memoryDir, 'handoffs', 'active.md');
-  if (!fs.existsSync(activePath)) return;
+  if (!fs.existsSync(activePath)) {
+    slog('github', 'pr-review-claims: no active.md');
+    return;
+  }
 
   let handoffs = parsePrReviewHandoffs(fs.readFileSync(activePath, 'utf-8'));
   handoffs = handoffs.filter(h => h.reviewer !== 'alex' && ['needs-review', 'review-pending', 'changes-requested'].includes(h.status));
-  if (handoffs.length === 0) return;
+  if (handoffs.length === 0) {
+    slog('github', 'pr-review-claims: 0 eligible handoffs');
+    return;
+  }
 
   const byPr = new Map<number, typeof handoffs>();
   for (const handoff of handoffs) {
@@ -464,9 +470,7 @@ export async function autoProduceInternalPrReviewClaims(): Promise<void> {
   }
 
   const result = appendMissingInternalPrReviewClaims(memoryDir, candidates);
-  if (result.created.length > 0) {
-    slog('github', `created ${result.created.length} internal PR review claim(s)`);
-  }
+  slog('github', `pr-review-claims: candidates=${candidates.length} created=${result.created.length} skipped=${result.skipped.length}`);
 }
 
 export async function autoRepairPrVerificationEvidence(): Promise<void> {


### PR DESCRIPTION
## Summary

Closes #195. Three previously silent no-op exit paths in `autoProduceInternalPrReviewClaims` now emit `slog` entries:

1. `no active.md` → `slog('github', 'pr-review-claims: no active.md')`
2. `0 eligible handoffs` after the reviewer/status filter → `slog('github', 'pr-review-claims: 0 eligible handoffs')`
3. Loop completion (always) → `slog('github', 'pr-review-claims: candidates=N created=M skipped=K')`

## Verification

- `pnpm exec tsc --noEmit` clean (only pre-existing unrelated errors in workspace.ts/write-lease.ts).
- `result.skipped` shape verified at `src/pr-review-runner.ts:286,304` (`InternalPrReviewClaimResult` has `created` + `skipped`).
- Behavior unchanged — only adds 1–2 slog lines per cron tick.

## Why now

PR #194 yesterday: I patched the body at 23:01Z but `pr-review-consensus` stayed `request_changes` because `autoProduceInternalPrReviewClaims` apparently never re-fired (or fired and silently skipped — unrecoverable from logs). Had to manually invoke at 23:04Z. Three silent vectors → zero observability → wedged.

## Falsifier

After landing, next PR body edit should produce `pr-review-claims: candidates=N created=M skipped=K` within one cron tick. If still silent → loop entry path itself is broken (narrower hypothesis, separate issue).

## Test plan

- [x] tsc clean
- [x] No behavior change (just added log statements)
- [ ] Post-merge: observe slog stream for `pr-review-claims:` lines on next cron tick