### PR TITLE
fix: gate routine reactive triggers

### DIFF
--- a/src/loop.ts
+++ b/src/loop.ts
@@ -117,6 +117,7 @@ import { routeInboxItems } from './task-graph.js';
 import { triageRouting, logTriageBypass } from './myelin-fleet.js';
 import { initSharedKnowledge, observe as kbObserve, getKnowledgeSummary } from './shared-knowledge.js';
 import type { Phase0Results } from './preprocess.js';
+import { reactiveTriggerGate, parseReactiveTriggerSource, extractTriggerPath, type ReactiveTriggerSource } from './reactive-trigger-gate.js';
 
 // =============================================================================
 // Types
@@ -153,6 +154,7 @@ export interface LoopStatus {
   mode: 'task' | 'autonomous' | 'idle';
   pendingPriority?: { reason: string; waitingMs: number };
   omlxGate?: string;
+  reactiveTriggerGate?: string;
 }
 
 const DEFAULT_CONFIG: AgentLoopConfig = {
@@ -1014,6 +1016,13 @@ export class AgentLoop {
       return;
     }
 
+    if (event.source === 'workspace') {
+      const path = typeof agentEvent.data?.path === 'string' ? agentEvent.data.path : undefined;
+      if (this.skipReactiveTrigger('workspace', path, { scheduleHeartbeat: false })) {
+        return;
+      }
+    }
+
     // If agent process is busy — only P0 (telegram-user) can preempt.
     // Lower priority events queue up and wait for the current work to finish.
     if (isLoopBusy()) {
@@ -1038,6 +1047,45 @@ export class AgentLoop {
     this.triggerReason = event.source === 'telegram' ? 'telegram-user' : `${event.source}${detail}`;
 
     this.runCycle();
+  }
+
+  private skipReactiveTrigger(
+    source: ReactiveTriggerSource,
+    triggerPath: string | undefined,
+    opts: { scheduleHeartbeat: boolean },
+  ): boolean {
+    const memDir = getMemoryRootDir();
+    let pendingInbox = 0;
+    let pendingHighPriority = 0;
+    try { pendingInbox = readPendingInbox().length; } catch { /* best effort */ }
+    try { pendingHighPriority = getHighPriorityPendingCount(memDir); } catch { /* best effort */ }
+
+    const decision = reactiveTriggerGate.decide({
+      source,
+      path: triggerPath,
+      perceptionChanged: perceptionStreams.version !== this.lastPerceptionVersion,
+      pendingHighPriority,
+      pendingInbox,
+      pendingDelegationResults: this.hasPendingDelegationResults,
+      pendingPriority: !!this.pendingPriority,
+      lastAction: this.lastAction,
+      trueNoopStreak: this.trueNoopStreak,
+    });
+    if (decision.action === 'wake') return false;
+
+    slog('LOOP', `[reactive-gate] skip ${source}: ${decision.reason} (saved≈${decision.savedContextChars} chars)`);
+    logTriageBypass(source, 'skip', decision.reason);
+    eventBus.emit('action:loop', {
+      event: 'reactive-trigger.skip',
+      source,
+      reason: decision.reason,
+      savedContextChars: decision.savedContextChars,
+    });
+    this.lastCycleTime = Date.now();
+    if (opts.scheduleHeartbeat && this.running && !this.paused) {
+      this.scheduleHeartbeat();
+    }
+    return true;
   }
 
   /** Event handler — bound to `this` for subscribe/unsubscribe */
@@ -1317,6 +1365,7 @@ export class AgentLoop {
         pendingPriority: { reason: this.pendingPriority.reason, waitingMs: Date.now() - this.pendingPriority.arrivedAt },
       } : {}),
       ...(gateStatsStr ? { omlxGate: gateStatsStr } : {}),
+      reactiveTriggerGate: reactiveTriggerGate.formatStatus(),
     };
   }
 
