### PR TITLE
fix: guard heartbeat recurring-error phantoms

### DIFF
--- a/src/external-memory-health.ts
+++ b/src/external-memory-health.ts
@@ -34,6 +34,17 @@ export function evaluateMemoryStateTruth(memoryDir: string, repoRoot: string): E
     };
   }
 
+  const heartbeatPhantoms = findHeartbeatRecurringErrorPhantoms(memoryDir);
+  if (heartbeatPhantoms.length > 0) {
+    const hasP0 = heartbeatPhantoms.some(item => item.priority === 'P0');
+    return {
+      status: hasP0 ? 'blocked' : 'warn',
+      summary: `${heartbeatPhantoms.length} HEARTBEAT recurring-error task(s) lack live error-pattern support`,
+      evidence: [...evidence, ...heartbeatPhantoms.slice(0, 8).map(item => `HEARTBEAT.md:${item.line} ${item.priority} ${item.title}`)],
+      repair: 'Retire or refresh stale HEARTBEAT error tasks so context render follows live error-pattern truth instead of historical counters.',
+    };
+  }
+
   const gitDir = path.join(memoryDir, '.git');
   if (!fs.existsSync(gitDir)) {
     return {
@@ -159,6 +170,100 @@ export function evaluateKgExternalMemoryTruth(memoryDir: string, now = new Date(
     evidence,
   };
 }
+
+function findHeartbeatRecurringErrorPhantoms(memoryDir: string): Array<{ line: number; priority: string; title: string }> {
+  const heartbeatPath = path.join(memoryDir, 'HEARTBEAT.md');
+  if (!fs.existsSync(heartbeatPath)) return [];
+
+  const livePatterns = readLiveErrorPatternNeedles(memoryDir);
+  const heartbeat = stripHtmlComments(fs.readFileSync(heartbeatPath, 'utf-8'));
+  const lines = heartbeat.split('\n');
+  const phantoms: Array<{ line: number; priority: string; title: string }> = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].trim();
+    if (!line.startsWith('- [ ]')) continue;
+    const recurring = line.match(/(?:\(|（)(\d+)\s*(?:次|x|occurrences?),?\s*last\s*(\d{4}-\d{2}-\d{2})(?:\)|）)/i);
+    if (!recurring) continue;
+
+    const title = extractHeartbeatTaskTitle(line);
+    const needles = recurringErrorNeedles(title);
+    if (needles.length === 0) continue;
+
+    const liveMatch = needles.some(needle => livePatterns.some(pattern => pattern.includes(needle)));
+    if (!liveMatch) {
+      phantoms.push({
+        line: i + 1,
+        priority: extractPriority(line),
+        title: title || line.slice(0, 120),
+      });
+    }
+  }
+
+  return phantoms;
+}
+
+function readLiveErrorPatternNeedles(memoryDir: string): string[] {
+  const filePath = path.join(memoryDir, 'state', 'error-patterns.json');
+  if (!fs.existsSync(filePath)) return [];
+  try {
+    const raw = JSON.parse(fs.readFileSync(filePath, 'utf-8')) as Record<string, unknown>;
+    return Object.entries(raw)
+      .filter(([, value]) => {
+        const record = value as Record<string, unknown>;
+        return record.resolved !== true;
+      })
+      .map(([key, value]) => {
+        const record = value as Record<string, unknown>;
+        return normalizePatternText([
+          key,
+          String(record.lastMessage ?? ''),
+          String(record.rootCause ?? ''),
+        ].join(' '));
+      });
+  } catch {
+    return [];
+  }
+}
+
+function stripHtmlComments(text: string): string {
+  return text.replace(/<!--[\s\S]*?-->\n?/g, '');
+}
+
+function extractHeartbeatTaskTitle(line: string): string {
+  const bold = line.match(/\*\*(.*?)\*\*/);
+  if (bold?.[1]) return bold[1];
+  return line.replace(/^- \[ \]\s*/, '').replace(/(?:\(|（)\d+\s*(?:次|x|occurrences?),?\s*last\s*\d{4}-\d{2}-\d{2}(?:\)|）).*/, '').trim();
+}
+
+function extractPriority(line: string): string {
+  return line.match(/\bP[0-3]\b/)?.[0] ?? 'P?';
+}
+
+function recurringErrorNeedles(title: string): string[] {
+  const normalized = normalizePatternText(title);
+  return normalized
+    .split(/\s+/)
+    .filter(token => token.length >= 4 && !STOP_PATTERN_TOKENS.has(token));
+}
+
+function normalizePatternText(text: string): string {
+  return text.toLowerCase().replace(/[^a-z0-9_]+/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+const STOP_PATTERN_TOKENS = new Set([
+  'cannot',
+  'read',
+  'properties',
+  'property',
+  'undefined',
+  'error',
+  'timeout',
+  'failed',
+  'failure',
+  'unknown',
+  'real',
+]);
 
 function findMalformedCriticalJsonl(memoryDir: string): Array<{ file: string; line: number; error: string }> {
   const malformed: Array<{ file: string; line: number; error: string }> = [];

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -2719,7 +2719,10 @@ export class AgentLoop {
       // Soft falsifier gate — reuse shared extractDecisionBlock (fire-and-forget)
       try {
         const decision = extractDecisionBlock(response);
-        slog('LEDGER', `soft-gate enter: response=${response?.length ?? 0}ch hasMarker=${response ? /^##\s*Decision/m.test(response) : false} cycle=${this.cycleCount}`);
+        const len = response?.length ?? 0;
+        const hasMarker = response ? /^##\s*Decision/m.test(response) : false;
+        let outcome: 'wrote' | 'no-chose' | 'null-with-marker' | 'null-no-marker' | 'short-skip';
+        let extra: Record<string, unknown> = {};
         if (decision?.chose) {
           writeCommitment({
             cycle_id: this.cycleCount,
@@ -2729,35 +2732,31 @@ export class AgentLoop {
             // Phase 2 (cycle 16, 2026-05-06): Decision-block emits are self-promises.
             counterparty: { kind: 'self' },
           });
-          if (!decision.falsifier) slog('LEDGER', 'soft-gate: OODA action without falsifier');
+          outcome = 'wrote';
+          extra = { has_falsifier: Boolean(decision.falsifier) };
         } else if (decision && !decision.chose) {
           // Issue #80: parsed Decision block but `chose` field missing/empty.
-          // Heuristic to avoid log spam: only emit when response looks substantial.
-          if (response && response.length > 200) {
-            const keys = Object.keys(decision).join(',') || '<empty>';
-            slog('LEDGER', `soft-gate skip: extractDecisionBlock returned object without chose (keys=${keys}, response=${response.length}ch)`);
-          }
-        } else if (!decision && response && response.length > 200) {
-          // Issue #80: regex returned null on a non-trivial response (potential silent miss).
-          // Length gate keeps tool-only / short cycles quiet.
-          const hasDecisionMarker = /^##\s*Decision/m.test(response);
-          if (hasDecisionMarker) {
-            // Issue #88 (2026-05-06): when header is detected but field-extract fails,
-            // dump first 300ch after the header so the regex flaw is self-diagnosing.
-            const headerIdx = response.search(/^#{2,3}\s*Decision\b/im);
-            const snippet = headerIdx >= 0
+          outcome = 'no-chose';
+          extra = { keys: Object.keys(decision).join(',') || '<empty>' };
+        } else if (len <= 200) {
+          outcome = 'short-skip';
+        } else if (hasMarker) {
+          // Issue #88: keep the diagnostic bytes, but make the event structured.
+          const headerIdx = response.search(/^#{2,3}\s*Decision\b/im);
+          extra = {
+            snippet: headerIdx >= 0
               ? response.slice(headerIdx, headerIdx + 300).replace(/\n/g, '\\n')
-              : '<no-header>';
-            slog('LEDGER', `soft-gate skip: extractDecisionBlock returned null (response=${response.length}ch, has_decision_marker=true, snippet="${snippet}")`);
-          } else {
-            // Issue #88 followup: also dump head when marker missing on substantial response (cl-5 false-branch evidence).
-            const head = response.slice(0, 200).replace(/\n/g, '\\n');
-            slog('LEDGER', `soft-gate skip: extractDecisionBlock returned null (response=${response.length}ch, has_decision_marker=false, head="${head}")`);
-          }
+              : '<no-header>',
+          };
+          outcome = 'null-with-marker';
+        } else {
+          extra = { head: response.slice(0, 200).replace(/\n/g, '\\n') };
+          outcome = 'null-no-marker';
         }
+        slog('LEDGER', JSON.stringify({ evt: 'soft-gate', cycle: this.cycleCount, len, hasMarker, outcome, ...extra }));
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
-        slog('LEDGER', `soft-gate threw: ${msg}`);
+        slog('LEDGER', JSON.stringify({ evt: 'soft-gate', cycle: this.cycleCount, outcome: 'threw', msg }));
       }
 
       // ── Filter out chats already sent via streaming ──

--- a/tests/external-memory-health.test.ts
+++ b/tests/external-memory-health.test.ts
@@ -42,6 +42,62 @@ describe('external memory health', () => {
     expect(['warn', 'ok']).toContain(result.status);
   });
 
+  it('blocks unchecked P0 recurring-error HEARTBEAT tasks with no live error-pattern support', () => {
+    writeFileSync(path.join(tmpDir, 'state', 'task-events.jsonl'), '', 'utf-8');
+    writeFileSync(path.join(tmpDir, 'state', 'error-patterns.json'), JSON.stringify({
+      'TIMEOUT:silent_exit_void::callClaude': {
+        count: 15,
+        lastSeen: '2026-05-07',
+        lastMessage: 'CLI silent_exit_void after 327s',
+      },
+    }), 'utf-8');
+    writeFileSync(path.join(tmpDir, 'HEARTBEAT.md'), [
+      '# HEARTBEAT',
+      '## Active Tasks',
+      '- [ ] **P0 Cannot read properties of unde:generic**（72 次, last 2026-04-25）：historical counter',
+    ].join('\n'), 'utf-8');
+
+    const result = evaluateMemoryStateTruth(tmpDir, tmpDir);
+
+    expect(result.status).toBe('blocked');
+    expect(result.summary).toContain('HEARTBEAT recurring-error');
+    expect(result.evidence.join('\n')).toContain('unde:generic');
+  });
+
+  it('ignores retired recurring-error HEARTBEAT tasks wrapped in comments', () => {
+    writeFileSync(path.join(tmpDir, 'state', 'task-events.jsonl'), '', 'utf-8');
+    writeFileSync(path.join(tmpDir, 'state', 'error-patterns.json'), '{}', 'utf-8');
+    writeFileSync(path.join(tmpDir, 'HEARTBEAT.md'), [
+      '# HEARTBEAT',
+      '## Active Tasks',
+      '<!-- - [x] **P0 Cannot read properties of unde:generic**（72 次, last 2026-04-25）：historical counter -->',
+    ].join('\n'), 'utf-8');
+
+    const result = evaluateMemoryStateTruth(tmpDir, tmpDir);
+
+    expect(result.status).toBe('ok');
+  });
+
+  it('keeps active recurring-error HEARTBEAT tasks when backed by a live error-pattern', () => {
+    writeFileSync(path.join(tmpDir, 'state', 'task-events.jsonl'), '', 'utf-8');
+    writeFileSync(path.join(tmpDir, 'state', 'error-patterns.json'), JSON.stringify({
+      'TIMEOUT:silent_exit_void::callClaude': {
+        count: 15,
+        lastSeen: '2026-05-07',
+        lastMessage: 'CLI silent_exit_void after 327s',
+      },
+    }), 'utf-8');
+    writeFileSync(path.join(tmpDir, 'HEARTBEAT.md'), [
+      '# HEARTBEAT',
+      '## Active Tasks',
+      '- [ ] **P1 silent_exit_void**（15 次, last 2026-05-07）：new live samples still need root cause',
+    ].join('\n'), 'utf-8');
+
+    const result = evaluateMemoryStateTruth(tmpDir, tmpDir);
+
+    expect(result.status).toBe('ok');
+  });
+
   it('treats absent KG footprint as not configured for this memory workspace', () => {
     vi.stubEnv('KG_URL', '');
 


### PR DESCRIPTION
## Summary
- Add a memory-state-truth guard for unchecked HEARTBEAT recurring-error tasks whose title no longer has a live unresolved entry in `state/error-patterns.json`.
- Treat unsupported P0 recurring-error tasks as blocked closure so stale historical counters cannot keep Kuro chasing phantom work.
- Consolidate the soft-gate ledger diagnostics into a structured `evt=soft-gate` log with explicit outcomes instead of accumulating ad hoc log branches.

## Verification
- `pnpm exec vitest run tests/external-memory-health.test.ts tests/autonomy-closure-health.test.ts`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`