### PR TITLE
fix: accept middleware list envelopes

### DIFF
--- a/src/middleware-truth-reconciler.ts
+++ b/src/middleware-truth-reconciler.ts
@@ -160,14 +160,34 @@ export async function reconcileMiddlewareCommitmentsSafe(
 async function listMiddlewareCommitments(baseUrl: string, fetchImpl: typeof fetch): Promise<Commitment[]> {
   const res = await fetchImpl(`${baseUrl}/commits?status=active`);
   if (!res.ok) throw new Error(`GET /commits failed: HTTP ${res.status}`);
-  return await res.json() as Commitment[];
+  return parseCommitmentsResponse(await res.json());
 }
 
 async function listMiddlewareTasks(baseUrl: string, fetchImpl: typeof fetch): Promise<MiddlewareTaskSnapshot[]> {
   const res = await fetchImpl(`${baseUrl}/tasks?limit=200`);
   if (!res.ok) throw new Error(`GET /tasks failed: HTTP ${res.status}`);
-  const payload = await res.json() as { tasks?: MiddlewareTaskSnapshot[] } | MiddlewareTaskSnapshot[];
-  return Array.isArray(payload) ? payload : payload.tasks ?? [];
+  return parseTasksResponse(await res.json());
+}
+
+export function parseCommitmentsResponse(payload: unknown): Commitment[] {
+  if (Array.isArray(payload)) return payload as Commitment[];
+  if (payload && typeof payload === 'object') {
+    const record = payload as { items?: unknown; commitments?: unknown; commits?: unknown };
+    if (Array.isArray(record.items)) return record.items as Commitment[];
+    if (Array.isArray(record.commitments)) return record.commitments as Commitment[];
+    if (Array.isArray(record.commits)) return record.commits as Commitment[];
+  }
+  return [];
+}
+
+export function parseTasksResponse(payload: unknown): MiddlewareTaskSnapshot[] {
+  if (Array.isArray(payload)) return payload as MiddlewareTaskSnapshot[];
+  if (payload && typeof payload === 'object') {
+    const record = payload as { items?: unknown; tasks?: unknown };
+    if (Array.isArray(record.items)) return record.items as MiddlewareTaskSnapshot[];
+    if (Array.isArray(record.tasks)) return record.tasks as MiddlewareTaskSnapshot[];
+  }
+  return [];
 }
 
 async function patchCommitment(

--- a/tests/middleware-truth-reconciler.test.ts
+++ b/tests/middleware-truth-reconciler.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
   canonicalMiddlewareCommitmentKey,
+  parseCommitmentsResponse,
+  parseTasksResponse,
   planMiddlewareCommitmentTruthActions,
   reconcileMiddlewareCommitmentsSafe,
 } from '../src/middleware-truth-reconciler.js';
@@ -95,12 +97,15 @@ describe('middleware truth reconciler', () => {
   it('patches planned reconciliation actions through middleware status updates', async () => {
     const fetchImpl = vi.fn(async (url: string, init?: RequestInit) => {
       if (url.endsWith('/tasks?limit=200')) {
-        return new Response(JSON.stringify({ tasks: [{ id: 'task-completed', status: 'completed' }] }), { status: 200 });
+        return new Response(JSON.stringify({ count: 1, items: [{ id: 'task-completed', status: 'completed' }] }), { status: 200 });
       }
       if (url.endsWith('/commits?status=active')) {
-        return new Response(JSON.stringify([
-          commitment({ id: 'cmt/completed', linked_task_id: 'task-completed' }),
-        ]), { status: 200 });
+        return new Response(JSON.stringify({
+          count: 1,
+          items: [
+            commitment({ id: 'cmt/completed', linked_task_id: 'task-completed' }),
+          ],
+        }), { status: 200 });
       }
       if (url.endsWith('/commit/cmt%2Fcompleted') && init?.method === 'PATCH') {
         expect(JSON.parse(String(init.body))).toMatchObject({
@@ -116,5 +121,17 @@ describe('middleware truth reconciler', () => {
       baseUrl: 'http://middleware.test',
       fetchImpl,
     })).resolves.toEqual({ planned: 1, applied: 1, skipped: 0 });
+  });
+
+  it('accepts middleware list envelopes from current and legacy endpoints', () => {
+    const c = commitment({ id: 'cmt-current' });
+    expect(parseCommitmentsResponse({ count: 1, items: [c] })).toEqual([c]);
+    expect(parseCommitmentsResponse({ commitments: [c] })).toEqual([c]);
+    expect(parseCommitmentsResponse([c])).toEqual([c]);
+
+    const task = { id: 'task-current', status: 'completed' as const };
+    expect(parseTasksResponse({ count: 1, items: [task] })).toEqual([task]);
+    expect(parseTasksResponse({ tasks: [task] })).toEqual([task]);
+    expect(parseTasksResponse([task])).toEqual([task]);
   });
 });


### PR DESCRIPTION
## Summary
- Accept current middleware list envelopes (`{ count, items }`) in the middleware truth reconciler.
- Keep compatibility with legacy array, `{ commitments }`, `{ commits }`, and `{ tasks }` response shapes.
- Add regression coverage for the live middleware schema.

## Verification
- `pnpm exec vitest run tests/middleware-truth-reconciler.test.ts`
- `pnpm typecheck`
- `pnpm build`