@@ -1438,6 +1487,11 @@ export class AgentLoop {
     // Placed here (not in handleEvent) so ALL cycle entry points are covered:
     // heartbeat timer, priority drain, direct-message queue, and event-driven triggers
     const reason = this.triggerReason ?? '';
+    if (parseReactiveTriggerSource(reason) === 'heartbeat') {
+      if (this.skipReactiveTrigger('heartbeat', extractTriggerPath(reason), { scheduleHeartbeat: true })) {
+        return;
+      }
+    }
     const isDM = [...AgentLoop.DIRECT_MESSAGE_SOURCES].some(s => reason.startsWith(s))
       || reason.startsWith('direct-message');
     const isContinuation = reason.startsWith('continuation');

--- a/src/reactive-trigger-gate.ts
+++ b/src/reactive-trigger-gate.ts
@@ -1,0 +1,242 @@
+/**
+ * Reactive trigger gate.
+ *
+ * Cheap pre-context guard for routine triggers. It exists to stop workspace /
+ * heartbeat noise from spending a full OODA context build when a lightweight
+ * probe says there is no new actionable work.
+ */
+
+export type ReactiveTriggerSource =
+  | 'workspace'
+  | 'heartbeat'
+  | 'mobile'
+  | 'telegram'
+  | 'room'
+  | 'chat'
+  | 'alert'
+  | 'cron'
+  | 'delegation-complete'
+  | 'delegation-batch'
+  | 'continuation'
+  | 'manual'
+  | 'startup'
+  | 'unknown';
+
+export interface ReactiveTriggerProbe {
+  source: ReactiveTriggerSource;
+  nowMs?: number;
+  path?: string;
+  perceptionChanged: boolean;
+  pendingHighPriority: number;
+  pendingInbox: number;
+  pendingDelegationResults: boolean;
+  pendingPriority: boolean;
+  lastAction?: string | null;
+  trueNoopStreak: number;
+}
+
+export interface ReactiveTriggerGateOptions {
+  workspaceCooldownMs: number;
+  heartbeatIdleCooldownMs: number;
+  estimatedContextChars: number;
+}
+
+export interface ReactiveTriggerDecision {
+  action: 'wake' | 'skip';
+  reason: string;
+  savedContextChars: number;
+}
+
+export interface ReactiveTriggerGateMetrics {
+  skipped: number;
+  woken: number;
+  savedContextChars: number;
+  lastDecision: {
+    action: 'wake' | 'skip';
+    source: ReactiveTriggerSource;
+    reason: string;
+    ts: string;
+  } | null;
+}
+
+const DEFAULT_OPTIONS: ReactiveTriggerGateOptions = {
+  workspaceCooldownMs: 5 * 60 * 1000,
+  heartbeatIdleCooldownMs: 5 * 60 * 1000,
+  estimatedContextChars: 25_000,
+};
+
+const BYPASS_SOURCES = new Set<ReactiveTriggerSource>([
+  'telegram',
+  'room',
+  'chat',
+  'alert',
+  'cron',
+  'delegation-complete',
+  'delegation-batch',
+  'continuation',
+  'manual',
+  'startup',
+]);
+
+export class ReactiveTriggerGate {
+  private readonly options: ReactiveTriggerGateOptions;
+  private lastWorkspaceWakeByKey = new Map<string, number>();
+  private lastHeartbeatIdleSkipAt = 0;
+  private metrics: ReactiveTriggerGateMetrics = {
+    skipped: 0,
+    woken: 0,
+    savedContextChars: 0,
+    lastDecision: null,
+  };
+
+  constructor(options: Partial<ReactiveTriggerGateOptions> = {}) {
+    this.options = { ...DEFAULT_OPTIONS, ...options };
+  }
+
+  decide(probe: ReactiveTriggerProbe): ReactiveTriggerDecision {
+    const now = probe.nowMs ?? Date.now();
+    const source = normalizeSource(probe.source);
+    const actionable = actionableProbeReasons(probe);
+    let decision: ReactiveTriggerDecision;
+
+    if (BYPASS_SOURCES.has(source)) {
+      decision = { action: 'wake', reason: `bypass:${source}`, savedContextChars: 0 };
+    } else if (actionable.length > 0) {
+      decision = { action: 'wake', reason: `probe:${actionable.join('+')}`, savedContextChars: 0 };
+    } else if (source === 'workspace') {
+      decision = this.workspaceDecision(probe, now);
+    } else if (source === 'heartbeat') {
+      decision = this.heartbeatDecision(probe, now);
+    } else {
+      decision = { action: 'wake', reason: 'not-routine', savedContextChars: 0 };
+    }
+
+    this.record(source, decision, now);
+    return decision;
+  }
+
+  getMetrics(): ReactiveTriggerGateMetrics {
+    return {
+      ...this.metrics,
+      lastDecision: this.metrics.lastDecision ? { ...this.metrics.lastDecision } : null,
+    };
+  }
+
+  formatStatus(): string {
+    const last = this.metrics.lastDecision;
+    const lastText = last ? ` last=${last.action}:${last.source}:${last.reason}` : '';
+    return `ReactiveTriggerGate: skipped=${this.metrics.skipped} woken=${this.metrics.woken} saved≈${this.metrics.savedContextChars} chars${lastText}`;
+  }
+
+  reset(): void {
+    this.lastWorkspaceWakeByKey.clear();
+    this.lastHeartbeatIdleSkipAt = 0;
+    this.metrics = {
+      skipped: 0,
+      woken: 0,
+      savedContextChars: 0,
+      lastDecision: null,
+    };
+  }
+
+  private workspaceDecision(probe: ReactiveTriggerProbe, now: number): ReactiveTriggerDecision {
+    const key = workspaceKey(probe.path);
+    const lastWake = this.lastWorkspaceWakeByKey.get(key) ?? 0;
+    if (lastWake > 0 && now - lastWake < this.options.workspaceCooldownMs) {
+      return {
+        action: 'skip',
+        reason: `workspace-cooldown:${key}`,
+        savedContextChars: this.options.estimatedContextChars,
+      };
+    }
+
+    this.lastWorkspaceWakeByKey.set(key, now);
+    return { action: 'wake', reason: `workspace-probe:${key}`, savedContextChars: 0 };
+  }
+
+  private heartbeatDecision(probe: ReactiveTriggerProbe, now: number): ReactiveTriggerDecision {
+    const idleLastAction = !probe.lastAction || /no action|穩態|無需行動|nothing to do/i.test(probe.lastAction);
+    if (idleLastAction || probe.trueNoopStreak > 0 || !probe.perceptionChanged) {
+      if (this.lastHeartbeatIdleSkipAt === 0) {
+        this.lastHeartbeatIdleSkipAt = now;
+        return {
+          action: 'skip',
+          reason: 'heartbeat-idle-probe',
+          savedContextChars: this.options.estimatedContextChars,
+        };
+      }
+      if (now - this.lastHeartbeatIdleSkipAt < this.options.heartbeatIdleCooldownMs) {
+        return {
+          action: 'skip',
+          reason: 'heartbeat-idle-cooldown',
+          savedContextChars: this.options.estimatedContextChars,
+        };
+      }
+      this.lastHeartbeatIdleSkipAt = now;
+      return { action: 'wake', reason: 'heartbeat-periodic-scout', savedContextChars: 0 };
+    }
+    return { action: 'wake', reason: 'heartbeat-probe', savedContextChars: 0 };
+  }
+
+  private record(source: ReactiveTriggerSource, decision: ReactiveTriggerDecision, now: number): void {
+    if (decision.action === 'skip') {
+      this.metrics.skipped++;
+      this.metrics.savedContextChars += decision.savedContextChars;
+    } else {
+      this.metrics.woken++;
+    }
+    this.metrics.lastDecision = {
+      action: decision.action,
+      source,
+      reason: decision.reason,
+      ts: new Date(now).toISOString(),
+    };
+  }
+}
+
+export function parseReactiveTriggerSource(triggerReason: string | null | undefined): ReactiveTriggerSource {
+  const reason = (triggerReason ?? '').trim();
+  if (!reason) return 'unknown';
+  if (reason.startsWith('telegram-user') || reason.startsWith('telegram')) return 'telegram';
+  if (reason.startsWith('room')) return 'room';
+  if (reason.startsWith('chat')) return 'chat';
+  if (reason.startsWith('workspace')) return 'workspace';
+  if (reason.startsWith('heartbeat')) return 'heartbeat';
+  if (reason.startsWith('mobile')) return 'mobile';
+  if (reason.startsWith('alert')) return 'alert';
+  if (reason.startsWith('cron')) return 'cron';
+  if (reason.startsWith('delegation-complete')) return 'delegation-complete';
+  if (reason.startsWith('delegation-batch')) return 'delegation-batch';
+  if (reason.startsWith('continuation')) return 'continuation';
+  if (reason.startsWith('manual')) return 'manual';
+  if (reason.startsWith('startup')) return 'startup';
+  if (reason.startsWith('direct-message')) return 'chat';
+  return 'unknown';
+}
+
+export function extractTriggerPath(triggerReason: string | null | undefined): string | undefined {
+  const reason = triggerReason ?? '';
+  const match = reason.match(/"path"\s*:\s*"([^"]+)"/);
+  return match?.[1];
+}
+
+function actionableProbeReasons(probe: ReactiveTriggerProbe): string[] {
+  const reasons: string[] = [];
+  if (probe.pendingPriority) reasons.push('pending-priority');
+  if (probe.pendingDelegationResults) reasons.push('delegation-results');
+  if (probe.pendingInbox > 0) reasons.push('pending-inbox');
+  if (probe.pendingHighPriority > 0 && probe.trueNoopStreak < 3) reasons.push('high-priority-work');
+  return reasons;
+}
+
+function workspaceKey(triggerPath: string | undefined): string {
+  if (!triggerPath) return 'workspace';
+  if (triggerPath.startsWith('memory/handoffs/')) return triggerPath;
+  return triggerPath.split('/').slice(0, 2).join('/') || triggerPath;
+}
+
+function normalizeSource(source: ReactiveTriggerSource): ReactiveTriggerSource {
+  return source === 'mobile' ? 'heartbeat' : source;
+}
+
+export const reactiveTriggerGate = new ReactiveTriggerGate();

