### PR TITLE
fix(scheduler): reset dispatch suppression on human events

### DIFF
--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -324,6 +324,8 @@ export function schedulerPick(
     status: ['pending', 'in_progress'],
   });
 
+  resetSuppressionsForExternalEvents(events);
+
   const tasks: TaskSnapshot[] = entries.map(entryToSnapshot)
     .filter(t => {
       const proc = getProcess(t.id);
@@ -438,6 +440,17 @@ export function resetAllSuppressions(): void {
     slog('SCHED', `suppression-reset-all cleared ${count} suppressed tasks`);
     eventBus.emit('action:scheduler', { event: 'suppression-reset-all', count });
   }
+}
+
+function resetSuppressionsForExternalEvents(events: IncomingEvent[]): void {
+  if (suppressedTaskIds.size === 0 && terminalSignalCount.size === 0) return;
+  const hasHumanDirectedEvent = events.some(event =>
+    event.isAlexDirectMessage
+    || event.priority === 0
+    || ['telegram', 'telegram-user', 'room', 'chat'].includes(event.source),
+  );
+  if (!hasHumanDirectedEvent) return;
+  resetAllSuppressions();
 }
 
 export function isTaskSuppressed(taskId: string): boolean {

--- a/tests/scheduler-dispatch-suppression.test.ts
+++ b/tests/scheduler-dispatch-suppression.test.ts
@@ -245,4 +245,44 @@ describe('schedulerPick — suppressed tasks excluded from dispatch', () => {
     expect(decision.taskId).toBe(active.id);
     expect(decision.taskId).not.toBe(suppressed.id);
   });
+
+  it('keeps suppression across routine scheduler events', async () => {
+    const task = await appendMemoryIndexEntry(tmpDir, {
+      type: 'task',
+      status: 'pending',
+      summary: 'P0 task suppressed by repeated terminal signals',
+      payload: { priority: 0 },
+    });
+    invalidateIndexCache();
+
+    for (let i = 0; i < DISPATCH_SUPPRESSION_THRESHOLD; i++) {
+      recordTaskTerminalSignal(task.id);
+    }
+
+    const decision = schedulerPick(tmpDir, [{ source: 'heartbeat', priority: 3, isAlexDirectMessage: false }]);
+
+    expect(isTaskSuppressed(task.id)).toBe(true);
+    expect(decision.taskId).not.toBe(task.id);
+  });
+
+  it('resets suppression on a human-directed scheduler event', async () => {
+    const task = await appendMemoryIndexEntry(tmpDir, {
+      type: 'task',
+      status: 'pending',
+      summary: 'P0 task revived by Alex message',
+      payload: { priority: 0 },
+    });
+    invalidateIndexCache();
+
+    for (let i = 0; i < DISPATCH_SUPPRESSION_THRESHOLD; i++) {
+      recordTaskTerminalSignal(task.id);
+    }
+    expect(isTaskSuppressed(task.id)).toBe(true);
+
+    const decision = schedulerPick(tmpDir, [{ source: 'room', priority: 0, isAlexDirectMessage: true }]);
+
+    expect(isTaskSuppressed(task.id)).toBe(false);
+    expect(getTerminalSignalCount(task.id)).toBe(0);
+    expect(decision.taskId).toBe(task.id);
+  });
 });


### PR DESCRIPTION
## Summary

Completes the reset side of #196's dispatch-suppression loop.

- Keep suppressed tasks suppressed across routine heartbeat/cron-style scheduler events.
- Reset suppression state only when the scheduler sees a human-directed event (`room`, `chat`, `telegram`, or `isAlexDirectMessage`).
- Add regression coverage for both routine-event persistence and human-event reset.

This avoids the broad reset-all behavior from superseded PR #207 while still giving Alex/new human input a way to revive previously suppressed work.

## Verification

- `pnpm exec vitest run tests/scheduler-dispatch-suppression.test.ts` -> 22 passed
- `pnpm typecheck` -> clean
- `pnpm build` -> clean

Partial/follow-up for #196: this covers human event reset. A future PR can add more precise task-id reset for PR webhook/state-change events if needed.