### PR TITLE
fix: feed workflow myelin lifecycle events

### DIFF
--- a/src/memory-index.ts
+++ b/src/memory-index.ts
@@ -325,6 +325,7 @@ export async function appendMemoryIndexEntry(
   });
 
   writeThroughEntry(memoryDir, entry);
+  await recordWorkflowCreation(memoryDir, entry);
   slog('INDEX', `append ${entry.id} type=${entry.type} status=${entry.status} bucket=${bucket}`);
   return entry;
 }
@@ -450,7 +451,107 @@ export async function updateMemoryIndexEntry(
   });
 
   writeThroughEntry(memoryDir, updated);
+  await recordWorkflowTransition(memoryDir, current, updated);
   return updated;
+}
+
+async function recordWorkflowCreation(memoryDir: string, entry: MemoryIndexEntry): Promise<void> {
+  void memoryDir;
+  if (entry.type !== 'task' && entry.type !== 'goal') return;
+  const payload = (entry.payload ?? {}) as Record<string, unknown>;
+  const needsDecomposition = entry.status === 'needs-decomposition' || payload.needs_decomposition === true;
+  try {
+    const { triageWorkflowEvent } = await import('./myelin-fleet.js');
+    await triageWorkflowEvent({
+      type: 'task-start',
+      source: 'ooda-cycle',
+      context: {
+        taskId: entry.id,
+        title: entry.summary ?? '',
+        status: entry.status,
+        ideaClarity: needsDecomposition ? 'vague' : 'concrete',
+        fileImpact: needsDecomposition ? 3 : estimateFileImpact(entry.summary ?? '', payload),
+        origin: payload.origin ?? entry.source ?? 'unknown',
+      },
+    });
+  } catch (error) {
+    slog('WARN', `workflow myelin creation record failed: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+async function recordWorkflowTransition(
+  memoryDir: string,
+  previous: MemoryIndexEntry,
+  updated: MemoryIndexEntry,
+): Promise<void> {
+  void memoryDir;
+  if (previous.status === updated.status) return;
+  if (updated.type !== 'task' && updated.type !== 'goal') return;
+
+  if (TASK_TERMINAL_STATUSES.has(updated.status)) {
+    const verified = isWorkflowVerified(updated);
+    try {
+      const { triageWorkflowEvent } = await import('./myelin-fleet.js');
+      await triageWorkflowEvent({
+        type: 'task-done',
+        source: 'ooda-cycle',
+        context: {
+          taskId: updated.id,
+          title: updated.summary ?? '',
+          status: updated.status,
+          verified,
+          doneRatio: verified ? 1 : 0.95,
+        },
+      });
+    } catch (error) {
+      slog('WARN', `workflow myelin terminal record failed: ${error instanceof Error ? error.message : String(error)}`);
+    }
+    return;
+  }
+
+  if (['blocked', 'hold', 'needs-decomposition'].includes(String(updated.status))) {
+    const payload = (updated.payload ?? {}) as Record<string, unknown>;
+    try {
+      const { triageWorkflowEvent } = await import('./myelin-fleet.js');
+      await triageWorkflowEvent({
+        type: 'process-friction',
+        source: 'ooda-cycle',
+        context: {
+          taskId: updated.id,
+          title: updated.summary ?? '',
+          status: updated.status,
+          frictionType: 'any',
+          hasToolsAvailable: !payload.provider_resource_hold,
+          attemptCount: Number(payload.auto_executor_failures ?? payload.ticksSinceLastProgress ?? 0),
+        },
+      });
+    } catch (error) {
+      slog('WARN', `workflow myelin friction record failed: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+}
+
+function estimateFileImpact(summary: string, payload: Record<string, unknown>): number {
+  const verifyCommand = String(payload.verify_command ?? '');
+  const text = `${summary}\n${verifyCommand}`;
+  const files = new Set(text.match(/[a-zA-Z0-9_./-]+\.(?:ts|tsx|js|mjs|json|md|html|css|sh)/g) ?? []);
+  if (files.size > 0) return Math.min(10, files.size);
+  if (/architecture|refactor|redesign|重新設計|整套|跨/.test(text)) return 3;
+  return 1;
+}
+
+function isWorkflowVerified(entry: MemoryIndexEntry): boolean {
+  const payload = (entry.payload ?? {}) as Record<string, unknown>;
+  const verifyProof = payload.verify_proof as Record<string, unknown> | undefined;
+  if (verifyProof?.passed === true) return true;
+  const verify = payload.verify;
+  if (Array.isArray(verify) && verify.length > 0) {
+    return verify.every(item => {
+      const record = item as Record<string, unknown>;
+      return record.status === 'pass';
+    });
+  }
+  return entry.status === 'completed' || entry.status === 'done';
 }
 
 export async function deleteMemoryIndexEntry(

--- a/src/myelin-fleet.ts
+++ b/src/myelin-fleet.ts
@@ -14,6 +14,7 @@
 
 import { createMyelin, createFleet, logDecision } from 'myelinate';
 import type { Myelin, MyelinStats, TriageResult, MyelinFleet, FleetStats } from 'myelinate';
+import path from 'node:path';
 
 import { slog } from './utils.js';
 import { getMemoryRootDir } from './memory-paths.js';
@@ -25,13 +26,23 @@ import type { TaskLane } from './task-graph.js';
 
 export type LearningAction = 'deep-dive' | 'index-only' | 'connect' | 'defer';
 export type RoutingAction = TaskLane | 'merge';
-export type WorkflowAction = 'propose' | 'decompose' | 'complete' | 'evolve';
+export type WorkflowAction =
+  | 'write-proposal'
+  | 'decompose-tasks'
+  | 'mark-and-continue'
+  | 'execute-or-delegate'
+  | 'try-self-first'
+  | 'evolve-process';
 
 const WORKFLOW_DOMAIN = {
   domain: 'workflow',
   description: '開發工作流程決策 — 提案/拆解/完成/流程演化',
-  seedRulesPath: 'memory/myelin-workflow-rules.json',
+  rulesFile: 'myelin-workflow-rules.json',
 } as const;
+
+function myelinPath(file: string): string {
+  return path.join(getMemoryRootDir(), file);
+}
 
 // =============================================================================
 // Heuristic functions (pure, no side effects)
@@ -101,15 +112,18 @@ async function workflowLLM(event: { type: string; source?: string; context?: Rec
   const doneRatio = Number(ctx.doneRatio ?? 0);
 
   if (phase === 'proposal' || /proposal|提案|scope|spec/.test(text)) {
-    return { action: 'propose', reason: 'proposal signal detected' };
+    return { action: 'write-proposal', reason: 'proposal signal detected' };
   }
   if (phase === 'breakdown' || /拆解|breakdown|tasks|steps/.test(text)) {
-    return { action: 'decompose', reason: 'task breakdown signal detected' };
+    return { action: 'decompose-tasks', reason: 'task breakdown signal detected' };
   }
   if (phase === 'done' || doneRatio >= 0.95 || /完成|done|closed/.test(text)) {
-    return { action: 'complete', reason: 'completion signal detected' };
+    return { action: 'mark-and-continue', reason: 'completion signal detected' };
   }
-  return { action: 'evolve', reason: 'default to process evolution' };
+  if (/block|blocked|hold|stuck|error|failed|friction|卡住|阻塞|失敗/.test(text)) {
+    return { action: 'try-self-first', reason: 'obstacle signal detected' };
+  }
+  return { action: 'evolve-process', reason: 'default to process evolution' };
 }
 
 // =============================================================================
@@ -128,8 +142,8 @@ function getFleet(): MyelinFleet<string> {
             // Triage bypass decisions are all rule-based — LLM fallback is unused
             return { action: 'wake', reason: 'default-wake' };
           },
-          rulesPath: './memory/myelin-triage-rules.json',
-          logPath: TRIAGE_LOG_PATH,
+          rulesPath: myelinPath('myelin-triage-rules.json'),
+          logPath: triageLogPath(),
           autoLog: false, // bypass decisions are logged manually via logTriageBypass
           failOpenAction: 'wake',
           crystallize: {
@@ -143,8 +157,8 @@ function getFleet(): MyelinFleet<string> {
         name: 'learning',
         instance: createMyelin<string>({
           llm: learningLLM,
-          rulesPath: './memory/myelin-learning-rules.json',
-          logPath: './memory/myelin-learning-decisions.jsonl',
+          rulesPath: myelinPath('myelin-learning-rules.json'),
+          logPath: myelinPath('myelin-learning-decisions.jsonl'),
           autoLog: true,
           failOpenAction: 'index-only',
           crystallize: { minOccurrences: 5, minConsistency: 0.90 },
@@ -154,8 +168,8 @@ function getFleet(): MyelinFleet<string> {
         name: 'routing',
         instance: createMyelin<string>({
           llm: routingLLM,
-          rulesPath: './memory/myelin-routing-rules.json',
-          logPath: './memory/myelin-routing-decisions.jsonl',
+          rulesPath: myelinPath('myelin-routing-rules.json'),
+          logPath: myelinPath('myelin-routing-decisions.jsonl'),
           failOpenAction: 'ooda',
           crystallize: { minOccurrences: 8, minConsistency: 0.90 },
         }),
@@ -164,8 +178,8 @@ function getFleet(): MyelinFleet<string> {
         name: 'research',
         instance: createMyelin<string>({
           llm: async () => ({ action: 'normal', reason: 'no-llm-fallback' }),
-          rulesPath: './memory/research-rules.json',
-          logPath: './memory/research-decisions.jsonl',
+          rulesPath: myelinPath('research-rules.json'),
+          logPath: myelinPath('research-decisions.jsonl'),
           autoLog: true,
           failOpen: true,
           failOpenAction: 'normal',
@@ -176,10 +190,10 @@ function getFleet(): MyelinFleet<string> {
         name: WORKFLOW_DOMAIN.domain,
         instance: createMyelin<string>({
           llm: workflowLLM,
-          rulesPath: `./${WORKFLOW_DOMAIN.seedRulesPath}`,
-          logPath: './memory/myelin-workflow-decisions.jsonl',
+          rulesPath: myelinPath(WORKFLOW_DOMAIN.rulesFile),
+          logPath: myelinPath('myelin-workflow-decisions.jsonl'),
           autoLog: true,
-          failOpenAction: 'evolve',
+          failOpenAction: 'evolve-process',
           crystallize: { minOccurrences: 5, minConsistency: 0.90 },
         }),
       },
@@ -193,12 +207,15 @@ function getFleet(): MyelinFleet<string> {
 // Public API — drop-in replacements for myelin-integration.ts exports
 // =============================================================================
 
-const TRIAGE_LOG_PATH = './memory/myelin-decisions.jsonl';
+function triageLogPath(): string {
+  return myelinPath('myelin-decisions.jsonl');
+}
+
 /** Log a hard-rule bypass directly (triage domain removed from fleet). */
 export function logTriageBypass(source: string, action: 'wake' | 'skip', reason: string): void {
   try {
     logDecision(
-      TRIAGE_LOG_PATH,
+      triageLogPath(),
       { type: source, source, context: {} },
       action,
       `hard-rule: ${reason}`,
@@ -322,6 +339,32 @@ export async function triageRouting(event: {
   const r = result!;
   const emoji = r.method === 'rule' ? '⚡' : '🧠';
   slog('MYELIN-ROUTE', `${emoji} ${event.type}/${event.taskType}: → ${r.action} (${r.latencyMs}ms ${r.method})`);
+  return r;
+}
+
+// =============================================================================
+// Workflow lifecycle
+// =============================================================================
+
+/**
+ * Route concrete lifecycle events through the workflow myelin.
+ * Called from memory-index task creation/status transitions so workflow rules
+ * are measured against actual work, not just crystallized in isolation.
+ */
+export async function triageWorkflowEvent(event: {
+  type: 'task-start' | 'proposal-status-change' | 'task-done' | 'analysis-complete' | 'obstacle-detected' | 'process-friction';
+  source?: string;
+  context?: Record<string, unknown>;
+}): Promise<TriageResult<string>> {
+  const result = await getFleet().triageWith('workflow', {
+    type: event.type,
+    source: event.source ?? 'ooda-cycle',
+    context: event.context ?? {},
+  });
+
+  const r = result!;
+  const emoji = r.method === 'rule' ? '⚡' : '🧠';
+  slog('MYELIN-WORKFLOW', `${emoji} ${event.type}: → ${r.action} (${r.latencyMs}ms ${r.method})`);
   return r;
 }
 

--- a/tests/workflow-myelin-lifecycle.test.ts
+++ b/tests/workflow-myelin-lifecycle.test.ts
@@ -1,0 +1,105 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+let tmpDir: string;
+let previousMemoryDir: string | undefined;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(path.join(os.tmpdir(), 'mini-agent-workflow-myelin-'));
+  previousMemoryDir = process.env.MINI_AGENT_MEMORY_DIR;
+  process.env.MINI_AGENT_MEMORY_DIR = tmpDir;
+  vi.resetModules();
+  writeWorkflowRules();
+});
+
+afterEach(() => {
+  if (previousMemoryDir === undefined) delete process.env.MINI_AGENT_MEMORY_DIR;
+  else process.env.MINI_AGENT_MEMORY_DIR = previousMemoryDir;
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('workflow myelin lifecycle integration', () => {
+  it('records rule-hit workflow decisions into the configured memory root', async () => {
+    const { triageWorkflowEvent } = await import('../src/myelin-fleet.js');
+    const { getMyelinStatus } = await import('../src/myelin-status.js');
+
+    const result = await triageWorkflowEvent({
+      type: 'task-done',
+      source: 'ooda-cycle',
+      context: { verified: true, taskId: 'idx-test' },
+    });
+
+    expect(result).toEqual(expect.objectContaining({
+      action: 'mark-and-continue',
+      method: 'rule',
+    }));
+
+    const log = readFileSync(path.join(tmpDir, 'myelin-workflow-decisions.jsonl'), 'utf-8');
+    expect(log).toContain('"method":"rule"');
+    expect(log).toContain('"action":"mark-and-continue"');
+    expect(getMyelinStatus(tmpDir, 10).domains.find(domain => domain.name === 'workflow')?.health).toBe('effective');
+  });
+
+  it('feeds task creation into workflow rules instead of leaving workflow idle', async () => {
+    const { appendMemoryIndexEntry } = await import('../src/memory-index.js');
+
+    await appendMemoryIndexEntry(tmpDir, {
+      type: 'task',
+      status: 'needs-decomposition',
+      summary: '改善整套跨模組流程',
+      refs: [],
+      payload: { needs_decomposition: true },
+    });
+
+    const logPath = path.join(tmpDir, 'myelin-workflow-decisions.jsonl');
+    await waitFor(() => existsSync(logPath) && readFileSync(logPath, 'utf-8').includes('"action":"write-proposal"'));
+
+    const log = readFileSync(logPath, 'utf-8');
+    expect(log).toContain('"method":"rule"');
+    expect(log).toContain('"action":"write-proposal"');
+  });
+});
+
+function writeWorkflowRules(): void {
+  mkdirSync(tmpDir, { recursive: true });
+  writeFileSync(path.join(tmpDir, 'myelin-workflow-rules.json'), JSON.stringify([
+    {
+      id: 'workflow_proposal_gate',
+      match: {
+        type: 'task-start',
+        source: 'ooda-cycle',
+        context: {
+          ideaClarity: 'vague',
+          fileImpact: { gte: 3 },
+        },
+      },
+      action: 'write-proposal',
+      reason: 'vague task touching several files should write proposal',
+      createdAt: '2026-05-07T00:00:00.000Z',
+      hitCount: 0,
+    },
+    {
+      id: 'workflow_immediate_completion',
+      match: {
+        type: 'task-done',
+        source: 'ooda-cycle',
+        context: { verified: true },
+      },
+      action: 'mark-and-continue',
+      reason: 'verified completion should immediately mark and continue',
+      createdAt: '2026-05-07T00:00:00.000Z',
+      hitCount: 0,
+    },
+  ], null, 2), 'utf-8');
+}
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  const deadline = Date.now() + 1000;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await new Promise(resolve => setTimeout(resolve, 25));
+  }
+  expect(predicate()).toBe(true);
+}


### PR DESCRIPTION
## Summary
- Route workflow myelin rules/logs through the configured external memory root instead of repo-local memory paths.
- Add a public workflow lifecycle triage API and feed task creation/status transitions from memory-index.
- Cover the lifecycle path with regression tests so workflow myelin no longer stays idle when real tasks move.

## Verification
- `pnpm exec vitest run tests/workflow-myelin-lifecycle.test.ts tests/myelin-status.test.ts`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`