--- a/tests/reactive-trigger-gate.test.ts
+++ b/tests/reactive-trigger-gate.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+import { ReactiveTriggerGate, extractTriggerPath, parseReactiveTriggerSource, type ReactiveTriggerProbe } from '../src/reactive-trigger-gate.js';
+
+function probe(overrides: Partial<ReactiveTriggerProbe> = {}): ReactiveTriggerProbe {
+  return {
+    source: 'workspace',
+    nowMs: Date.parse('2026-05-07T00:00:00.000Z'),
+    perceptionChanged: true,
+    pendingHighPriority: 0,
+    pendingInbox: 0,
+    pendingDelegationResults: false,
+    pendingPriority: false,
+    lastAction: 'no action',
+    trueNoopStreak: 1,
+    ...overrides,
+  };
+}
+
+describe('ReactiveTriggerGate', () => {
+  it('debounces repeated workspace noise by path without a full context cycle', () => {
+    const gate = new ReactiveTriggerGate({
+      workspaceCooldownMs: 5 * 60_000,
+      estimatedContextChars: 25_000,
+    });
+
+    expect(gate.decide(probe({ path: 'memory/handoffs/active.md' }))).toEqual(expect.objectContaining({
+      action: 'wake',
+      reason: 'workspace-probe:memory/handoffs/active.md',
+    }));
+    expect(gate.decide(probe({
+      path: 'memory/handoffs/active.md',
+      nowMs: Date.parse('2026-05-07T00:01:00.000Z'),
+    }))).toEqual(expect.objectContaining({
+      action: 'skip',
+      reason: 'workspace-cooldown:memory/handoffs/active.md',
+      savedContextChars: 25_000,
+    }));
+
+    expect(gate.getMetrics()).toEqual(expect.objectContaining({
+      skipped: 1,
+      woken: 1,
+      savedContextChars: 25_000,
+    }));
+  });
+
+  it('lets workspace wake immediately when the lightweight probe sees real work', () => {
+    const gate = new ReactiveTriggerGate({ workspaceCooldownMs: 5 * 60_000 });
+    gate.decide(probe({ path: 'memory/handoffs/active.md' }));
+
+    const decision = gate.decide(probe({
+      path: 'memory/handoffs/active.md',
+      nowMs: Date.parse('2026-05-07T00:01:00.000Z'),
+      pendingHighPriority: 1,
+      trueNoopStreak: 0,
+    }));
+
+    expect(decision).toEqual(expect.objectContaining({
+      action: 'wake',
+      reason: 'probe:high-priority-work',
+    }));
+  });
+
+  it('never gates direct messages, alerts, or delegation completions', () => {
+    const gate = new ReactiveTriggerGate({ workspaceCooldownMs: 5 * 60_000 });
+
+    for (const source of ['telegram', 'room', 'chat', 'alert', 'delegation-complete', 'delegation-batch', 'continuation'] as const) {
+      expect(gate.decide(probe({ source }))).toEqual(expect.objectContaining({
+        action: 'wake',
+        reason: `bypass:${source}`,
+      }));
+    }
+  });
+
+  it('skips idle heartbeat probes and records estimated context savings', () => {
+    const gate = new ReactiveTriggerGate({
+      heartbeatIdleCooldownMs: 5 * 60_000,
+      estimatedContextChars: 30_000,
+    });
+
+    expect(gate.decide(probe({
+      source: 'heartbeat',
+      perceptionChanged: false,
+      lastAction: 'nothing to do',
+      trueNoopStreak: 2,
+    }))).toEqual(expect.objectContaining({
+      action: 'skip',
+      reason: 'heartbeat-idle-probe',
+      savedContextChars: 30_000,
+    }));
+
+    expect(gate.getMetrics().savedContextChars).toBe(30_000);
+  });
+
+  it('allows periodic heartbeat scout after the idle cooldown', () => {
+    const gate = new ReactiveTriggerGate({
+      heartbeatIdleCooldownMs: 5 * 60_000,
+      estimatedContextChars: 30_000,
+    });
+    gate.decide(probe({
+      source: 'heartbeat',
+      perceptionChanged: false,
+      lastAction: 'nothing to do',
+      nowMs: Date.parse('2026-05-07T00:00:00.000Z'),
+    }));
+
+    expect(gate.decide(probe({
+      source: 'heartbeat',
+      perceptionChanged: false,
+      lastAction: 'nothing to do',
+      nowMs: Date.parse('2026-05-07T00:06:00.000Z'),
+    }))).toEqual(expect.objectContaining({
+      action: 'wake',
+      reason: 'heartbeat-periodic-scout',
+    }));
+  });
+
+  it('parses trigger reasons used by AgentLoop', () => {
+    expect(parseReactiveTriggerSource('workspace: {"source":"sentinel","path":"memory/handoffs/active.md"}')).toBe('workspace');
+    expect(parseReactiveTriggerSource('heartbeat')).toBe('heartbeat');
+    expect(parseReactiveTriggerSource('telegram-user (inbox-recovery)')).toBe('telegram');
+    expect(parseReactiveTriggerSource('delegation-batch(3)')).toBe('delegation-batch');
+    expect(extractTriggerPath('workspace: {"source":"sentinel","path":"memory/handoffs/active.md"}')).toBe('memory/handoffs/active.md');
+  });
+});


