### PR TITLE
fix: add middleware dispatch circuit breaker

### DIFF
--- a/src/middleware-client.ts
+++ b/src/middleware-client.ts
@@ -202,6 +202,17 @@ export class MiddlewareOfflineError extends MiddlewareError {
   }
 }
 
+export class MiddlewareCircuitOpenError extends MiddlewareError {
+  constructor(
+    public baseUrl: string,
+    public retryAt: string,
+    public failureCount: number,
+  ) {
+    super(`middleware circuit open at ${baseUrl}; retry after ${retryAt} (${failureCount} offline failures)`);
+    this.name = 'MiddlewareCircuitOpenError';
+  }
+}
+
 export class MiddlewareValidationError extends MiddlewareError {
   constructor(message: string, public errors?: string[]) {
     super(message);
@@ -319,15 +330,69 @@ export interface CreateClientOptions {
   baseUrl?: string;
   transport?: Transport;
   requestTimeoutMs?: number;
+  circuitBreaker?: false | Partial<MiddlewareCircuitConfig>;
 }
+
+export interface MiddlewareCircuitConfig {
+  failureThreshold: number;
+  initialBackoffMs: number;
+  maxBackoffMs: number;
+}
+
+export interface MiddlewareCircuitState {
+  baseUrl: string;
+  state: 'closed' | 'open';
+  failureCount: number;
+  openedUntil?: string;
+  lastFailureAt?: string;
+}
+
+const DEFAULT_CIRCUIT: MiddlewareCircuitConfig = {
+  failureThreshold: 3,
+  initialBackoffMs: 5 * 60 * 1000,
+  maxBackoffMs: 60 * 60 * 1000,
+};
+
+const circuitStates = new Map<string, {
+  failureCount: number;
+  openedUntilMs: number;
+  lastFailureAtMs?: number;
+}>();
 
 export function createMiddlewareClient(opts: CreateClientOptions = {}): MiddlewareClient {
   const baseUrl = opts.baseUrl ?? process.env.MIDDLEWARE_URL ?? 'http://localhost:3200';
   const transport = opts.transport ?? new HttpTransport(baseUrl, opts.requestTimeoutMs);
+  const circuitConfig = opts.circuitBreaker === false
+    ? null
+    : { ...DEFAULT_CIRCUIT, ...(opts.circuitBreaker ?? {}) };
+
+  async function request<T>(
+    method: 'GET' | 'POST' | 'PATCH' | 'DELETE',
+    path: string,
+    body?: unknown,
+    signal?: AbortSignal,
+  ): Promise<T> {
+    if (circuitConfig && isCircuitGatedPath(method, path)) {
+      assertCircuitAllows(baseUrl);
+    }
+
+    try {
+      const result = await transport.request<T>(method, path, body, signal);
+      if (circuitConfig && (path === '/health' || isCircuitGatedPath(method, path))) {
+        resetMiddlewareCircuitBreaker(baseUrl);
+      }
+      return result;
+    } catch (err) {
+      if (circuitConfig && err instanceof MiddlewareOfflineError) {
+        recordMiddlewareOfflineFailure(baseUrl, circuitConfig);
+      }
+      throw err;
+    }
+  }
 
   const client: MiddlewareClient = {
-    dispatch: (req) => transport.request('POST', '/dispatch', req),
-    plan: (req) => transport.request('POST', '/plan', req),
+    dispatch: (req) => request('POST', '/dispatch', req),
+    plan: (req) => request('POST', '/plan', req),
     accomplish: (req) => {
       // Map AccomplishRequest fields to middleware's body schema
       const body: Record<string, unknown> = { goal: req.goal };
@@ -337,20 +402,20 @@ export function createMiddlewareClient(opts: CreateClientOptions = {}): Middlewa
       if (req.callbackUrl) body.callback = req.callbackUrl;
       if (req.callbackFrom) body.callbackFrom = req.callbackFrom;
       if (req.wait) body.wait = req.wait;
-      return transport.request('POST', '/accomplish', body);
+      return request('POST', '/accomplish', body);
     },
-    status: (id) => transport.request('GET', `/status/${encodeURIComponent(id)}`),
-    planStatus: (id) => transport.request('GET', `/plan/${encodeURIComponent(id)}`),
-    health: () => transport.request('GET', '/health'),
+    status: (id) => request('GET', `/status/${encodeURIComponent(id)}`),
+    planStatus: (id) => request('GET', `/plan/${encodeURIComponent(id)}`),
+    health: () => request('GET', '/health'),
     cancel: (id) =>
-      transport.request<void>('DELETE', `/task/${encodeURIComponent(id)}`),
+      request<void>('DELETE', `/task/${encodeURIComponent(id)}`),
     cancelPlan: (id) =>
-      transport.request<void>('DELETE', `/plan/${encodeURIComponent(id)}`),
+      request<void>('DELETE', `/plan/${encodeURIComponent(id)}`),
 
-    createCommitment: (req) => transport.request('POST', '/commit', req),
-    getCommitment: (id) => transport.request('GET', `/commit/${encodeURIComponent(id)}`),
+    createCommitment: (req) => request('POST', '/commit', req),
+    getCommitment: (id) => request('GET', `/commit/${encodeURIComponent(id)}`),
     resolveCommitment: (id, resolution) =>
-      transport.request<void>('PATCH', `/commit/${encodeURIComponent(id)}`, {
+      request<void>('PATCH', `/commit/${encodeURIComponent(id)}`, {
         status: 'fulfilled',
         resolution,
       }),
@@ -360,7 +425,7 @@ export function createMiddlewareClient(opts: CreateClientOptions = {}): Middlewa
       if (query.owner) qs.set('owner', query.owner);
       if (query.channel) qs.set('channel', query.channel);
       const suffix = qs.toString() ? `?${qs.toString()}` : '';
-      return transport.request('GET', `/commits${suffix}`);
+      return request('GET', `/commits${suffix}`);
     },
 
     async listWorkers() {
@@ -390,6 +455,56 @@ export function createMiddlewareClient(opts: CreateClientOptions = {}): Middlewa
   };
 
   return client;
+}
+
+export function getMiddlewareCircuitState(baseUrl = process.env.MIDDLEWARE_URL ?? 'http://localhost:3200'): MiddlewareCircuitState {
+  const state = circuitStates.get(baseUrl);
+  const openedUntilMs = state?.openedUntilMs ?? 0;
+  const open = openedUntilMs > Date.now();
+  return {
+    baseUrl,
+    state: open ? 'open' : 'closed',
+    failureCount: state?.failureCount ?? 0,
+    ...(open ? { openedUntil: new Date(openedUntilMs).toISOString() } : {}),
+    ...(state?.lastFailureAtMs ? { lastFailureAt: new Date(state.lastFailureAtMs).toISOString() } : {}),
+  };
+}
+
+export function resetMiddlewareCircuitBreaker(baseUrl?: string): void {
+  if (baseUrl) {
+    circuitStates.delete(baseUrl);
+    return;
+  }
+  circuitStates.clear();
+}
+
+function assertCircuitAllows(baseUrl: string): void {
+  const state = circuitStates.get(baseUrl);
+  if (!state || state.openedUntilMs <= Date.now()) return;
+  throw new MiddlewareCircuitOpenError(
+    baseUrl,
+    new Date(state.openedUntilMs).toISOString(),
+    state.failureCount,
+  );
+}
+
+function recordMiddlewareOfflineFailure(baseUrl: string, config: MiddlewareCircuitConfig): void {
+  const now = Date.now();
+  const state = circuitStates.get(baseUrl) ?? { failureCount: 0, openedUntilMs: 0 };
+  const failureCount = state.failureCount + 1;
+  const openedUntilMs = failureCount >= config.failureThreshold
+    ? now + backoffForFailure(failureCount, config)
+    : 0;
+  circuitStates.set(baseUrl, { failureCount, openedUntilMs, lastFailureAtMs: now });
+}
+
+function backoffForFailure(failureCount: number, config: MiddlewareCircuitConfig): number {
+  const exponent = Math.max(0, failureCount - config.failureThreshold);
+  return Math.min(config.maxBackoffMs, config.initialBackoffMs * (2 ** exponent));
+}
+
+function isCircuitGatedPath(method: string, path: string): boolean {
+  return method === 'POST' && ['/dispatch', '/plan', '/accomplish'].includes(path);
 }
 
 async function waitForTerminal(

--- a/tests/middleware-client-circuit-breaker.test.ts
+++ b/tests/middleware-client-circuit-breaker.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  createMiddlewareClient,
+  getMiddlewareCircuitState,
+  MiddlewareCircuitOpenError,
+  MiddlewareOfflineError,
+  resetMiddlewareCircuitBreaker,
+  type Transport,
+} from '../src/middleware-client.js';
+
+function offlineTransport(baseUrl: string): Transport {
+  return {
+    request: vi.fn(async () => {
+      throw new MiddlewareOfflineError(baseUrl);
+    }),
+  };
+}
+
+describe('middleware client circuit breaker', () => {
+  const baseUrl = 'http://middleware.test';
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-07T00:00:00.000Z'));
+    resetMiddlewareCircuitBreaker();
+  });
+
+  afterEach(() => {
+    resetMiddlewareCircuitBreaker();
+    vi.useRealTimers();
+  });
+
+  it('opens after repeated offline dispatch failures and fails fast during backoff', async () => {
+    const transport = offlineTransport(baseUrl);
+    const client = createMiddlewareClient({
+      baseUrl,
+      transport,
+      circuitBreaker: {
+        failureThreshold: 3,
+        initialBackoffMs: 1000,
+        maxBackoffMs: 8000,
+      },
+    });
+
+    await expect(client.dispatch({ worker: 'coder', task: 'one' })).rejects.toBeInstanceOf(MiddlewareOfflineError);
+    await expect(client.dispatch({ worker: 'coder', task: 'two' })).rejects.toBeInstanceOf(MiddlewareOfflineError);
+    await expect(client.dispatch({ worker: 'coder', task: 'three' })).rejects.toBeInstanceOf(MiddlewareOfflineError);
+
+    expect(getMiddlewareCircuitState(baseUrl)).toEqual(expect.objectContaining({
+      state: 'open',
+      failureCount: 3,
+      openedUntil: '2026-05-07T00:00:01.000Z',
+    }));
+
+    await expect(client.dispatch({ worker: 'coder', task: 'blocked' })).rejects.toBeInstanceOf(MiddlewareCircuitOpenError);
+    expect(transport.request).toHaveBeenCalledTimes(3);
+
+    vi.advanceTimersByTime(1000);
+    await expect(client.dispatch({ worker: 'coder', task: 'probe after backoff' })).rejects.toBeInstanceOf(MiddlewareOfflineError);
+
+    expect(getMiddlewareCircuitState(baseUrl)).toEqual(expect.objectContaining({
+      state: 'open',
+      failureCount: 4,
+      openedUntil: '2026-05-07T00:00:03.000Z',
+    }));
+    expect(transport.request).toHaveBeenCalledTimes(4);
+  });
+
+  it('allows health probes while open and resets the circuit on healthy middleware', async () => {
+    const transport: Transport = {
+      request: vi.fn(async (_method, path) => {
+        if (path === '/health') {
+          return {
+            status: 'ok',
+            service: 'agent-middleware',
+            workers: ['coder'],
+            tasks: 0,
+          };
+        }
+        throw new MiddlewareOfflineError(baseUrl);
+      }),
+    };
+    const client = createMiddlewareClient({
+      baseUrl,
+      transport,
+      circuitBreaker: {
+        failureThreshold: 1,
+        initialBackoffMs: 60_000,
+        maxBackoffMs: 60_000,
+      },
+    });
+
+    await expect(client.dispatch({ worker: 'coder', task: 'open circuit' })).rejects.toBeInstanceOf(MiddlewareOfflineError);
+    expect(getMiddlewareCircuitState(baseUrl).state).toBe('open');
+
+    await expect(client.health()).resolves.toEqual(expect.objectContaining({ status: 'ok' }));
+    expect(getMiddlewareCircuitState(baseUrl)).toEqual(expect.objectContaining({
+      state: 'closed',
+      failureCount: 0,
+    }));
+
+    await expect(client.dispatch({ worker: 'coder', task: 'allowed after health reset' })).rejects.toBeInstanceOf(MiddlewareOfflineError);
+    expect(transport.request).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not gate status polling or commitment reads', async () => {
+    const transport = offlineTransport(baseUrl);
+    const client = createMiddlewareClient({
+      baseUrl,
+      transport,
+      circuitBreaker: {
+        failureThreshold: 1,
+        initialBackoffMs: 60_000,
+        maxBackoffMs: 60_000,
+      },
+    });
+
+    await expect(client.dispatch({ worker: 'coder', task: 'open circuit' })).rejects.toBeInstanceOf(MiddlewareOfflineError);
+    await expect(client.status('mw-1')).rejects.toBeInstanceOf(MiddlewareOfflineError);
+    await expect(client.listCommitments({ status: 'active' })).rejects.toBeInstanceOf(MiddlewareOfflineError);
+
+    expect(transport.request).toHaveBeenCalledTimes(3);
+  });
+});


### PR DESCRIPTION
## Problem
Constraint Texture analysis showed a high-token waste pattern: Kuro kept trying to delegate while agent-middleware was offline. The measured day had 45 delegation failures, with 38 caused by middleware offline. Each failed attempt still burns a full cycle path: dispatch intent, wait/failure handling, retry pressure, and later failure review.

## Solution
Add a middleware client circuit breaker at the TypeScript SDK layer:
- Tracks consecutive `MiddlewareOfflineError` failures per `baseUrl`.
- Opens after 3 offline failures by default.
- Applies exponential backoff: 5 min initial, 60 min max.
- Fails fast for new work endpoints only: `POST /dispatch`, `POST /plan`, `POST /accomplish`.
- Keeps `/health`, status polling, and commitment reads available.
- Resets automatically when `/health` or a gated request succeeds.
- Exposes `getMiddlewareCircuitState()` and `resetMiddlewareCircuitBreaker()` for observability/tests.

## Verification
- `pnpm typecheck` passed in runtime checkout before moving patch
- `pnpm exec vitest run tests/middleware-client-circuit-breaker.test.ts tests/middleware-provider.test.ts tests/delegation-arbiter.test.ts` -> 19 passed in runtime checkout
- `pnpm build` passed in runtime checkout
- `pnpm test` passed in runtime checkout: 82 test files, 664 passed, 2 skipped
- In isolated worktree after applying the same patch:
  - `pnpm typecheck` passed
  - `pnpm exec vitest run tests/middleware-client-circuit-breaker.test.ts tests/middleware-provider.test.ts tests/delegation-arbiter.test.ts` -> 19 passed
  - `pnpm build` passed

## Notes
This deliberately gates only new work creation. Recovery probes and reads still go through so middleware can come back without manual reset.