### PR TITLE
fix: rotate decision logs

### DIFF
--- a/src/decision-log-rotation.ts
+++ b/src/decision-log-rotation.ts
@@ -1,0 +1,167 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { gzipSync } from 'node:zlib';
+import { getMemoryRootDir } from './memory-paths.js';
+
+export interface DecisionLogRotationOptions {
+  memoryDir?: string;
+  maxBytes?: number;
+  archiveDir?: string;
+  now?: Date;
+  compress?: boolean;
+  files?: string[];
+}
+
+export interface DecisionLogRotationResult {
+  file: string;
+  beforeBytes: number;
+  afterBytes: number;
+  archivedBytes: number;
+  archivedLines: number;
+  keptLines: number;
+  archives: string[];
+  skipped: boolean;
+}
+
+const DEFAULT_MAX_BYTES = 1024 * 1024;
+const DEFAULT_DECISION_LOGS = [
+  'myelin-decisions.jsonl',
+  'myelin-learning-decisions.jsonl',
+  'myelin-routing-decisions.jsonl',
+  'myelin-workflow-decisions.jsonl',
+  'research-decisions.jsonl',
+  path.join('state', 'decision-provenance.jsonl'),
+];
+
+export function getDecisionLogFiles(): string[] {
+  return [...DEFAULT_DECISION_LOGS];
+}
+
+export function rotateDecisionLogs(options: DecisionLogRotationOptions = {}): DecisionLogRotationResult[] {
+  const memoryDir = options.memoryDir ?? getMemoryRootDir();
+  const maxBytes = options.maxBytes ?? Number(process.env.MINI_AGENT_DECISION_LOG_MAX_BYTES ?? DEFAULT_MAX_BYTES);
+  const archiveDir = options.archiveDir ?? path.join(memoryDir, 'decisions-archive');
+  const files = options.files ?? DEFAULT_DECISION_LOGS;
+  const now = options.now ?? new Date();
+  const compress = options.compress ?? true;
+
+  return files.map(file => rotateOneDecisionLog({
+    file,
+    memoryDir,
+    maxBytes,
+    archiveDir,
+    now,
+    compress,
+  }));
+}
+
+function rotateOneDecisionLog(options: Required<Omit<DecisionLogRotationOptions, 'files'>> & { file: string }): DecisionLogRotationResult {
+  const filePath = path.resolve(options.memoryDir, options.file);
+  if (!fs.existsSync(filePath)) {
+    return emptyResult(options.file, 0, true);
+  }
+
+  const beforeBytes = fs.statSync(filePath).size;
+  if (beforeBytes <= options.maxBytes) {
+    return emptyResult(options.file, beforeBytes, true);
+  }
+
+  const lines = fs.readFileSync(filePath, 'utf-8').split('\n').filter(Boolean);
+  const { keep, archiveChunks } = splitForRotation(lines, options.maxBytes);
+  if (archiveChunks.length === 0) {
+    return emptyResult(options.file, beforeBytes, true);
+  }
+
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.mkdirSync(options.archiveDir, { recursive: true });
+
+  const stamp = timestampStamp(options.now);
+  const stem = path.basename(options.file, '.jsonl');
+  const archives: string[] = [];
+  let archivedBytes = 0;
+  let archivedLines = 0;
+
+  archiveChunks.forEach((chunk, index) => {
+    const plain = chunk.join('\n') + '\n';
+    const suffix = `${stamp}-part${String(index + 1).padStart(2, '0')}.jsonl`;
+    const archivePath = path.join(options.archiveDir, `${stem}-${suffix}${options.compress ? '.gz' : ''}`);
+    if (options.compress) {
+      fs.writeFileSync(archivePath, gzipSync(plain), { flag: 'wx' });
+    } else {
+      fs.writeFileSync(archivePath, plain, { flag: 'wx' });
+    }
+    archives.push(archivePath);
+    archivedBytes += Buffer.byteLength(plain);
+    archivedLines += chunk.length;
+  });
+
+  const active = keep.length > 0 ? keep.join('\n') + '\n' : '';
+  const tmpPath = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+  fs.writeFileSync(tmpPath, active, 'utf-8');
+  fs.renameSync(tmpPath, filePath);
+
+  return {
+    file: options.file,
+    beforeBytes,
+    afterBytes: fs.statSync(filePath).size,
+    archivedBytes,
+    archivedLines,
+    keptLines: keep.length,
+    archives,
+    skipped: false,
+  };
+}
+
+function splitForRotation(lines: string[], maxBytes: number): { keep: string[]; archiveChunks: string[][] } {
+  const keep: string[] = [];
+  let keepBytes = 0;
+
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const lineBytes = Buffer.byteLength(lines[i]) + 1;
+    if (keep.length > 0 && keepBytes + lineBytes > maxBytes) break;
+    if (lineBytes > maxBytes && keep.length === 0) {
+      keep.unshift(lines[i]);
+      keepBytes += lineBytes;
+      continue;
+    }
+    keep.unshift(lines[i]);
+    keepBytes += lineBytes;
+  }
+
+  const archiveLineCount = Math.max(0, lines.length - keep.length);
+  const archiveLines = lines.slice(0, archiveLineCount);
+  const archiveChunks: string[][] = [];
+  let chunk: string[] = [];
+  let chunkBytes = 0;
+
+  for (const line of archiveLines) {
+    const lineBytes = Buffer.byteLength(line) + 1;
+    if (chunk.length > 0 && chunkBytes + lineBytes > maxBytes) {
+      archiveChunks.push(chunk);
+      chunk = [];
+      chunkBytes = 0;
+    }
+    chunk.push(line);
+    chunkBytes += lineBytes;
+  }
+  if (chunk.length > 0) archiveChunks.push(chunk);
+
+  return { keep, archiveChunks };
+}
+
+function emptyResult(file: string, bytes: number, skipped: boolean): DecisionLogRotationResult {
+  return {
+    file,
+    beforeBytes: bytes,
+    afterBytes: bytes,
+    archivedBytes: 0,
+    archivedLines: 0,
+    keptLines: 0,
+    archives: [],
+    skipped,
+  };
+}
+
+function timestampStamp(date: Date): string {
+  return date.toISOString().replace(/[-:]/g, '').replace(/\.\d{3}Z$/, 'Z');
+}