### PR DESCRIPTION
## Problem
Constraint Texture analysis showed a large token waste source: routine workspace / heartbeat triggers can load a full OODA context and then decide there is no action to take. That burns the expensive path before Kuro has enough cheap evidence that a full cycle is warranted.

## Solution
Add a deterministic `ReactiveTriggerGate` before full context build for routine triggers:
- Workspace events use a path-keyed cooldown, so repeated sentinel/workspace noise skips the full OODA cycle.
- Heartbeat events run an idle lightweight probe before context build.
- The gate wakes immediately when cheap probes see real work:
  - pending inbox
  - pending high-priority tasks
  - pending delegation results
  - pending priority event
- Direct messages, alerts, cron, delegation completions, continuation, manual, and startup triggers bypass the gate.
- Idle heartbeat still gets periodic scout wakeups after cooldown so Kuro does not lose autonomous monitoring entirely.
- `/loop/status` now includes `ReactiveTriggerGate` metrics: skipped/woken/saved estimated context chars/last decision.

## Verification
Before rebase:
- `pnpm typecheck` passed
- `pnpm exec vitest run tests/reactive-trigger-gate.test.ts tests/loop.test.ts tests/event-bus.test.ts` -> 36 passed
- `pnpm build` passed
- `pnpm test` -> 82 test files passed, 667 passed, 2 skipped

After rebase onto latest `origin/main`:
- `pnpm typecheck` passed
- `pnpm exec vitest run tests/reactive-trigger-gate.test.ts tests/loop.test.ts` -> 23 passed
- `pnpm build` passed

## Notes
This intentionally gates only routine/noisy triggers. It does not suppress human-facing/direct-message paths or delegation-result absorption.