### PR TITLE
fix: classify middleware failures from output only

### DIFF
--- a/src/middleware-failure-self-healing.ts
+++ b/src/middleware-failure-self-healing.ts
@@ -71,7 +71,7 @@ export async function classifyMiddlewareFailures(
   tasks: MiddlewareTaskRecord[],
   now = new Date(),
 ): Promise<MiddlewareFailureSweepResult> {
-  const known = new Set(readMiddlewareFailureClassificationsSync(memoryDir).map(record => record.taskId));
+  const known = new Map(readMiddlewareFailureClassificationsSync(memoryDir).map(record => [record.taskId, record]));
   const failedTasks = tasks.filter(task => task.status === 'failed' && task.id);
   const result: MiddlewareFailureSweepResult = {
     scanned: tasks.length,
@@ -83,14 +83,16 @@ export async function classifyMiddlewareFailures(
 
   for (const task of failedTasks) {
     const taskId = task.id as string;
-    if (known.has(taskId)) {
+    const text = failureOutputText(task);
+    const bucket = classifyMiddlewareFailureBucket(text);
+    const providerHold = classifyProviderResourceHold(text, now) ?? undefined;
+    const status: MiddlewareFailureClassification['status'] = providerHold ? 'held' : 'classified';
+    const existing = known.get(taskId);
+    if (existing && existing.bucket === bucket && existing.status === status) {
       result.skippedKnown++;
       continue;
     }
 
-    const text = failureText(task);
-    const bucket = classifyMiddlewareFailureBucket(text);
-    const providerHold = classifyProviderResourceHold(text, now) ?? undefined;
     const delegationDecision = recordDelegationFailure(memoryDir, {
       taskId,
       taskType: `middleware:${task.worker ?? 'unknown'}`,
@@ -99,13 +101,11 @@ export async function classifyMiddlewareFailures(
     }, now);
 
     let providerHoldTaskId: string | undefined;
-    let status: MiddlewareFailureClassification['status'] = 'classified';
     let delegationStatus: DelegationFailureStatus = 'resolved';
     let resolution = `middleware failed task classified as ${bucket}`;
 
     if (providerHold) {
       providerHoldTaskId = await ensureProviderHoldTask(memoryDir, providerHold, task, now);
-      status = 'held';
       result.held++;
       resolution = `${resolution}; provider held until ${providerHold.resumeAt}; holdTask=${providerHoldTaskId}`;
     } else if (bucket === 'max-turns') {
@@ -264,12 +264,13 @@ async function fetchMiddlewareTasks(baseUrl?: string, timeoutMs = 2500): Promise
   }
 }
 
-function failureText(task: MiddlewareTaskRecord): string {
-  return [
+function failureOutputText(task: MiddlewareTaskRecord): string {
+  const output = [
     task.error,
     task.result,
-    task.task,
   ].filter(value => typeof value === 'string' && value.trim()).join('\n').slice(0, 4000);
+  if (output) return output;
+  return String(task.task ?? '').slice(0, 4000);
 }
 
 function isMiddlewareFailureBucket(value: unknown): value is MiddlewareFailureBucket {

--- a/tests/middleware-failure-self-healing.test.ts
+++ b/tests/middleware-failure-self-healing.test.ts
@@ -78,7 +78,7 @@ describe('middleware failure self-healing', () => {
       id: 'task-turns',
       worker: 'coder',
       status: 'failed',
-      task: 'Implement a large repair',
+      task: 'Implement a large repair for a previous maximum budget failure',
       error: 'Task failed: reached maximum number of turns',
     }], new Date('2026-05-06T16:30:00.000Z'));
 
@@ -88,6 +88,31 @@ describe('middleware failure self-healing', () => {
       status: 'classified',
     }));
     expect(queryMemoryIndexSync(memoryDir, { type: ['task'], status: ['hold'] })).toHaveLength(0);
+  });
+
+  it('reclassifies a known task when better error-only signal changes the bucket', async () => {
+    await classifyMiddlewareFailures(memoryDir, [{
+      id: 'task-reclassify',
+      worker: 'coder',
+      status: 'failed',
+      task: 'Task text mentions maximum budget from a different failure',
+      error: 'Task failed: reached maximum number of turns',
+    }], new Date('2026-05-06T16:30:00.000Z'));
+
+    const second = await classifyMiddlewareFailures(memoryDir, [{
+      id: 'task-reclassify',
+      worker: 'coder',
+      status: 'failed',
+      task: 'Task text mentions maximum budget from a different failure',
+      error: 'Task failed: reached maximum budget',
+    }], new Date('2026-05-06T16:31:00.000Z'));
+
+    expect(second).toEqual(expect.objectContaining({ classified: 1, skippedKnown: 0, held: 1 }));
+    expect(readMiddlewareFailureClassificationsSync(memoryDir)[0]).toEqual(expect.objectContaining({
+      taskId: 'task-reclassify',
+      bucket: 'budget-or-quota',
+      status: 'held',
+    }));
   });
 
   it('exposes the same buckets used by middleware quality health', () => {


### PR DESCRIPTION
## Summary
- classify middleware failure buckets from `error/result` only, not the delegated task prompt
- allow already-classified task ids to be reclassified when the error-only bucket/status changes
- add coverage for prompts that mention budget while the actual failure is max-turns

## Verification
- `pnpm exec vitest run tests/middleware-failure-self-healing.test.ts tests/middleware-quality-health.test.ts tests/provider-resource-guard.test.ts`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`