--- a/src/housekeeping.ts
+++ b/src/housekeeping.ts
@@ -26,6 +26,7 @@ import { scanContradictions } from './contradiction-scanner.js';
 import { shouldTriggerKGIngest, markKGIngestTriggered, pushToKGService } from './kg-live-ingest.js';
 import { spawnDelegation } from './delegation.js';
 import { reconcileMiddlewareCommitmentsSafe } from './middleware-truth-reconciler.js';
+import { rotateDecisionLogs } from './decision-log-rotation.js';
 import type { MemoryIndexEntry } from './memory-index.js';
 import type { InboxItem, ParsedTags } from './types.js';
 
@@ -723,6 +724,15 @@ export async function runHousekeeping(): Promise<void> {
 
   // 低頻：每 10 cycle 掃描 instance 目錄下的過期臨時資源
   if (cycleCounter % 10 === 0) {
+    try {
+      const rotated = rotateDecisionLogs().filter(result => !result.skipped);
+      if (rotated.length > 0) {
+        const archived = rotated.reduce((sum, result) => sum + result.archivedLines, 0);
+        slog('HOUSEKEEPING', `decision-log rotation: ${rotated.length} file(s), ${archived} archived line(s)`);
+      }
+    } catch (err) {
+      slog('HOUSEKEEPING', `decision-log rotation skipped: ${err instanceof Error ? err.message : String(err)}`);
+    }
     await sweepInstanceDir().catch(() => {});
     // P1-5: Memory consolidation — migrate old entries to cold storage
     await consolidateMemory().catch(() => {});

--- a/tests/decision-log-rotation.test.ts
+++ b/tests/decision-log-rotation.test.ts
@@ -1,0 +1,71 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { gunzipSync } from 'node:zlib';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { rotateDecisionLogs } from '../src/decision-log-rotation.js';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mini-agent-decision-rotation-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('rotateDecisionLogs', () => {
+  it('archives old JSONL entries in compressed chunks and keeps the active file under the cap', () => {
+    const file = 'myelin-decisions.jsonl';
+    writeLines(file, Array.from({ length: 20 }, (_, i) => ({
+      _type: 'decision',
+      ts: `2026-05-07T00:${String(i).padStart(2, '0')}:00.000Z`,
+      action: `action-${i}`,
+      reason: 'x'.repeat(40),
+    })));
+
+    const [result] = rotateDecisionLogs({
+      memoryDir: tmpDir,
+      files: [file],
+      maxBytes: 500,
+      now: new Date('2026-05-07T01:02:03.000Z'),
+    });
+
+    expect(result.skipped).toBe(false);
+    expect(result.archives.length).toBeGreaterThan(0);
+    expect(result.archivedLines + result.keptLines).toBe(20);
+
+    const activePath = path.join(tmpDir, file);
+    expect(fs.statSync(activePath).size).toBeLessThanOrEqual(500);
+    const activeLines = fs.readFileSync(activePath, 'utf-8').trim().split('\n');
+    expect(activeLines.at(-1)).toContain('action-19');
+
+    const archivedText = result.archives
+      .map(archive => gunzipSync(fs.readFileSync(archive)).toString('utf-8'))
+      .join('');
+    expect(archivedText).toContain('action-0');
+    expect(result.archives[0]).toContain('myelin-decisions-20260507T010203Z-part01.jsonl.gz');
+  });
+
+  it('skips files already below the cap', () => {
+    writeLines('research-decisions.jsonl', [
+      { _type: 'decision', ts: '2026-05-07T00:00:00.000Z', action: 'normal' },
+    ]);
+
+    const [result] = rotateDecisionLogs({
+      memoryDir: tmpDir,
+      files: ['research-decisions.jsonl'],
+      maxBytes: 10_000,
+    });
+
+    expect(result.skipped).toBe(true);
+    expect(result.archives).toEqual([]);
+  });
+});
+
+function writeLines(file: string, records: unknown[]): void {
+  const filePath = path.join(tmpDir, file);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, records.map(record => JSON.stringify(record)).join('\n') + '\n', 'utf-8');
+}


### PR DESCRIPTION
## Summary
- Add size-based JSONL decision log rotation for myelin and decision-provenance logs.
- Archive old records into gzip chunks under `decisions-archive/` while keeping active logs under the configured cap.
- Run rotation from housekeeping every 10 cycles.

Closes #200.

## Verification
- `pnpm exec vitest run tests/decision-log-rotation.test.ts tests/myelin-status.test.ts`
- `pnpm typecheck`
- `pnpm build`