### PR TITLE
feat: add system truth reconciler

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "janitor:workspaces:apply": "tsx scripts/workspace-janitor.ts --apply",
     "check:runtime-workspace": "tsx scripts/check-runtime-workspace.ts",
     "autocorrect:runtime-workspace": "tsx scripts/runtime-workspace-autocorrect.ts",
+    "check:system-truth": "tsx scripts/system-truth.ts",
     "setup:external-memory": "tsx scripts/setup-external-memory.ts",
     "memory:repo:setup": "tsx scripts/setup-memory-repo.ts --init",
     "memory:repo:check": "tsx scripts/setup-memory-repo.ts --check",

--- a/scripts/system-truth.ts
+++ b/scripts/system-truth.ts
@@ -1,0 +1,42 @@
+#!/usr/bin/env tsx
+import { initFeatures } from '../src/features.js';
+import { getMemoryRootDir } from '../src/memory-paths.js';
+import { applySafeSystemTruth, evaluateSystemTruth, formatSystemTruth } from '../src/system-truth.js';
+
+const args = new Set(process.argv.slice(2));
+const json = args.has('--json');
+const applySafe = args.has('--apply-safe');
+const noKgPushSample = args.has('--no-kg-push-sample');
+
+initFeatures();
+
+const options = {
+  memoryDir: getMemoryRootDir(),
+  repoRoot: process.cwd(),
+  kgPushSample: !noKgPushSample,
+};
+
+if (applySafe) {
+  const result = await applySafeSystemTruth(options);
+  if (json) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    console.log(formatSystemTruth(result.after));
+    console.log('');
+    console.log(`apply-safe: applied=${result.applied.length} skipped=${result.skipped.length}`);
+    for (const action of result.applied) console.log(`- ${action.action} ${action.commitmentId}: ${action.reason}`);
+    for (const skipped of result.skipped) console.log(`- skipped ${skipped}`);
+  }
+  if (result.after.status === 'blocked') process.exit(1);
+  process.exit(0);
+}
+
+const snapshot = await evaluateSystemTruth(options);
+
+if (json) {
+  console.log(JSON.stringify(snapshot, null, 2));
+} else {
+  console.log(formatSystemTruth(snapshot));
+}
+
+if (snapshot.status === 'blocked') process.exit(1);

