### PR TITLE
fix: close PR lifecycle gaps

### DIFF
--- a/src/autonomy-closure-health.ts
+++ b/src/autonomy-closure-health.ts
@@ -6,6 +6,7 @@ import { evaluatePrReviewConsensus, parsePrReviewHandoffs, readPrReviewClaimsSyn
 import { evaluateRuntimeMemoryPlacement } from './memory-paths.js';
 import { eventBus } from './event-bus.js';
 import { readTestHealthSnapshot, summarizeTestHealth } from './test-health-autopilot.js';
+import { evaluatePrClosureGaps } from './pr-autopilot.js';
 
 export type AutonomyClosureStage =
   | 'runtime-workspace'
@@ -322,16 +323,8 @@ function prReviewConsensusStage(memoryDir: string): AutonomyClosureStageResult {
   }
 
   const activeContent = readFileSync(activePath, 'utf-8');
+  const openPrGaps = evaluatePrClosureGaps(memoryDir, activeContent);
   const handoffs = parsePrReviewHandoffs(activeContent);
-  if (handoffs.length === 0) {
-    return {
-      stage: 'pr-review-consensus',
-      status: 'ok',
-      summary: 'no pending PR review handoffs',
-      evidence: [],
-    };
-  }
-
   const claims = readPrReviewClaimsSync(memoryDir);
   const consensuses = evaluatePrReviewConsensus(handoffs, claims);
   const missing = consensuses.filter(c => c.status === 'pending' && c.missingReviewers.length > 0);
@@ -352,6 +345,34 @@ function prReviewConsensusStage(memoryDir: string): AutonomyClosureStageResult {
       summary: `${missing.length} PR(s) still missing internal review claims`,
       evidence: missing.slice(0, 5).map(c => `PR #${c.prNumber}: missing ${c.missingReviewers.join(', ')}`),
       repair: 'Run GitHub automation to produce internal review claims and consensus.',
+    };
+  }
+  if (
+    openPrGaps.snapshotMissing
+    || openPrGaps.snapshotStale
+    || openPrGaps.readyUntracked.length > 0
+    || openPrGaps.staleDrafts.length > 0
+  ) {
+    const evidence: string[] = [];
+    if (openPrGaps.snapshotMissing) evidence.push('open PR snapshot missing');
+    if (openPrGaps.snapshotStale) evidence.push(`open PR snapshot stale: generatedAt=${openPrGaps.snapshotGeneratedAt ?? 'unknown'}`);
+    evidence.push(...openPrGaps.readyUntracked.slice(0, 5).map(pr => `PR #${pr.number}: ready but not tracked for review (${pr.title})`));
+    evidence.push(...openPrGaps.staleDrafts.slice(0, 5).map(pr => `PR #${pr.number}: stale draft needs triage (${pr.title})`));
+
+    return {
+      stage: 'pr-review-consensus',
+      status: 'warn',
+      summary: 'open PR lifecycle has unclosed tracking gaps',
+      evidence,
+      repair: 'Run GitHub automation to refresh open-prs.json, queue PR review handoffs, and triage stale drafts.',
+    };
+  }
+  if (handoffs.length === 0) {
+    return {
+      stage: 'pr-review-consensus',
+      status: 'ok',
+      summary: 'no pending PR review handoffs and open PR snapshot is current',
+      evidence: [`snapshot=${openPrGaps.snapshotGeneratedAt ?? 'current'}`],
     };
   }
   return {

--- a/src/github.ts
+++ b/src/github.ts
@@ -28,7 +28,6 @@ import {
   decidePrReviewAssignment,
   decidePrConflictAction,
   type MergedPullRequestSummary,
-  type OpenPullRequestSummary,
 } from './pr-lifecycle-governance.js';
 import {
   appendMissingInternalPrReviewClaims,
@@ -38,6 +37,15 @@ import {
   reconcilePrReviewHandoffs,
   runPrReviewConsensus,
 } from './pr-review-runner.js';
+import {
+  appendStaleDraftPrHandoffs,
+  extractClosingIssueRefs,
+  findUntrackedPrs,
+  shouldAutoCloseSupersededPr,
+  writeOpenPrSnapshot,
+  type IssueStateSummary,
+  type OpenPrSnapshotEntry,
+} from './pr-autopilot.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -296,8 +304,12 @@ interface ReviewablePR {
   body?: string | null;
   isDraft?: boolean;
   reviewDecision?: string;
+  reviewRequests?: unknown[];
   labels?: Array<{ name: string }>;
   url?: string;
+  createdAt?: string;
+  updatedAt?: string;
+  headRefName?: string;
 }
 
 export async function autoTrackPrReviewNeeds(): Promise<void> {
@@ -306,8 +318,9 @@ export async function autoTrackPrReviewNeeds(): Promise<void> {
 
   let prs: ReviewablePR[];
   try {
-    const { stdout } = await gh(['pr', 'list', '--state', 'open', '--json', 'number,title,body,isDraft,reviewDecision,labels,url', '--limit', '50']);
+    const { stdout } = await gh(['pr', 'list', '--state', 'open', '--json', 'number,title,body,isDraft,reviewDecision,reviewRequests,labels,url,createdAt,updatedAt,headRefName', '--limit', '50']);
     prs = JSON.parse(stdout);
+    writeOpenPrSnapshot(getMemoryRootDir(), prs.map(toOpenPrSummary));
   } catch {
     return;
   }
@@ -323,6 +336,8 @@ export async function autoTrackPrReviewNeeds(): Promise<void> {
   const newRows: string[] = [];
   const assignments: Array<{ prNumber: number; reviewers: Array<'akari' | 'codex' | 'claude-code' | 'alex'> }> = [];
   let inboxCount = 0;
+  const normalizedPrs = prs.map(toOpenPrSummary);
+  const { staleDrafts } = findUntrackedPrs(normalizedPrs, activeContent);
 
   for (const pr of prs) {
     const decision = decidePrReviewAssignment(toOpenPrSummary(pr));
@@ -361,23 +376,75 @@ export async function autoTrackPrReviewNeeds(): Promise<void> {
   if (newRows.length > 0) {
     nextActiveContent = activeContent.trimEnd() + '\n' + newRows.join('\n') + '\n';
   }
+  const draftHandoffs = appendStaleDraftPrHandoffs(nextActiveContent, staleDrafts, today);
+  nextActiveContent = draftHandoffs.content;
   nextActiveContent = reconcilePrReviewHandoffs(nextActiveContent, assignments);
   if (nextActiveContent !== activeContent) fs.writeFileSync(activePath, nextActiveContent, 'utf-8');
-  if (newRows.length > 0 || inboxCount > 0) {
-    slog('github', `tracked ${newRows.length} PR review handoff(s), ${inboxCount} inbox item(s)`);
+  if (newRows.length > 0 || draftHandoffs.appended > 0 || inboxCount > 0) {
+    slog('github', `tracked ${newRows.length} PR review handoff(s), ${draftHandoffs.appended} draft triage handoff(s), ${inboxCount} inbox item(s)`);
   }
 }
 
-function toOpenPrSummary(pr: ReviewablePR): OpenPullRequestSummary {
+function toOpenPrSummary(pr: ReviewablePR): OpenPrSnapshotEntry {
   return {
     number: pr.number,
     title: pr.title,
     body: pr.body,
     reviewDecision: pr.reviewDecision,
-    reviewRequests: [],
+    reviewRequests: Array.isArray(pr.reviewRequests) ? pr.reviewRequests : [],
     labels: pr.labels?.map(l => l.name),
     isDraft: pr.isDraft,
+    url: pr.url,
+    createdAt: pr.createdAt,
+    updatedAt: pr.updatedAt,
+    headRefName: pr.headRefName,
   };
+}
+
+interface SupersedablePR extends ReviewablePR {
+  labels?: Array<{ name: string }>;
+}
+
+async function autoCloseSupersededPRs(): Promise<void> {
+  let prs: SupersedablePR[];
+  try {
+    const { stdout } = await gh(['pr', 'list', '--state', 'open', '--json', 'number,title,body,isDraft,labels,url,createdAt', '--limit', '50']);
+    prs = JSON.parse(stdout);
+  } catch {
+    return;
+  }
+
+  let closedCount = 0;
+  for (const pr of prs) {
+    const normalized = toOpenPrSummary(pr);
+    const refs = extractClosingIssueRefs(`${pr.title}\n${pr.body ?? ''}`);
+    if (refs.length === 0) continue;
+
+    const issues: IssueStateSummary[] = [];
+    let issueLookupFailed = false;
+    for (const ref of refs) {
+      try {
+        const { stdout } = await gh(['issue', 'view', String(ref), '--json', 'number,state,closedAt']);
+        issues.push(JSON.parse(stdout));
+      } catch {
+        issueLookupFailed = true;
+        break;
+      }
+    }
+    if (issueLookupFailed) continue;
+    if (!shouldAutoCloseSupersededPr(normalized, refs, issues)) continue;
+
+    const reason = `This PR declares ${refs.map(ref => `#${ref}`).join(', ')} as closing scope, and that issue is already closed. Closing to keep the autonomous PR queue truthful; reopen or create a fresh PR if this still has unique scope.`;
+    try {
+      await gh(['pr', 'close', String(pr.number), '--comment', reason]);
+      closedCount++;
+      slog('github', `closed superseded PR #${pr.number}: ${pr.title}`);
+    } catch {
+      // Per-PR failure should not block the rest of the GitHub autopilot.
+    }
+  }
+
+  if (closedCount > 0) slog('github', `closed ${closedCount} superseded PR(s)`);
 }
 
 function escapeTable(text: string): string {
@@ -875,6 +942,7 @@ export async function githubAutoActions(): Promise<void> {
 
   await autoCreateIssueFromProposal().catch(() => {});
   await autoCloseCompletedIssues().catch(() => {});
+  await autoCloseSupersededPRs().catch(() => {});
   await autoTrackPrReviewNeeds().catch(() => {});
   await autoProduceInternalPrReviewClaims().catch(() => {});
   await autoTrackPrReviewConsensus().catch(() => {});

--- a/src/pr-autopilot.ts
+++ b/src/pr-autopilot.ts
@@ -1,0 +1,213 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { decidePrReviewAssignment, type OpenPullRequestSummary } from './pr-lifecycle-governance.js';
+
+export const OPEN_PRS_SNAPSHOT_FILE = 'open-prs.json';
+export const DEFAULT_DRAFT_TTL_HOURS = 2;
+export const DEFAULT_SNAPSHOT_TTL_HOURS = 2;
+
+export interface OpenPrSnapshotEntry extends OpenPullRequestSummary {
+  url?: string;
+  createdAt?: string | null;
+  updatedAt?: string | null;
+  headRefName?: string | null;
+}
+
+export interface OpenPrSnapshot {
+  generatedAt: string;
+  prs: OpenPrSnapshotEntry[];
+}
+
+export interface PrClosureGaps {
+  snapshotMissing: boolean;
+  snapshotStale: boolean;
+  snapshotGeneratedAt?: string;
+  readyUntracked: OpenPrSnapshotEntry[];
+  staleDrafts: OpenPrSnapshotEntry[];
+}
+
+export interface IssueStateSummary {
+  number: number;
+  state: string;
+  closedAt?: string | null;
+}
+
+const CLOSING_REF_RE = /(?:^|[\s(])(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)\b/gi;
+
+export function getOpenPrSnapshotPath(memoryDir: string): string {
+  return path.join(memoryDir, 'state', OPEN_PRS_SNAPSHOT_FILE);
+}
+
+export function writeOpenPrSnapshot(memoryDir: string, prs: OpenPrSnapshotEntry[], now = new Date()): OpenPrSnapshot {
+  const snapshot = {
+    generatedAt: now.toISOString(),
+    prs: prs.map(normalizePrSnapshotEntry),
+  };
+  const snapshotPath = getOpenPrSnapshotPath(memoryDir);
+  fs.mkdirSync(path.dirname(snapshotPath), { recursive: true });
+  fs.writeFileSync(snapshotPath, JSON.stringify(snapshot, null, 2) + '\n', 'utf-8');
+  return snapshot;
+}
+
+export function readOpenPrSnapshot(memoryDir: string): OpenPrSnapshot | null {
+  const snapshotPath = getOpenPrSnapshotPath(memoryDir);
+  if (!fs.existsSync(snapshotPath)) return null;
+  try {
+    const parsed = JSON.parse(fs.readFileSync(snapshotPath, 'utf-8')) as OpenPrSnapshot;
+    if (!Array.isArray(parsed.prs)) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function evaluatePrClosureGaps(
+  memoryDir: string,
+  activeContent: string,
+  now = new Date(),
+  options: { draftTtlHours?: number; snapshotTtlHours?: number } = {},
+): PrClosureGaps {
+  const snapshot = readOpenPrSnapshot(memoryDir);
+  if (!snapshot) {
+    return {
+      snapshotMissing: true,
+      snapshotStale: false,
+      readyUntracked: [],
+      staleDrafts: [],
+    };
+  }
+
+  const snapshotTtlHours = options.snapshotTtlHours ?? DEFAULT_SNAPSHOT_TTL_HOURS;
+  const generatedAtMs = Date.parse(snapshot.generatedAt);
+  const snapshotStale = !Number.isFinite(generatedAtMs)
+    || (now.getTime() - generatedAtMs) >= snapshotTtlHours * 60 * 60 * 1000;
+
+  const gaps = findUntrackedPrs(snapshot.prs, activeContent, now, options);
+  return {
+    snapshotMissing: false,
+    snapshotStale,
+    snapshotGeneratedAt: snapshot.generatedAt,
+    ...gaps,
+  };
+}
+
+export function findUntrackedPrs(
+  prs: OpenPrSnapshotEntry[],
+  activeContent: string,
+  now = new Date(),
+  options: { draftTtlHours?: number } = {},
+): Pick<PrClosureGaps, 'readyUntracked' | 'staleDrafts'> {
+  const tracked = parseTrackedPrNumbers(activeContent);
+  const draftTtlHours = options.draftTtlHours ?? getDraftTtlHours();
+  const readyUntracked: OpenPrSnapshotEntry[] = [];
+  const staleDrafts: OpenPrSnapshotEntry[] = [];
+
+  for (const pr of prs) {
+    if (tracked.has(pr.number)) continue;
+    const labels = new Set((pr.labels ?? []).map(label => label.toLowerCase()));
+    if (labels.has('hold')) continue;
+
+    const decision = decidePrReviewAssignment(pr);
+    if (decision.needsAssignment) {
+      readyUntracked.push(pr);
+      continue;
+    }
+
+    if (pr.isDraft && ageHours(pr.createdAt, now) >= draftTtlHours) {
+      staleDrafts.push(pr);
+    }
+  }
+
+  return { readyUntracked, staleDrafts };
+}
+
+export function appendStaleDraftPrHandoffs(
+  activeContent: string,
+  prs: OpenPrSnapshotEntry[],
+  today: string,
+): { content: string; appended: number } {
+  let content = activeContent.trimEnd();
+  let appended = 0;
+  const existing = parseTrackedPrNumbers(activeContent);
+
+  for (const pr of prs) {
+    if (existing.has(pr.number) || content.includes(`PR #${pr.number}`)) continue;
+    content += `\n| github | kuro | PR #${pr.number} draft triage: ${escapeTable(pr.title)} | needs-triage | ${today} | - |`;
+    appended++;
+  }
+
+  return {
+    content: appended > 0 ? content + '\n' : activeContent,
+    appended,
+  };
+}
+
+export function parseTrackedPrNumbers(activeContent: string): Set<number> {
+  const tracked = new Set<number>();
+  for (const line of activeContent.split('\n')) {
+    if (!line.trim().startsWith('|')) continue;
+    const match = line.match(/\bPR #(\d+)\b/);
+    if (match) tracked.add(Number(match[1]));
+  }
+  return tracked;
+}
+
+export function extractClosingIssueRefs(text: string): number[] {
+  const refs = new Set<number>();
+  let match: RegExpExecArray | null;
+  while ((match = CLOSING_REF_RE.exec(text)) !== null) refs.add(Number(match[1]));
+  return [...refs].sort((a, b) => a - b);
+}
+
+export function shouldAutoCloseSupersededPr(
+  pr: Pick<OpenPrSnapshotEntry, 'createdAt' | 'isDraft' | 'labels'>,
+  closingRefs: number[],
+  issues: IssueStateSummary[],
+): boolean {
+  if (pr.isDraft) return false;
+  const labels = new Set((pr.labels ?? []).map(label => label.toLowerCase()));
+  if (labels.has('hold')) return false;
+  if (closingRefs.length === 0 || issues.length !== closingRefs.length) return false;
+
+  const prCreatedAt = Date.parse(pr.createdAt ?? '');
+  if (!Number.isFinite(prCreatedAt)) return false;
+
+  return issues.every(issue => {
+    if (issue.state.toUpperCase() !== 'CLOSED') return false;
+    const closedAt = Date.parse(issue.closedAt ?? '');
+    return Number.isFinite(closedAt) && closedAt >= prCreatedAt;
+  });
+}
+
+export function getDraftTtlHours(): number {
+  const raw = process.env.MINI_AGENT_PR_DRAFT_TTL_HOURS;
+  const parsed = raw ? Number(raw) : DEFAULT_DRAFT_TTL_HOURS;
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_DRAFT_TTL_HOURS;
+}
+
+function normalizePrSnapshotEntry(pr: OpenPrSnapshotEntry): OpenPrSnapshotEntry {
+  return {
+    number: pr.number,
+    title: pr.title,
+    body: pr.body ?? null,
+    authorLogin: pr.authorLogin ?? null,
+    labels: pr.labels ?? [],
+    isDraft: Boolean(pr.isDraft),
+    reviewDecision: pr.reviewDecision ?? null,
+    reviewRequests: Array.isArray(pr.reviewRequests) ? pr.reviewRequests : [],
+    url: pr.url,
+    createdAt: pr.createdAt ?? null,
+    updatedAt: pr.updatedAt ?? null,
+    headRefName: pr.headRefName ?? null,
+  };
+}
+
+function ageHours(iso: string | null | undefined, now: Date): number {
+  const then = Date.parse(iso ?? '');
+  if (!Number.isFinite(then)) return 0;
+  return (now.getTime() - then) / (60 * 60 * 1000);
+}
+
+function escapeTable(text: string): string {
+  return text.replace(/\|/g, '/').replace(/\s+/g, ' ').trim();
+}

--- a/tests/pr-autopilot.test.ts
+++ b/tests/pr-autopilot.test.ts
@@ -1,0 +1,101 @@
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  appendStaleDraftPrHandoffs,
+  evaluatePrClosureGaps,
+  extractClosingIssueRefs,
+  findUntrackedPrs,
+  parseTrackedPrNumbers,
+  shouldAutoCloseSupersededPr,
+  writeOpenPrSnapshot,
+  type OpenPrSnapshotEntry,
+} from '../src/pr-autopilot.js';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(path.join(os.tmpdir(), 'mini-agent-pr-autopilot-'));
+  mkdirSync(path.join(tmpDir, 'state'), { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+const activeMd = [
+  '# Active Handoffs',
+  '',
+  '| From | To | Task | Status | Created | Done |',
+  '|------|----|------|--------|---------|------|',
+  '| github | codex | PR #10 fix: already tracked | needs-review | 05-07 | - |',
+].join('\n') + '\n';
+
+function pr(input: Partial<OpenPrSnapshotEntry> & Pick<OpenPrSnapshotEntry, 'number' | 'title'>): OpenPrSnapshotEntry {
+  return {
+    body: '',
+    labels: [],
+    isDraft: false,
+    reviewDecision: null,
+    reviewRequests: [],
+    createdAt: '2026-05-07T00:00:00.000Z',
+    updatedAt: '2026-05-07T00:00:00.000Z',
+    ...input,
+  };
+}
+
+describe('PR autopilot closure', () => {
+  it('detects ready untracked PRs and stale drafts', () => {
+    const now = new Date('2026-05-07T04:00:00.000Z');
+    const gaps = findUntrackedPrs([
+      pr({ number: 10, title: 'fix: already tracked' }),
+      pr({ number: 11, title: 'fix: needs review' }),
+      pr({ number: 12, title: 'fix: fresh draft', isDraft: true, createdAt: '2026-05-07T03:00:00.000Z' }),
+      pr({ number: 13, title: 'fix: stale draft', isDraft: true, createdAt: '2026-05-07T00:30:00.000Z' }),
+      pr({ number: 14, title: 'fix: hold', labels: ['hold'] }),
+    ], activeMd, now, { draftTtlHours: 2 });
+
+    expect(gaps.readyUntracked.map(item => item.number)).toEqual([11]);
+    expect(gaps.staleDrafts.map(item => item.number)).toEqual([13]);
+  });
+
+  it('appends stale draft triage handoffs once', () => {
+    const result = appendStaleDraftPrHandoffs(activeMd, [
+      pr({ number: 13, title: 'fix: stale draft | needs table escape', isDraft: true }),
+      pr({ number: 10, title: 'fix: already tracked', isDraft: true }),
+    ], '05-07');
+
+    expect(result.appended).toBe(1);
+    expect(result.content).toContain('| github | kuro | PR #13 draft triage: fix: stale draft / needs table escape | needs-triage | 05-07 | - |');
+    expect(parseTrackedPrNumbers(result.content).has(13)).toBe(true);
+  });
+
+  it('makes autonomy closure depend on the open PR snapshot', () => {
+    writeOpenPrSnapshot(tmpDir, [pr({ number: 11, title: 'fix: needs review' })], new Date('2026-05-07T03:30:00.000Z'));
+
+    const gaps = evaluatePrClosureGaps(tmpDir, activeMd, new Date('2026-05-07T04:00:00.000Z'));
+
+    expect(gaps.snapshotMissing).toBe(false);
+    expect(gaps.snapshotStale).toBe(false);
+    expect(gaps.readyUntracked.map(item => item.number)).toEqual([11]);
+  });
+
+  it('extracts only closing issue refs for superseded PR closure', () => {
+    expect(extractClosingIssueRefs('Refs #196\nCloses #200\nfixes #201\nrelated #202')).toEqual([200, 201]);
+  });
+
+  it('auto-closes only low-risk superseded PRs', () => {
+    expect(shouldAutoCloseSupersededPr(
+      pr({ number: 217, title: 'feat: old fix', createdAt: '2026-05-07T02:24:00.000Z' }),
+      [200],
+      [{ number: 200, state: 'CLOSED', closedAt: '2026-05-07T02:27:00.000Z' }],
+    )).toBe(true);
+
+    expect(shouldAutoCloseSupersededPr(
+      pr({ number: 218, title: 'feat: active fix', createdAt: '2026-05-07T02:24:00.000Z' }),
+      [200],
+      [{ number: 200, state: 'OPEN', closedAt: null }],
+    )).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add an open PR snapshot as file truth so autonomy closure can detect untracked GitHub PRs
- route ready PRs into review handoffs and stale draft PRs into triage handoffs
- conservatively close superseded PRs whose explicit closing issue is already closed

## Verification
- `pnpm typecheck`
- `pnpm exec vitest run tests/pr-autopilot.test.ts`
- `pnpm test`
- `pnpm build`