### PR TITLE
fix(loop): wire recordTaskTerminalSignal into kuro:done path (#196 #203)

### DIFF
--- a/src/loop.ts
+++ b/src/loop.ts
@@ -39,7 +39,7 @@ import {
   startThread, progressThread, completeThread, pauseThread,
 } from './temporal.js';
 import { hasP0Tasks, getPendingTaskPreviews, getP0TaskPreviews, markTaskDoneByDescription, getHighPriorityPendingCount, queryMemoryIndexSync, incrementTaskStaleness, healAbandonedGoals, scanPipelineVerify, getPipelineStuckAnalysis, cleanStaleEntries } from './memory-index.js';
-import { schedulerPick, advanceTick, schedulerTaskDone, getSchedulerState, getSchedulerStatus, entryToSnapshot, consumeNeedsPickNext, type IncomingEvent as SchedulerEvent } from './scheduler.js';
+import { schedulerPick, advanceTick, schedulerTaskDone, getSchedulerState, getSchedulerStatus, entryToSnapshot, consumeNeedsPickNext, recordTaskTerminalSignal, type IncomingEvent as SchedulerEvent } from './scheduler.js';
 import { registerProcess, transitionProcess, suspendProcess, resumeProcess, completeProcess, incrementTicks, getCurrentProcess, getProcessTableStatus, syncFromTasks, initProcessTable, persistProcessTable } from './process-table.js';
 import { saveSuspendCheckpoint, loadSuspendCheckpoint, clearSuspendCheckpoint } from './cycle-state.js';
 import { onSchedulerTick } from './reactive-policies.js';
@@ -3045,6 +3045,10 @@ export class AgentLoop {
               }
             }
             schedulerTaskDone(schedState.currentTaskId);
+            // issue #196/#203: record terminal signal so consecutive <kuro:done>
+            // on the same task triggers dispatch suppression (PR #202 export had
+            // 0 src/ callers — wiring it here is the intended integration point).
+            recordTaskTerminalSignal(schedState.currentTaskId);
             completeProcess(schedState.currentTaskId);
           }
           if (markedCount === 0) {


### PR DESCRIPTION
## Summary

Fixes the dead-code gap reported in #203: PR #202 added dispatch suppression
APIs to scheduler.ts but had **0 callers in src/**, so the suppression filter
in `schedulerPick` (line 332-337) was always checking against an empty set in
production. Issue #196's phantom re-dispatch bug therefore stayed live.

## What changed

`src/loop.ts` — wire `recordTaskTerminalSignal(currentTaskId)` immediately
after `schedulerTaskDone(currentTaskId)` in the `<kuro:done>` handler at
line ~3047. This is the integration point identified in #203.

**Skipped per #203 guidance:** loop.ts:2272 / 2287 (correction and
autonomy-closure auto-resolve). Those are normal flow that should not suppress
re-dispatch — only consecutive terminal signals on the *same task id from
`<kuro:done>`* should trigger suppression.

The reset path (line 3 of #203's recommendations) is intentionally **not**
included in this PR — picking the right reset trigger (room msg / file watcher
/ PR webhook) is design work, not a one-line wire-up. Filed as follow-up.

## Why I noticed

The current Kuro instance hit this bug live this cycle: the scheduler kept
re-dispatching a phantom "P0 autonomy closure: repair pr-review-consensus"
task after 6+ delegations all reported `status=healthy, score=100`. That's
exactly the failure mode #196 describes.

## Falsifier

From #203:
- After this lands, when a task hits `<kuro:done>` 3+ times consecutively,
  `tail server.log | grep dispatch-suppression` should show ≥1 entry.
- If 24 hours pass with 0 `dispatch-suppression` slog and tasks still
  re-dispatch → the integration point is wrong (some other dispatch source
  bypasses `schedulerPick`).

## Tests

- `pnpm vitest run tests/scheduler` → 42/42 pass
- `pnpm tsc --noEmit` → clean

## Test plan

- [ ] Merge and observe server.log for `dispatch-suppression` slog within
      next phantom-task scenario
- [ ] If 24hr silent → re-open with "integration point wrong" hypothesis
- [ ] Follow-up PR: wire reset path (candidates: roomMsg handler / PR webhook)

Closes #203. Partial fix for #196 (suppression now active; reset still TODO).

🤖 Generated with [Claude Code](https://claude.com/claude-code)