--- a/src/api.ts
+++ b/src/api.ts
@@ -902,7 +902,7 @@ export function createApi(port = 3001): express.Express {
   app.use(createRateLimiter());
 
   // Request logging middleware (skip noisy polling endpoints)
-  const SILENT_PATHS = new Set(['/health', '/status', '/api/dashboard/behaviors', '/api/dashboard/learning', '/api/dashboard/journal', '/api/dashboard/cognition', '/api/dashboard/capabilities', '/api/dashboard/context', '/api/dashboard/inner-state', '/api/events', '/api/room/stream', '/api/memory/structured', '/api/memory/history', '/api/memory/files']);
+  const SILENT_PATHS = new Set(['/health', '/status', '/api/system-truth', '/api/dashboard/behaviors', '/api/dashboard/learning', '/api/dashboard/journal', '/api/dashboard/cognition', '/api/dashboard/capabilities', '/api/dashboard/context', '/api/dashboard/inner-state', '/api/events', '/api/room/stream', '/api/memory/structured', '/api/memory/history', '/api/memory/files']);
   app.use((req: Request, res: Response, next: NextFunction) => {
     if (SILENT_PATHS.has(req.path)) { next(); return; }
     const start = Date.now();
@@ -2918,6 +2918,26 @@ export function createApi(port = 3001): express.Express {
       res.json(evaluateAutonomyClosure(memDir));
     } catch {
       res.json({ status: 'unknown', score: 0, stages: [], blockingStages: [], warningStages: [], recommendedTask: null });
+    }
+  });
+
+  app.get('/api/system-truth', async (req: Request, res: Response) => {
+    try {
+      const { evaluateSystemTruth } = await import('./system-truth.js');
+      const memDir = getMemoryRootDir();
+      const kgPushSample = req.query.kgPushSample !== 'false';
+      const snapshot = await evaluateSystemTruth({
+        memoryDir: memDir,
+        repoRoot: process.cwd(),
+        kgPushSample,
+      });
+      res.json(snapshot);
+    } catch (err) {
+      res.status(500).json({
+        status: 'unknown',
+        score: 0,
+        error: err instanceof Error ? err.message : String(err),
+      });
     }
   });
 

--- a/src/system-truth.ts
+++ b/src/system-truth.ts
@@ -1,0 +1,549 @@
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { evaluateAutonomyClosure } from './autonomy-closure-health.js';
+import { getFeature } from './features.js';
+import { queryMemoryIndexSync, type MemoryIndexEntry } from './memory-index.js';
+
+export type TruthSeverity = 'info' | 'warn' | 'blocker';
+export type TruthStatus = 'healthy' | 'degraded' | 'blocked';
+
+export interface TruthFinding {
+  severity: TruthSeverity;
+  kind:
+    | 'local-task-backlog'
+    | 'middleware-offline'
+    | 'middleware-active-backlog'
+    | 'middleware-duplicate-active'
+    | 'middleware-stale-active'
+    | 'middleware-unreviewed-completed'
+    | 'kg-offline'
+    | 'kg-retrieval-disabled'
+    | 'kg-push-low-signal'
+    | 'closure-health';
+  summary: string;
+  evidence: string[];
+  recommendation?: string;
+}
+
+export interface MiddlewareTaskTruth {
+  id: string;
+  worker: string;
+  status: string;
+  durationMs?: number;
+  startedAt?: string;
+  completedAt?: string;
+  task: string;
+}
+
+export interface MiddlewareCommitmentTruth {
+  id: string;
+  status: string;
+  owner?: string;
+  created_at: string;
+  text: string;
+  linked_task_id?: string;
+}
+
+export interface KnowledgeGraphTruth {
+  online: boolean;
+  health?: Record<string, unknown>;
+  maintenanceScore?: number;
+  retrievalAugmentEnabled: boolean;
+  pushSample?: string;
+  error?: string;
+}
+
+export interface SystemTruthSnapshot {
+  status: TruthStatus;
+  generatedAt: string;
+  score: number;
+  counts: {
+    localActiveTasks: number;
+    middlewareActiveCommitments: number | null;
+    middlewareRunningTasks: number | null;
+    middlewareUnreviewedCompletedTasks: number | null;
+    kgNodes: number | null;
+    kgEdges: number | null;
+  };
+  local: {
+    activeTasks: Array<Pick<MemoryIndexEntry, 'id' | 'status' | 'summary' | 'ts' | 'payload'>>;
+    autonomyStatus: ReturnType<typeof evaluateAutonomyClosure>['status'];
+    autonomyScore: number;
+  };
+  middleware: {
+    online: boolean;
+    health?: Record<string, unknown>;
+    activeCommitments: MiddlewareCommitmentTruth[];
+    recentTasks: MiddlewareTaskTruth[];
+    error?: string;
+  };
+  kg: KnowledgeGraphTruth;
+  findings: TruthFinding[];
+}
+
+export interface SystemTruthApplyAction {
+  commitmentId: string;
+  action: 'cancel' | 'fulfill';
+  reason: string;
+  evidence: string;
+}
+
+export interface SystemTruthApplyResult {
+  before: SystemTruthSnapshot;
+  after: SystemTruthSnapshot;
+  applied: SystemTruthApplyAction[];
+  skipped: string[];
+}
+
+export interface EvaluateSystemTruthOptions {
+  memoryDir: string;
+  repoRoot?: string;
+  middlewareUrl?: string;
+  kgUrl?: string;
+  now?: Date;
+  fetchImpl?: typeof fetch;
+  middlewareTaskLimit?: number;
+  kgPushSample?: boolean;
+}
+
+const ACTIVE_TASK_STATUSES = ['pending', 'in_progress', 'needs-decomposition', 'blocked', 'hold'];
+const ACTIVE_COMMITMENT_STATUS = 'active';
+const STALE_ACTIVE_MS = 12 * 60 * 60 * 1000;
+
+export async function evaluateSystemTruth(options: EvaluateSystemTruthOptions): Promise<SystemTruthSnapshot> {
+  const now = options.now ?? new Date();
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const repoRoot = options.repoRoot ?? process.cwd();
+  const middlewareUrl = trimTrailingSlash(options.middlewareUrl ?? process.env.MIDDLEWARE_URL ?? 'http://localhost:3200');
+  const kgUrl = trimTrailingSlash(options.kgUrl ?? process.env.KG_BASE_URL ?? 'http://localhost:3300');
+
+  const localActiveTasks = queryMemoryIndexSync(options.memoryDir, {
+    type: ['task'],
+    status: ACTIVE_TASK_STATUSES,
+  });
+  const autonomy = evaluateAutonomyClosure(options.memoryDir, { repoRoot, now });
+  const middleware = await readMiddlewareTruth(middlewareUrl, fetchImpl, options.middlewareTaskLimit ?? 200);
+  const kg = await readKnowledgeGraphTruth(kgUrl, fetchImpl, options.kgPushSample ?? true);
+
+  const findings: TruthFinding[] = [
+    ...localFindings(localActiveTasks, autonomy.status),
+    ...middlewareFindings(middleware, now),
+    ...kgFindings(kg),
+  ];
+
+  const blockerCount = findings.filter(f => f.severity === 'blocker').length;
+  const warnCount = findings.filter(f => f.severity === 'warn').length;
+  const score = Math.max(0, 100 - blockerCount * 25 - warnCount * 8);
+  const status: TruthStatus = blockerCount > 0 ? 'blocked' : warnCount > 0 ? 'degraded' : 'healthy';
+
+  return {
+    status,
+    generatedAt: now.toISOString(),
+    score,
+    counts: {
+      localActiveTasks: localActiveTasks.length,
+      middlewareActiveCommitments: middleware.online ? middleware.activeCommitments.length : null,
+      middlewareRunningTasks: middleware.online ? middleware.recentTasks.filter(t => t.status === 'running').length : null,
+      middlewareUnreviewedCompletedTasks: middleware.online ? countUnreviewedCompleted(options.memoryDir, middleware.recentTasks) : null,
+      kgNodes: typeof kg.health?.nodes === 'number' ? kg.health.nodes : null,
+      kgEdges: typeof kg.health?.edges === 'number' ? kg.health.edges : null,
+    },
+    local: {
+      activeTasks: localActiveTasks.slice(0, 50).map(t => ({
+        id: t.id,
+        status: t.status,
+        summary: t.summary,
+        ts: t.ts,
+        payload: t.payload,
+      })),
+      autonomyStatus: autonomy.status,
+      autonomyScore: autonomy.score,
+    },
+    middleware,
+    kg,
+    findings,
+  };
+}
+
+export async function applySafeSystemTruth(options: EvaluateSystemTruthOptions): Promise<SystemTruthApplyResult> {
+  const before = await evaluateSystemTruth({ ...options, kgPushSample: false });
+  const middlewareUrl = trimTrailingSlash(options.middlewareUrl ?? process.env.MIDDLEWARE_URL ?? 'http://localhost:3200');
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const applied: SystemTruthApplyAction[] = [];
+  const skipped: string[] = [];
+
+  if (!before.middleware.online) {
+    skipped.push(`middleware offline: ${before.middleware.error ?? 'unknown error'}`);
+    return { before, after: before, applied, skipped };
+  }
+
+  const seen = new Set<string>();
+  for (const action of planSafeMiddlewareActions(before)) {
+    if (seen.has(action.commitmentId)) continue;
+    seen.add(action.commitmentId);
+    try {
+      await patchCommitment(middlewareUrl, fetchImpl, action);
+      applied.push(action);
+    } catch (err) {
+      skipped.push(`${action.commitmentId}: ${errorMessage(err)}`);
+    }
+  }
+
+  const after = await evaluateSystemTruth({ ...options, kgPushSample: false });
+  return { before, after, applied, skipped };
+}
+
+export function formatSystemTruth(snapshot: SystemTruthSnapshot): string {
+  const lines: string[] = [];
+  lines.push(`system truth: ${snapshot.status} score=${snapshot.score}`);
+  lines.push(`generated: ${snapshot.generatedAt}`);
+  lines.push(`local active tasks: ${snapshot.counts.localActiveTasks}`);
+  lines.push(`middleware active commitments: ${snapshot.counts.middlewareActiveCommitments ?? 'offline'}`);
+  lines.push(`middleware running tasks: ${snapshot.counts.middlewareRunningTasks ?? 'offline'}`);
+  lines.push(`middleware unreviewed completed: ${snapshot.counts.middlewareUnreviewedCompletedTasks ?? 'offline'}`);
+  lines.push(`kg: ${snapshot.kg.online ? `${snapshot.counts.kgNodes ?? '?'} nodes / ${snapshot.counts.kgEdges ?? '?'} edges` : 'offline'}`);
+  lines.push('');
+  lines.push('findings:');
+  if (snapshot.findings.length === 0) {
+    lines.push('- info no truth gaps detected');
+  } else {
+    for (const finding of snapshot.findings) {
+      lines.push(`- ${finding.severity} ${finding.kind}: ${finding.summary}`);
+      for (const evidence of finding.evidence.slice(0, 5)) lines.push(`  evidence: ${evidence}`);
+      if (finding.recommendation) lines.push(`  next: ${finding.recommendation}`);
+    }
+  }
+  return lines.join('\n');
+}
+
+export function duplicateActiveCommitments(active: MiddlewareCommitmentTruth[]): Array<{ key: string; items: MiddlewareCommitmentTruth[] }> {
+  const groups = new Map<string, MiddlewareCommitmentTruth[]>();
+  for (const commitment of active) {
+    const key = canonicalCommitmentKey(commitment.text);
+    if (!key) continue;
+    const group = groups.get(key) ?? [];
+    group.push(commitment);
+    groups.set(key, group);
+  }
+  return [...groups.entries()]
+    .filter(([, items]) => items.length > 1)
+    .map(([key, items]) => ({ key, items }));
+}
+
+export function planSafeMiddlewareActions(snapshot: SystemTruthSnapshot): SystemTruthApplyAction[] {
+  if (!snapshot.middleware.online) return [];
+  const actions: SystemTruthApplyAction[] = [];
+  const active = snapshot.middleware.activeCommitments;
+
+  for (const group of duplicateActiveCommitments(active)) {
+    const sorted = [...group.items].sort(compareCommitmentsNewestFirst);
+    const keep = sorted[0];
+    for (const duplicate of sorted.slice(1)) {
+      actions.push({
+        commitmentId: duplicate.id,
+        action: 'cancel',
+        reason: 'duplicate-active-commitment',
+        evidence: `system-truth apply-safe: duplicate active commitment; kept freshest ${keep.id}`,
+      });
+    }
+  }
+
+  const terminalTasks = new Map(
+    snapshot.middleware.recentTasks
+      .filter(t => ['completed', 'failed', 'cancelled', 'skipped'].includes(t.status))
+      .map(t => [t.id, t]),
+  );
+
+  for (const commitment of active) {
+    if (!commitment.linked_task_id) continue;
+    const task = terminalTasks.get(commitment.linked_task_id);
+    if (!task) continue;
+    actions.push({
+      commitmentId: commitment.id,
+      action: task.status === 'completed' ? 'fulfill' : 'cancel',
+      reason: `linked-task-${task.status}`,
+      evidence: `system-truth apply-safe: linked task ${task.id} is ${task.status}`,
+    });
+  }
+
+  return actions;
+}
+
+export function canonicalCommitmentKey(text: string): string {
+  return extractTaskTitle(text)
+    .toLowerCase()
+    .replace(/task id:\s*\S+/g, '')
+    .replace(/idx-[a-z0-9-]+/g, '')
+    .replace(/#\d+/g, '#')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 160);
+}
+
+async function readMiddlewareTruth(baseUrl: string, fetchImpl: typeof fetch, taskLimit: number): Promise<SystemTruthSnapshot['middleware']> {
+  try {
+    const [health, commits, tasks] = await Promise.all([
+      fetchJson<Record<string, unknown>>(fetchImpl, `${baseUrl}/health`, 3000),
+      fetchJson<{ items?: unknown[] }>(fetchImpl, `${baseUrl}/commits?status=${ACTIVE_COMMITMENT_STATUS}`, 5000),
+      fetchJson<{ tasks?: unknown[] }>(fetchImpl, `${baseUrl}/tasks?limit=${taskLimit}`, 5000),
+    ]);
+    return {
+      online: true,
+      health,
+      activeCommitments: (commits.items ?? []).map(parseCommitment).filter(Boolean) as MiddlewareCommitmentTruth[],
+      recentTasks: (tasks.tasks ?? []).map(parseMiddlewareTask).filter(Boolean) as MiddlewareTaskTruth[],
+    };
+  } catch (err) {
+    return {
+      online: false,
+      activeCommitments: [],
+      recentTasks: [],
+      error: errorMessage(err),
+    };
+  }
+}
+
+async function readKnowledgeGraphTruth(baseUrl: string, fetchImpl: typeof fetch, includePushSample: boolean): Promise<KnowledgeGraphTruth> {
+  const feature = getFeature('kg-retrieval-augment');
+  try {
+    const [health, stats, push] = await Promise.all([
+      fetchJson<Record<string, unknown>>(fetchImpl, `${baseUrl}/health`, 3000),
+      fetchJson<Record<string, unknown>>(fetchImpl, `${baseUrl}/api/stats`, 3000).catch(() => ({})),
+      includePushSample
+        ? fetchJson<{ text?: string }>(fetchImpl, `${baseUrl}/api/push/formatted`, 3000, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            context: 'Kuro mini-agent middleware knowledge graph closure truth reconciliation',
+            agent_id: 'kuro',
+            limit: 3,
+          }),
+        }).catch(() => undefined)
+        : Promise.resolve(undefined),
+    ]);
+    const merged = { ...health, ...stats };
+    const lastRun = (health.maintenance as { last_run?: { result?: { report?: { quality?: { score?: number } } } } } | undefined)
+      ?.last_run?.result?.report?.quality?.score;
+    return {
+      online: true,
+      health: merged,
+      maintenanceScore: typeof lastRun === 'number' ? lastRun : undefined,
+      retrievalAugmentEnabled: feature?.enabled ?? true,
+      pushSample: push?.text,
+    };
+  } catch (err) {
+    return {
+      online: false,
+      retrievalAugmentEnabled: feature?.enabled ?? true,
+      error: errorMessage(err),
+    };
+  }
+}
+
+function localFindings(activeTasks: MemoryIndexEntry[], autonomyStatus: string): TruthFinding[] {
+  const findings: TruthFinding[] = [];
+  if (activeTasks.length > 10) {
+    findings.push({
+      severity: 'warn',
+      kind: 'local-task-backlog',
+      summary: `${activeTasks.length} local active task(s) are visible to scheduler`,
+      evidence: activeTasks.slice(0, 5).map(t => `${t.id} ${t.status}: ${(t.summary ?? '').slice(0, 100)}`),
+      recommendation: 'Reconcile task-events before creating new autonomous work.',
+    });
+  }
+  if (autonomyStatus === 'blocked') {
+    findings.push({
+      severity: 'blocker',
+      kind: 'closure-health',
+      summary: 'autonomy closure reports blocked',
+      evidence: ['pnpm check:autonomy-closure -- --json'],
+      recommendation: 'Repair the blocking autonomy stage before expanding KG or middleware behavior.',
+    });
+  }
+  return findings;
+}
+
+function middlewareFindings(middleware: SystemTruthSnapshot['middleware'], now: Date): TruthFinding[] {
+  if (!middleware.online) {
+    return [{
+      severity: 'blocker',
+      kind: 'middleware-offline',
+      summary: 'agent-middleware is not reachable',
+      evidence: [middleware.error ?? 'unknown error'],
+      recommendation: 'Restart middleware before dispatching or reconciling delegate lifecycle.',
+    }];
+  }
+
+  const findings: TruthFinding[] = [];
+  const active = middleware.activeCommitments;
+  if (active.length > 10) {
+    findings.push({
+      severity: 'warn',
+      kind: 'middleware-active-backlog',
+      summary: `${active.length} active middleware commitment(s) need reconciliation`,
+      evidence: active.slice(-5).map(c => `${c.id} ${ageLabel(c.created_at, now)}: ${extractTaskTitle(c.text)}`),
+      recommendation: 'Close fulfilled commitments or cancel obsolete ones with explicit evidence.',
+    });
+  }
+
+  for (const group of duplicateActiveCommitments(active)) {
+    findings.push({
+      severity: 'warn',
+      kind: 'middleware-duplicate-active',
+      summary: `${group.items.length} active commitments share the same task shape`,
+      evidence: group.items.map(c => `${c.id} ${ageLabel(c.created_at, now)}: ${extractTaskTitle(c.text)}`).slice(0, 6),
+      recommendation: 'Keep the freshest real task and cancel stale duplicates.',
+    });
+  }
+
+  const stale = active.filter(c => now.getTime() - Date.parse(c.created_at) > STALE_ACTIVE_MS);
+  if (stale.length > 0) {
+    findings.push({
+      severity: 'warn',
+      kind: 'middleware-stale-active',
+      summary: `${stale.length} active middleware commitment(s) are older than 12h`,
+      evidence: stale.slice(-8).map(c => `${c.id} ${ageLabel(c.created_at, now)}: ${extractTaskTitle(c.text)}`),
+      recommendation: 'Resolve, supersede, or cancel aged active commitments; do not let them re-enter Kuro context as live work.',
+    });
+  }
+  return findings;
+}
+
+function kgFindings(kg: KnowledgeGraphTruth): TruthFinding[] {
+  if (!kg.online) {
+    return [{
+      severity: 'warn',
+      kind: 'kg-offline',
+      summary: 'knowledge-graph service is not reachable',
+      evidence: [kg.error ?? 'unknown error'],
+      recommendation: 'Restore KG before relying on shared-memory claims.',
+    }];
+  }
+  const findings: TruthFinding[] = [];
+  if (!kg.retrievalAugmentEnabled) {
+    findings.push({
+      severity: 'warn',
+      kind: 'kg-retrieval-disabled',
+      summary: 'mini-agent KG retrieval augmentation is disabled',
+      evidence: ['feature=kg-retrieval-augment enabled=false'],
+      recommendation: 'Fix retrieval quality gates, then re-enable augmentation so KG affects Kuro decisions.',
+    });
+  }
+  if (kg.pushSample && likelyLowSignalPush(kg.pushSample)) {
+    findings.push({
+      severity: 'warn',
+      kind: 'kg-push-low-signal',
+      summary: 'KG push sample contains low-signal raw observations',
+      evidence: kg.pushSample.split('\n').filter(line => line.trim().startsWith('- **')).slice(0, 3),
+      recommendation: 'Down-rank raw observation nodes and prefer canonical/decision/principle nodes for context injection.',
+    });
+  }
+  return findings;
+}
+
+function extractTaskTitle(text: string): string {
+  const taskMatch = text.match(/## Task:\s*([^\n]+)/);
+  if (taskMatch?.[1]) return taskMatch[1].trim();
+  const first = text.split('\n').map(l => l.trim()).find(Boolean);
+  return first ?? '';
+}
+
+function countUnreviewedCompleted(memoryDir: string, tasks: MiddlewareTaskTruth[]): number {
+  const completed = tasks.filter(t => t.status === 'completed');
+  if (completed.length === 0) return 0;
+  const reviewedText = readReviewedDelegationText(memoryDir);
+  return completed.filter(t => !reviewedText.includes(t.id)).length;
+}
+
+function readReviewedDelegationText(memoryDir: string): string {
+  const candidates = [
+    path.join(memoryDir, 'state', 'task-closures.jsonl'),
+    path.join(memoryDir, 'state', 'work-journal.jsonl'),
+    path.join(memoryDir, 'state', 'activity-journal.jsonl'),
+  ];
+  return candidates
+    .filter(existsSync)
+    .map(p => {
+      try { return readFileSync(p, 'utf-8'); } catch { return ''; }
+    })
+    .join('\n');
+}
+
+function likelyLowSignalPush(text: string): boolean {
+  const rawSignals = ['kuro:', 'claude-code:', '收到。', '</recent_conversations>', '請求關閉討論'];
+  const hits = rawSignals.filter(signal => text.includes(signal)).length;
+  return hits >= 2 || /type="observation"| \[observation\]/i.test(text);
+}
+
+function parseCommitment(value: unknown): MiddlewareCommitmentTruth | null {
+  if (!value || typeof value !== 'object') return null;
+  const record = value as Record<string, unknown>;
+  if (typeof record.id !== 'string' || typeof record.status !== 'string' || typeof record.text !== 'string') return null;
+  return {
+    id: record.id,
+    status: record.status,
+    owner: typeof record.owner === 'string' ? record.owner : undefined,
+    created_at: typeof record.created_at === 'string' ? record.created_at : '',
+    text: record.text,
+    linked_task_id: typeof record.linked_task_id === 'string' ? record.linked_task_id : undefined,
+  };
+}
+
+function parseMiddlewareTask(value: unknown): MiddlewareTaskTruth | null {
+  if (!value || typeof value !== 'object') return null;
+  const record = value as Record<string, unknown>;
+  if (typeof record.id !== 'string' || typeof record.worker !== 'string' || typeof record.status !== 'string') return null;
+  return {
+    id: record.id,
+    worker: record.worker,
+    status: record.status,
+    durationMs: typeof record.durationMs === 'number' ? record.durationMs : undefined,
+    startedAt: typeof record.startedAt === 'string' ? record.startedAt : undefined,
+    completedAt: typeof record.completedAt === 'string' ? record.completedAt : undefined,
+    task: typeof record.task === 'string' ? record.task : '',
+  };
+}
+
+async function patchCommitment(baseUrl: string, fetchImpl: typeof fetch, action: SystemTruthApplyAction): Promise<void> {
+  const status = action.action === 'fulfill' ? 'fulfilled' : 'cancelled';
+  const kind = action.action === 'fulfill' ? 'task-close' : 'cancel';
+  await fetchJson(fetchImpl, `${baseUrl}/commit/${encodeURIComponent(action.commitmentId)}`, 5000, {
+    method: 'PATCH',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      status,
+      resolution: { kind, evidence: action.evidence },
+    }),
+  });
+}
+
+async function fetchJson<T>(fetchImpl: typeof fetch, url: string, timeoutMs: number, init?: RequestInit): Promise<T> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetchImpl(url, { ...init, signal: controller.signal });
+    if (!res.ok) throw new Error(`${url} HTTP ${res.status}`);
+    return await res.json() as T;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function ageLabel(ts: string, now: Date): string {
+  const ms = now.getTime() - Date.parse(ts);
+  if (!Number.isFinite(ms)) return 'age=unknown';
+  const hours = Math.max(0, ms / 3_600_000);
+  return hours < 48 ? `${hours.toFixed(1)}h` : `${(hours / 24).toFixed(1)}d`;
+}
+
+function compareCommitmentsNewestFirst(a: MiddlewareCommitmentTruth, b: MiddlewareCommitmentTruth): number {
+  return Date.parse(b.created_at) - Date.parse(a.created_at);
+}
+
+function trimTrailingSlash(value: string): string {
+  return value.replace(/\/+$/, '');
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/tests/system-truth.test.ts
+++ b/tests/system-truth.test.ts
@@ -1,0 +1,196 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  canonicalCommitmentKey,
+  duplicateActiveCommitments,
+  evaluateSystemTruth,
+  planSafeMiddlewareActions,
+  type MiddlewareCommitmentTruth,
+} from '../src/system-truth.js';
+
+describe('system truth reconciliation', () => {
+  let tmpDir: string;
+  let repoRoot: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(path.join(os.tmpdir(), 'mini-agent-system-truth-'));
+    repoRoot = path.join(tmpDir, 'runtime');
+    mkdirSync(repoRoot, { recursive: true });
+    mkdirSync(path.join(tmpDir, 'state'), { recursive: true });
+    mkdirSync(path.join(tmpDir, 'index'), { recursive: true });
+    writeFileSync(path.join(tmpDir, 'state/task-events.jsonl'), '', 'utf-8');
+    writeFileSync(path.join(tmpDir, 'index/relations.jsonl'), '', 'utf-8');
+    vi.stubEnv('MINI_AGENT_MEMORY_DIR', tmpDir);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('canonicalizes repeated middleware task envelopes across task ids and issue numbers', () => {
+    const a = canonicalCommitmentKey('## Task: P0 autonomy closure: repair pr-review-consensus\n\nTask ID: idx-a\n');
+    const b = canonicalCommitmentKey('## Task: P0 autonomy closure: repair pr-review-consensus\n\nTask ID: idx-b\n');
+    const c = canonicalCommitmentKey('## Task: P1 GitHub issue #167: graphify pipeline\nTask ID: idx-c');
+    const d = canonicalCommitmentKey('## Task: P1 GitHub issue #195: graphify pipeline\nTask ID: idx-d');
+
+    expect(a).toBe(b);
+    expect(c).toBe(d);
+  });
+
+  it('detects duplicate active middleware commitments', () => {
+    const base: Omit<MiddlewareCommitmentTruth, 'id' | 'text'> = {
+      status: 'active',
+      created_at: '2026-05-06T00:00:00.000Z',
+    };
+    const groups = duplicateActiveCommitments([
+      { ...base, id: 'c1', text: '## Task: P0 autonomy closure: repair pr-review-consensus\nTask ID: idx-a' },
+      { ...base, id: 'c2', text: '## Task: P0 autonomy closure: repair pr-review-consensus\nTask ID: idx-b' },
+      { ...base, id: 'c3', text: '## Task: unrelated' },
+    ]);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].items.map(i => i.id)).toEqual(['c1', 'c2']);
+  });
+
+  it('builds a degraded snapshot from live-source mocks without mutating state', async () => {
+    writeFileSync(
+      path.join(tmpDir, 'state/task-events.jsonl'),
+      Array.from({ length: 11 }, (_, i) => JSON.stringify({
+        id: `idx-task-${i}`,
+        ts: '2026-05-06T00:00:00.000Z',
+        type: 'task',
+        status: 'pending',
+        summary: `pending task ${i}`,
+        refs: [],
+      })).join('\n') + '\n',
+      'utf-8',
+    );
+
+    const fetchImpl = vi.fn(async (url: string) => {
+      if (url.endsWith('/health') && url.includes('middleware')) {
+        return jsonResponse({ status: 'ok', service: 'agent-middleware', workers: [], tasks: 2 });
+      }
+      if (url.includes('/commits')) {
+        return jsonResponse({
+          items: [
+            {
+              id: 'c1',
+              status: 'active',
+              created_at: '2026-05-06T00:00:00.000Z',
+              text: '## Task: P0 autonomy closure: repair pr-review-consensus\nTask ID: idx-a',
+            },
+            {
+              id: 'c2',
+              status: 'active',
+              created_at: '2026-05-06T00:10:00.000Z',
+              text: '## Task: P0 autonomy closure: repair pr-review-consensus\nTask ID: idx-b',
+            },
+          ],
+        });
+      }
+      if (url.includes('/tasks')) return jsonResponse({ tasks: [] });
+      if (url.endsWith('/health') && url.includes('kg')) return jsonResponse({ status: 'ok', service: 'knowledge-graph' });
+      if (url.includes('/api/stats')) return jsonResponse({ nodes: 10, edges: 20 });
+      if (url.includes('/api/push/formatted')) {
+        return jsonResponse({ text: '<kg-push>\n- **kuro: 收到** [observation]\n- **claude-code: done** [observation]\n</kg-push>' });
+      }
+      throw new Error(`unexpected url ${url}`);
+    }) as unknown as typeof fetch;
+
+    const snapshot = await evaluateSystemTruth({
+      memoryDir: tmpDir,
+      repoRoot,
+      middlewareUrl: 'http://middleware',
+      kgUrl: 'http://kg',
+      now: new Date('2026-05-06T13:00:00.000Z'),
+      fetchImpl,
+    });
+
+    expect(snapshot.status).toBe('degraded');
+    expect(snapshot.counts.localActiveTasks).toBe(11);
+    expect(snapshot.counts.middlewareActiveCommitments).toBe(2);
+    expect(snapshot.counts.kgNodes).toBe(10);
+    expect(snapshot.findings.map(f => f.kind)).toContain('local-task-backlog');
+    expect(snapshot.findings.map(f => f.kind)).toContain('middleware-duplicate-active');
+    expect(snapshot.findings.map(f => f.kind)).toContain('kg-push-low-signal');
+  });
+
+  it('plans safe middleware cleanup for older duplicates and linked terminal tasks only', () => {
+    const active: MiddlewareCommitmentTruth[] = [
+      {
+        id: 'old-duplicate',
+        status: 'active',
+        created_at: '2026-05-06T00:00:00.000Z',
+        text: '## Task: P0 autonomy closure: repair pr-review-consensus\nTask ID: idx-a',
+      },
+      {
+        id: 'new-duplicate',
+        status: 'active',
+        created_at: '2026-05-06T01:00:00.000Z',
+        text: '## Task: P0 autonomy closure: repair pr-review-consensus\nTask ID: idx-b',
+      },
+      {
+        id: 'linked-complete',
+        status: 'active',
+        created_at: '2026-05-06T02:00:00.000Z',
+        text: 'delegate completed',
+        linked_task_id: 'task-1',
+      },
+      {
+        id: 'linked-running',
+        status: 'active',
+        created_at: '2026-05-06T02:00:00.000Z',
+        text: 'delegate still running',
+        linked_task_id: 'task-2',
+      },
+    ];
+
+    const actions = planSafeMiddlewareActions({
+      status: 'degraded',
+      generatedAt: '2026-05-06T03:00:00.000Z',
+      score: 80,
+      counts: {
+        localActiveTasks: 0,
+        middlewareActiveCommitments: 4,
+        middlewareRunningTasks: 1,
+        middlewareUnreviewedCompletedTasks: 0,
+        kgNodes: 0,
+        kgEdges: 0,
+      },
+      local: { activeTasks: [], autonomyStatus: 'healthy', autonomyScore: 100 },
+      middleware: {
+        online: true,
+        activeCommitments: active,
+        recentTasks: [
+          { id: 'task-1', worker: 'coder', status: 'completed', task: '' },
+          { id: 'task-2', worker: 'coder', status: 'running', task: '' },
+        ],
+      },
+      kg: { online: true, retrievalAugmentEnabled: true },
+      findings: [],
+    });
+
+    expect(actions).toEqual([
+      expect.objectContaining({
+        commitmentId: 'old-duplicate',
+        action: 'cancel',
+        reason: 'duplicate-active-commitment',
+      }),
+      expect.objectContaining({
+        commitmentId: 'linked-complete',
+        action: 'fulfill',
+        reason: 'linked-task-completed',
+      }),
+    ]);
+  });
+});
+
+function jsonResponse(body: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => body,
+  } as Response;
+}


