### PR TITLE
fix: keep PR tracking after snapshot errors

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -320,9 +320,15 @@ export async function autoTrackPrReviewNeeds(): Promise<void> {
   try {
     const { stdout } = await gh(['pr', 'list', '--state', 'open', '--json', 'number,title,body,isDraft,reviewDecision,reviewRequests,labels,url,createdAt,updatedAt,headRefName', '--limit', '50']);
     prs = JSON.parse(stdout);
-    writeOpenPrSnapshot(getMemoryRootDir(), prs.map(toOpenPrSummary));
-  } catch {
+  } catch (err) {
+    slog('github', `open PR listing failed: ${String(err)}`);
     return;
+  }
+
+  try {
+    writeOpenPrSnapshot(getMemoryRootDir(), prs.map(toOpenPrSummary));
+  } catch (err) {
+    slog('github', `open PR snapshot write failed; continuing with handoff tracking: ${String(err)}`);
   }
 
   let activeContent: string;


### PR DESCRIPTION
## Summary
- split open PR listing errors from snapshot write errors
- keep PR review/draft handoff tracking running even when open-prs.json cannot be written
- log both failure modes instead of silently no-oping the PR lifecycle autopilot

## Verification
- `pnpm typecheck`
- `pnpm exec vitest run tests/pr-autopilot.test.ts`
- `pnpm build`