### PR TITLE
fix(hn-ai-trend): exponential backoff retry (5 attempts, ~15s)

### DIFF
--- a/scripts/hn-ai-trend.mjs
+++ b/scripts/hn-ai-trend.mjs
@@ -69,17 +69,20 @@ function isAITopic(item) {
   return AI_PATTERNS.some(p => p.test(text));
 }
 
-async function fetchJSON(url, attempt = 1) {
+async function fetchJSON(url, attempt = 1, maxAttempts = 5) {
   try {
     const r = await fetch(url);
     if (!r.ok) throw new Error(`HTTP ${r.status}`);
     return await r.json();
   } catch (e) {
-    if (attempt < 3) {
-      await new Promise(res => setTimeout(res, 500 * attempt));
-      return fetchJSON(url, attempt + 1);
+    if (attempt < maxAttempts) {
+      // exponential backoff with jitter: ~1s, 2s, 4s, 8s (cumulative ~15s)
+      const delay = 1000 * Math.pow(2, attempt - 1) + Math.floor(Math.random() * 250);
+      console.error(`[hn-ai-trend] fetch failed (${e.message}); retry ${attempt}/${maxAttempts - 1} in ${delay}ms`);
+      await new Promise(res => setTimeout(res, delay));
+      return fetchJSON(url, attempt + 1, maxAttempts);
     }
-    throw new Error(`${e.message} (${url})`);
+    throw new Error(`${e.message} (${url}) after ${maxAttempts} attempts`);
   }
 }
 


### PR DESCRIPTION
## Summary
- Today (2026-05-07) the 9:00 launchd cron logged HN topstories FATAL twice; manual retry at 11:27 succeeded
- Existing `fetchJSON` had retry but only 3 attempts × `500ms*attempt` = **~1.5s total** wait — too tight to bridge even a 30s API blip
- Now: 5 attempts with exponential backoff + jitter (1s, 2s, 4s, 8s ≈ 15s cumulative)
- Each retry now logs to stderr so launchd-log shows the failure mode (instead of single FATAL)

## Test plan
- [x] `node --check scripts/hn-ai-trend.mjs` — syntax OK
- [x] Live run on 2026-05-07 (no failures): wrote 7 posts → `memory/state/hn-ai-trend/2026-05-07.json`
- [ ] Falsifier (passive): next morning's launchd-log on a transient HN API blip should show `retry N/4 in Xms` lines rather than a single FATAL

🤖 Generated with [Claude Code](https://claude.com/claude-code)