### PR DESCRIPTION
## Problem
Kuro, middleware, and KG can each be locally healthy while disagreeing about what work is still active. The most visible failure mode is middleware accumulating duplicate or stale active commitments that continue to look like live work.

## Solution
- Add a `system-truth` reconciler that reads local memory-index/autonomy closure, middleware health/commitments/tasks, and KG health/stats.
- Add `pnpm check:system-truth` CLI with text/JSON output.
- Add `--apply-safe` mode that only mutates middleware commitments when evidence is mechanically safe:
  - cancel older duplicate active commitments, keeping the freshest one
  - fulfill/cancel active commitments linked to terminal middleware tasks
- Expose `GET /api/system-truth` for dashboard/API consumers.
- Cover canonical duplicate detection, degraded live-source snapshots, and safe action planning in Vitest.

## Verification
- `pnpm typecheck`
- `pnpm exec vitest run tests/system-truth.test.ts` -> 4 passed
- `pnpm build`
- `pnpm test` -> 82 test files passed, 665 passed, 2 skipped
- Live dry run before apply-safe: degraded score=60, local active tasks=0, middleware active commitments=21, duplicate active groups present
- Live `--apply-safe`: applied=6, skipped=0, cancelled stale duplicate active commitments only
- Live dry run after apply-safe: degraded score=84, middleware active commitments=15, duplicate active groups cleared

## Residual Risk
System truth remains degraded because 15 active middleware commitments and 9 stale commitments still require explicit issue/PR/log evidence before closing. This PR intentionally does not auto-close ambiguous work.