### PR TITLE
feat(falsifier-registry): structured ID-based registry (#197)

### DIFF
--- a/src/falsifier-registry.ts
+++ b/src/falsifier-registry.ts
@@ -1,0 +1,240 @@
+// Issue #197: Falsifier registry — structured tracking replaces text repetition.
+//
+// Problem: cycle output repeats falsifier conditions in natural language ~46x/day,
+// inflating tokens. No deduplication, no auto-expiry, no resolved tracking.
+//
+// Solution: append-only JSONL registry. Each falsifier gets a stable ID
+// (`fl-<8hex>`). Cycle output references `falsifier:fl-xxx` instead of restating
+// the full condition. Expired/resolved entries auto-prune from active list.
+//
+// Storage: memory/state/falsifier-registry.jsonl — one entry per line.
+// Mutations: register (new), resolve (set result), reread on every read.
+//
+// Schema is intentionally minimal — does NOT replace the executable
+// FalsifierQuery DSL in commitment-ledger.ts. This is the lightweight
+// reference layer for prose-style falsifiers in cycle output.
+
+import { existsSync, readFileSync, appendFileSync, mkdirSync } from 'node:fs';
+import path from 'node:path';
+import { createHash } from 'node:crypto';
+import { getMemoryStateDir } from './memory.js';
+import { slog } from './utils.js';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export type FalsifierResult = 'confirmed' | 'falsified' | 'expired';
+
+export interface FalsifierEntry {
+  id: string;                  // fl-<8 hex chars> — stable hash of condition
+  condition: string;           // human-readable predicate
+  cycleCreated: number;        // cycle number when registered
+  ttlCycles: number;           // expires after this many cycles
+  createdAt: string;           // ISO timestamp
+  resolvedAt?: string;
+  result?: FalsifierResult;
+  resolutionEvidence?: string; // why confirmed/falsified
+}
+
+interface RegistryFile {
+  path: string;
+  entries: Map<string, FalsifierEntry>;
+}
+
+// =============================================================================
+// Storage
+// =============================================================================
+
+const REGISTRY_FILENAME = 'falsifier-registry.jsonl';
+
+function registryPath(): string {
+  return path.join(getMemoryStateDir(), REGISTRY_FILENAME);
+}
+
+function readRegistry(): RegistryFile {
+  const filePath = registryPath();
+  const entries = new Map<string, FalsifierEntry>();
+  if (!existsSync(filePath)) {
+    return { path: filePath, entries };
+  }
+  const lines = readFileSync(filePath, 'utf8').split('\n').filter((l) => l.trim());
+  for (const line of lines) {
+    try {
+      const entry = JSON.parse(line) as FalsifierEntry;
+      // Last write wins — append-only with overwrite semantics for resolve().
+      entries.set(entry.id, entry);
+    } catch (err) {
+      slog('FALSIFIER', `parse error: ${(err as Error).message}`);
+    }
+  }
+  return { path: filePath, entries };
+}
+
+function appendEntry(filePath: string, entry: FalsifierEntry): void {
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  appendFileSync(filePath, JSON.stringify(entry) + '\n');
+}
+
+// =============================================================================
+// ID generation
+// =============================================================================
+
+/**
+ * Stable ID derived from condition text — same condition → same ID,
+ * enabling natural deduplication across cycles.
+ */
+function generateId(condition: string): string {
+  const hash = createHash('sha256').update(condition.trim()).digest('hex');
+  return `fl-${hash.slice(0, 8)}`;
+}
+
+// =============================================================================
+// Public API
+// =============================================================================
+
+export interface RegisterOptions {
+  condition: string;
+  cycleCreated: number;
+  ttlCycles?: number;       // default 5
+}
+
+/**
+ * Register a falsifier. If an entry with the same condition already exists
+ * AND is still active, returns the existing ID without re-appending.
+ * Returns the new or existing ID.
+ */
+export function registerFalsifier(opts: RegisterOptions): string {
+  const ttl = opts.ttlCycles ?? 5;
+  const id = generateId(opts.condition);
+  const reg = readRegistry();
+  const existing = reg.entries.get(id);
+  if (existing && !existing.resolvedAt && !isExpired(existing, opts.cycleCreated)) {
+    // Active duplicate — reuse ID, don't append.
+    return id;
+  }
+  const entry: FalsifierEntry = {
+    id,
+    condition: opts.condition.trim(),
+    cycleCreated: opts.cycleCreated,
+    ttlCycles: ttl,
+    createdAt: new Date().toISOString(),
+  };
+  appendEntry(reg.path, entry);
+  slog('FALSIFIER', `registered ${id} ttl=${ttl} cycle=${opts.cycleCreated}`);
+  return id;
+}
+
+export interface ResolveOptions {
+  id: string;
+  result: FalsifierResult;
+  evidence?: string;
+}
+
+/**
+ * Mark a falsifier resolved. Appends an updated entry; on reread, the latest
+ * entry wins (last-write-wins via Map.set on each line parse).
+ * Returns true if the falsifier existed and was updated, false otherwise.
+ */
+export function resolveFalsifier(opts: ResolveOptions): boolean {
+  const reg = readRegistry();
+  const existing = reg.entries.get(opts.id);
+  if (!existing) {
+    slog('FALSIFIER', `resolve miss: ${opts.id}`);
+    return false;
+  }
+  const updated: FalsifierEntry = {
+    ...existing,
+    resolvedAt: new Date().toISOString(),
+    result: opts.result,
+    resolutionEvidence: opts.evidence,
+  };
+  appendEntry(reg.path, updated);
+  slog('FALSIFIER', `resolved ${opts.id} → ${opts.result}`);
+  return true;
+}
+
+function isExpired(entry: FalsifierEntry, currentCycle: number): boolean {
+  return currentCycle - entry.cycleCreated >= entry.ttlCycles;
+}
+
+/**
+ * Active falsifiers = not resolved AND not yet expired by TTL.
+ * Sorted by createdAt ascending so oldest renders first.
+ */
+export function getActiveFalsifiers(currentCycle: number): FalsifierEntry[] {
+  const reg = readRegistry();
+  const active: FalsifierEntry[] = [];
+  for (const entry of reg.entries.values()) {
+    if (entry.resolvedAt) continue;
+    if (isExpired(entry, currentCycle)) continue;
+    active.push(entry);
+  }
+  active.sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+  return active;
+}
+
+/**
+ * Mark expired entries with result='expired' so they leave the active list
+ * permanently (vs. recomputing isExpired every read). Idempotent.
+ * Returns the number of entries newly marked expired.
+ */
+export function expireOverdueFalsifiers(currentCycle: number): number {
+  const reg = readRegistry();
+  let count = 0;
+  for (const entry of reg.entries.values()) {
+    if (entry.resolvedAt) continue;
+    if (!isExpired(entry, currentCycle)) continue;
+    const updated: FalsifierEntry = {
+      ...entry,
+      resolvedAt: new Date().toISOString(),
+      result: 'expired',
+    };
+    appendEntry(reg.path, updated);
+    count += 1;
+  }
+  if (count > 0) slog('FALSIFIER', `expired ${count} overdue entries`);
+  return count;
+}
+
+/**
+ * Compact context block for cycle output, replacing per-falsifier prose.
+ * Format: `[fl-abcdef12] condition (expires in N)` per line.
+ * Empty string when no active entries.
+ */
+export function buildFalsifierContext(currentCycle: number): string {
+  const active = getActiveFalsifiers(currentCycle);
+  if (active.length === 0) return '';
+  const lines = active.map((e) => {
+    const remaining = e.cycleCreated + e.ttlCycles - currentCycle;
+    return `  [${e.id}] ${e.condition} (expires in ${remaining})`;
+  });
+  return `Active falsifiers (${active.length}):\n${lines.join('\n')}`;
+}
+
+/**
+ * Stats for observability — useful for verifying issue #197 success criteria
+ * (active count should stay manageable, expired/resolved should accumulate).
+ */
+export function falsifierStats(currentCycle: number): {
+  active: number;
+  resolved: number;
+  expired: number;
+  total: number;
+} {
+  const reg = readRegistry();
+  let active = 0;
+  let resolved = 0;
+  let expired = 0;
+  for (const entry of reg.entries.values()) {
+    if (!entry.resolvedAt) {
+      if (isExpired(entry, currentCycle)) expired += 1;
+      else active += 1;
+    } else if (entry.result === 'expired') {
+      expired += 1;
+    } else {
+      resolved += 1;
+    }
+  }
+  return { active, resolved, expired, total: reg.entries.size };
+}

--- a/tests/falsifier-registry.test.ts
+++ b/tests/falsifier-registry.test.ts
@@ -1,0 +1,158 @@
+// Tests for issue #197 falsifier registry. Coverage:
+//  - register returns stable ID for same condition (dedup)
+//  - resolve marks entry resolved, last-write-wins on reread
+//  - getActiveFalsifiers excludes resolved + TTL-expired
+//  - expireOverdueFalsifiers marks overdue with result='expired'
+//  - buildFalsifierContext renders short reference block
+//  - falsifierStats counts active/resolved/expired correctly
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+let tmpStateDir: string;
+
+vi.mock('../src/memory.js', () => ({
+  getMemoryStateDir: () => tmpStateDir,
+}));
+
+vi.mock('../src/utils.js', () => ({
+  slog: vi.fn(),
+}));
+
+import {
+  registerFalsifier,
+  resolveFalsifier,
+  getActiveFalsifiers,
+  expireOverdueFalsifiers,
+  buildFalsifierContext,
+  falsifierStats,
+} from '../src/falsifier-registry.js';
+
+describe('falsifier-registry', () => {
+  beforeEach(() => {
+    tmpStateDir = mkdtempSync(path.join(tmpdir(), 'fr-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpStateDir, { recursive: true, force: true });
+  });
+
+  describe('registerFalsifier', () => {
+    it('returns stable id for same condition (dedup)', () => {
+      const id1 = registerFalsifier({ condition: 'tail X >= 1', cycleCreated: 1 });
+      const id2 = registerFalsifier({ condition: 'tail X >= 1', cycleCreated: 2 });
+      expect(id1).toBe(id2);
+      expect(id1).toMatch(/^fl-[a-f0-9]{8}$/);
+    });
+
+    it('different conditions get different ids', () => {
+      const id1 = registerFalsifier({ condition: 'foo', cycleCreated: 1 });
+      const id2 = registerFalsifier({ condition: 'bar', cycleCreated: 1 });
+      expect(id1).not.toBe(id2);
+    });
+
+    it('persists to disk', () => {
+      registerFalsifier({ condition: 'foo', cycleCreated: 1 });
+      expect(existsSync(path.join(tmpStateDir, 'falsifier-registry.jsonl'))).toBe(true);
+    });
+
+    it('re-registers if existing entry is resolved', () => {
+      const id1 = registerFalsifier({ condition: 'foo', cycleCreated: 1 });
+      resolveFalsifier({ id: id1, result: 'confirmed' });
+      // Re-register same condition after resolve — should still return same ID
+      // (stable hash) but append a fresh active entry.
+      const id2 = registerFalsifier({ condition: 'foo', cycleCreated: 5 });
+      expect(id1).toBe(id2);
+      const active = getActiveFalsifiers(5);
+      expect(active).toHaveLength(1);
+      expect(active[0].cycleCreated).toBe(5);
+    });
+  });
+
+  describe('resolveFalsifier', () => {
+    it('marks entry resolved with timestamp + result', () => {
+      const id = registerFalsifier({ condition: 'foo', cycleCreated: 1 });
+      const ok = resolveFalsifier({ id, result: 'falsified', evidence: 'count was 0' });
+      expect(ok).toBe(true);
+      const active = getActiveFalsifiers(2);
+      expect(active).toHaveLength(0);
+    });
+
+    it('returns false for unknown id', () => {
+      expect(resolveFalsifier({ id: 'fl-deadbeef', result: 'confirmed' })).toBe(false);
+    });
+  });
+
+  describe('getActiveFalsifiers', () => {
+    it('excludes ttl-expired entries', () => {
+      registerFalsifier({ condition: 'foo', cycleCreated: 1, ttlCycles: 3 });
+      // cycle 1 + ttl 3 → expires at cycle 4
+      expect(getActiveFalsifiers(3)).toHaveLength(1);
+      expect(getActiveFalsifiers(4)).toHaveLength(0);
+    });
+
+    it('default ttl is 5', () => {
+      registerFalsifier({ condition: 'foo', cycleCreated: 0 });
+      expect(getActiveFalsifiers(4)).toHaveLength(1);
+      expect(getActiveFalsifiers(5)).toHaveLength(0);
+    });
+
+    it('sorts by createdAt ascending', async () => {
+      registerFalsifier({ condition: 'first', cycleCreated: 1 });
+      // Ensure timestamp differs
+      await new Promise((r) => setTimeout(r, 5));
+      registerFalsifier({ condition: 'second', cycleCreated: 1 });
+      const active = getActiveFalsifiers(2);
+      expect(active.map((e) => e.condition)).toEqual(['first', 'second']);
+    });
+  });
+
+  describe('expireOverdueFalsifiers', () => {
+    it('marks overdue entries with result=expired', () => {
+      registerFalsifier({ condition: 'foo', cycleCreated: 0, ttlCycles: 2 });
+      registerFalsifier({ condition: 'bar', cycleCreated: 5, ttlCycles: 2 });
+      const count = expireOverdueFalsifiers(4);
+      expect(count).toBe(1);
+      const stats = falsifierStats(4);
+      expect(stats.expired).toBe(1);
+      expect(stats.active).toBe(1);
+    });
+
+    it('idempotent — re-expiring already-resolved entries returns 0', () => {
+      registerFalsifier({ condition: 'foo', cycleCreated: 0, ttlCycles: 2 });
+      expect(expireOverdueFalsifiers(4)).toBe(1);
+      expect(expireOverdueFalsifiers(4)).toBe(0);
+    });
+  });
+
+  describe('buildFalsifierContext', () => {
+    it('returns empty string when no active', () => {
+      expect(buildFalsifierContext(1)).toBe('');
+    });
+
+    it('renders compact reference block', () => {
+      registerFalsifier({ condition: 'tail commitments.jsonl >= 1', cycleCreated: 0, ttlCycles: 5 });
+      const ctx = buildFalsifierContext(1);
+      expect(ctx).toContain('Active falsifiers (1)');
+      expect(ctx).toMatch(/\[fl-[a-f0-9]{8}\] tail commitments\.jsonl >= 1 \(expires in 4\)/);
+    });
+  });
+
+  describe('falsifierStats', () => {
+    it('counts active/resolved/expired correctly', () => {
+      const a = registerFalsifier({ condition: 'a', cycleCreated: 0, ttlCycles: 5 });
+      registerFalsifier({ condition: 'b', cycleCreated: 0, ttlCycles: 1 });
+      const c = registerFalsifier({ condition: 'c', cycleCreated: 0, ttlCycles: 5 });
+      resolveFalsifier({ id: c, result: 'confirmed' });
+      expireOverdueFalsifiers(3); // 'b' expires
+      const stats = falsifierStats(3);
+      expect(stats.active).toBe(1); // only 'a'
+      expect(stats.resolved).toBe(1); // 'c'
+      expect(stats.expired).toBe(1); // 'b'
+      expect(stats.total).toBe(3);
+      expect(a).toBeTruthy();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- New `src/falsifier-registry.ts`: stable hash-based IDs (`fl-<8hex>`) for falsifier conditions, append-only JSONL storage, last-write-wins on resolve/expire.
- 14 unit tests covering dedup, TTL expiry, resolve, idempotent expire, context rendering, stats.
- This is the **registry primitives** half of #197. Wiring into prompt-builder/dispatcher (so cycle output emits `falsifier:fl-xxx` instead of full prose) is a deliberate follow-up to keep this PR small and reviewable.

## Why two layers?
`commitment-ledger.ts` already has executable `FalsifierQuery` DSL (`kg_count`, `log_grep`, ...). That's for falsifiers the system can auto-resolve. This new registry is the lightweight prose-side reference layer for human-judgment falsifiers — orthogonal axis, not replacement.

## Verification
- [x] `pnpm test tests/falsifier-registry.test.ts` → 14/14 passing locally
- [x] `pnpm typecheck` clean
- [ ] CI green
- [ ] Follow-up PR wires `buildFalsifierContext()` into cycle context block

Closes part of #197.