### PR TITLE
fix(runtime): autocorrect behind dirty checkout

### DIFF
--- a/src/runtime-workspace-autocorrect.ts
+++ b/src/runtime-workspace-autocorrect.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process';
-import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { isSafeRuntimeBranch, refreshGitIndex } from './workspace-isolation.js';
 
@@ -47,12 +47,6 @@ export function autocorrectRuntimeWorkspace(repoRoot = process.cwd(), opts: {
       reason: `runtime checkout is on ${snapshot.branch ?? 'unknown'}; expected runtime/main before autocorrect`,
     };
   }
-  if (snapshot.behind > 0) {
-    return {
-      status: 'blocked',
-      reason: `runtime checkout is behind origin/${baseBranch}; sync base before autocorrect`,
-    };
-  }
   const mode = snapshot.ahead > 0 ? 'commits' : snapshot.dirty ? 'tracked-dirty' : 'clean';
   if (snapshot.dirty && snapshot.hasUntracked) {
     return {
@@ -60,7 +54,7 @@ export function autocorrectRuntimeWorkspace(repoRoot = process.cwd(), opts: {
       reason: 'runtime checkout has untracked changes; commit, move, or ignore them before autocorrect',
     };
   }
-  if (mode === 'clean') return { status: 'not-needed', reason: 'runtime checkout is clean' };
+  if (mode === 'clean' && snapshot.behind === 0) return { status: 'not-needed', reason: 'runtime checkout is clean' };
   if (!snapshot.headSha) return { status: 'failed', reason: 'could not read runtime HEAD sha' };
 
   const shortSha = mode === 'tracked-dirty' ? `dirty-${Date.now().toString(36)}` : snapshot.headSha.slice(0, 8);
@@ -82,13 +76,30 @@ export function autocorrectRuntimeWorkspace(repoRoot = process.cwd(), opts: {
 
   try {
     git(root, ['fetch', 'origin', baseBranch]);
+    if (snapshot.behind > 0 && mode === 'clean') {
+      git(root, ['reset', '--hard', `origin/${baseBranch}`]);
+      return {
+        status: 'not-needed',
+        reason: `fast-forwarded protected runtime checkout to origin/${baseBranch}`,
+        resetRuntime: true,
+      };
+    }
+    if (snapshot.behind > 0 && mode === 'tracked-dirty' && trackedDirtyMatchesRef(root, `origin/${baseBranch}`)) {
+      git(root, ['reset', '--hard', `origin/${baseBranch}`]);
+      return {
+        status: 'not-needed',
+        reason: `runtime dirty state was already present in origin/${baseBranch}; synced protected checkout`,
+        resetRuntime: true,
+      };
+    }
     // Idempotency: if the remote branch already exists from a prior partial run,
     // skip the cherry-pick + push step. This handles the case where `gh pr create`
     // (or any later step) failed mid-sequence and the loop retries the autocorrect.
     const remoteBranchExists = !!safeGit(root, ['ls-remote', '--heads', 'origin', branch]);
     if (!remoteBranchExists) {
       if (mode === 'tracked-dirty') {
-        ensureWorktree(root, worktree, branch, `origin/${baseBranch}`);
+        const dirtyBaseRef = snapshot.behind > 0 ? snapshot.headSha : `origin/${baseBranch}`;
+        ensureWorktree(root, worktree, branch, dirtyBaseRef);
         moveTrackedDirtyToWorktree(root, worktree);
       } else {
         // Create worktree directly at headSha to preserve original commit hashes
@@ -123,6 +134,21 @@ export function autocorrectRuntimeWorkspace(repoRoot = process.cwd(), opts: {
       worktree,
     };
   }
+}
+
+function trackedDirtyMatchesRef(repoRoot: string, ref: string): boolean {
+  const paths = git(repoRoot, ['diff', '--name-only', 'HEAD'])
+    .split('\n')
+    .map(line => line.trim())
+    .filter(Boolean);
+  if (paths.length === 0) return true;
+  return paths.every(file => {
+    const diskPath = path.join(repoRoot, file);
+    if (!existsSync(diskPath)) return false;
+    const refBytes = safeGitBytes(repoRoot, ['show', `${ref}:${file}`]);
+    if (!refBytes) return false;
+    return readFileSync(diskPath).equals(refBytes);
+  });
 }
 
 function readGitSnapshot(repoRoot: string): GitSnapshot | null {
@@ -224,6 +250,19 @@ function moveTrackedDirtyToWorktree(repoRoot: string, worktree: string): void {
 function safeGit(cwd: string, args: string[]): string | null {
   try {
     return git(cwd, args).trim();
+  } catch {
+    return null;
+  }
+}
+
+function safeGitBytes(cwd: string, args: string[]): Buffer | null {
+  try {
+    return execFileSync('git', args, {
+      cwd,
+      encoding: 'buffer',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 60_000,
+    });
   } catch {
     return null;
   }

--- a/tests/runtime-workspace-autocorrect.test.ts
+++ b/tests/runtime-workspace-autocorrect.test.ts
@@ -82,6 +82,125 @@ describe('runtime workspace autocorrect', () => {
     expect(gitOut(result.worktree!, ['show', 'HEAD:README.md'])).toContain('tracked dirty');
   });
 
+  it('syncs a clean runtime checkout that is behind origin/main', () => {
+    const remote = path.join(tmpDir, 'behind-clean-remote.git');
+    const repo = path.join(tmpDir, 'behind-clean-mini-agent');
+    const peer = path.join(tmpDir, 'behind-clean-peer');
+    git(tmpDir, ['init', '--bare', remote]);
+    git(tmpDir, ['clone', remote, repo]);
+    git(repo, ['config', 'user.email', 'test@example.com']);
+    git(repo, ['config', 'user.name', 'Test User']);
+    writeFileSync(path.join(repo, 'README.md'), 'base\n');
+    git(repo, ['add', 'README.md']);
+    git(repo, ['commit', '-m', 'init']);
+    git(repo, ['branch', '-M', 'runtime/main']);
+    git(repo, ['push', '-u', 'origin', 'runtime/main:main']);
+    git(repo, ['fetch', 'origin', 'main']);
+    git(repo, ['branch', '--set-upstream-to=origin/main', 'runtime/main']);
+
+    git(tmpDir, ['clone', remote, peer]);
+    git(peer, ['config', 'user.email', 'test@example.com']);
+    git(peer, ['config', 'user.name', 'Test User']);
+    git(peer, ['checkout', '-b', 'main', 'origin/main']);
+    writeFileSync(path.join(peer, 'README.md'), 'base\nremote\n');
+    git(peer, ['commit', '-am', 'remote change']);
+    git(peer, ['push', 'origin', 'HEAD:main']);
+    git(repo, ['fetch', 'origin', 'main']);
+
+    const result = autocorrectRuntimeWorkspace(repo, {
+      apply: true,
+      createPr: false,
+      worktreeParent: tmpDir,
+    });
+
+    expect(result).toEqual(expect.objectContaining({
+      status: 'not-needed',
+      resetRuntime: true,
+    }));
+    expect(gitOut(repo, ['rev-parse', 'HEAD'])).toBe(gitOut(repo, ['rev-parse', 'origin/main']));
+    expect(gitOut(repo, ['status', '--short', '--branch'])).toContain('runtime/main...origin/main');
+  });
+
+  it('syncs behind tracked dirt without a PR when origin already contains the same file truth', () => {
+    const remote = path.join(tmpDir, 'behind-same-remote.git');
+    const repo = path.join(tmpDir, 'behind-same-mini-agent');
+    const peer = path.join(tmpDir, 'behind-same-peer');
+    git(tmpDir, ['init', '--bare', remote]);
+    git(tmpDir, ['clone', remote, repo]);
+    git(repo, ['config', 'user.email', 'test@example.com']);
+    git(repo, ['config', 'user.name', 'Test User']);
+    writeFileSync(path.join(repo, 'README.md'), 'base\n');
+    git(repo, ['add', 'README.md']);
+    git(repo, ['commit', '-m', 'init']);
+    git(repo, ['branch', '-M', 'runtime/main']);
+    git(repo, ['push', '-u', 'origin', 'runtime/main:main']);
+    git(repo, ['fetch', 'origin', 'main']);
+    git(repo, ['branch', '--set-upstream-to=origin/main', 'runtime/main']);
+
+    writeFileSync(path.join(repo, 'README.md'), 'base\nremote same\n');
+    git(tmpDir, ['clone', remote, peer]);
+    git(peer, ['config', 'user.email', 'test@example.com']);
+    git(peer, ['config', 'user.name', 'Test User']);
+    git(peer, ['checkout', '-b', 'main', 'origin/main']);
+    writeFileSync(path.join(peer, 'README.md'), 'base\nremote same\n');
+    git(peer, ['commit', '-am', 'remote same change']);
+    git(peer, ['push', 'origin', 'HEAD:main']);
+    git(repo, ['fetch', 'origin', 'main']);
+
+    const result = autocorrectRuntimeWorkspace(repo, {
+      apply: true,
+      createPr: false,
+      worktreeParent: tmpDir,
+    });
+
+    expect(result).toEqual(expect.objectContaining({
+      status: 'not-needed',
+      resetRuntime: true,
+    }));
+    expect(result.worktree).toBeUndefined();
+    expect(gitOut(repo, ['rev-parse', 'HEAD'])).toBe(gitOut(repo, ['rev-parse', 'origin/main']));
+    expect(gitOut(repo, ['status', '--short', '--branch'])).toContain('runtime/main...origin/main');
+  });
+
+  it('moves behind tracked dirt into an isolated worktree before syncing runtime', () => {
+    const remote = path.join(tmpDir, 'behind-dirty-remote.git');
+    const repo = path.join(tmpDir, 'behind-dirty-mini-agent');
+    const peer = path.join(tmpDir, 'behind-dirty-peer');
+    git(tmpDir, ['init', '--bare', remote]);
+    git(tmpDir, ['clone', remote, repo]);
+    git(repo, ['config', 'user.email', 'test@example.com']);
+    git(repo, ['config', 'user.name', 'Test User']);
+    writeFileSync(path.join(repo, 'README.md'), 'base\n');
+    writeFileSync(path.join(repo, 'OTHER.md'), 'base\n');
+    git(repo, ['add', 'README.md', 'OTHER.md']);
+    git(repo, ['commit', '-m', 'init']);
+    git(repo, ['branch', '-M', 'runtime/main']);
+    git(repo, ['push', '-u', 'origin', 'runtime/main:main']);
+    git(repo, ['fetch', 'origin', 'main']);
+    git(repo, ['branch', '--set-upstream-to=origin/main', 'runtime/main']);
+
+    writeFileSync(path.join(repo, 'README.md'), 'base\nlocal dirty\n');
+    git(tmpDir, ['clone', remote, peer]);
+    git(peer, ['config', 'user.email', 'test@example.com']);
+    git(peer, ['config', 'user.name', 'Test User']);
+    git(peer, ['checkout', '-b', 'main', 'origin/main']);
+    writeFileSync(path.join(peer, 'OTHER.md'), 'base\nremote change\n');
+    git(peer, ['commit', '-am', 'remote unrelated change']);
+    git(peer, ['push', 'origin', 'HEAD:main']);
+    git(repo, ['fetch', 'origin', 'main']);
+
+    const result = autocorrectRuntimeWorkspace(repo, {
+      apply: true,
+      createPr: false,
+      worktreeParent: tmpDir,
+    });
+
+    expect(result.status).toBe('created-worktree');
+    expect(gitOut(repo, ['rev-parse', 'HEAD'])).toBe(gitOut(repo, ['rev-parse', 'origin/main']));
+    expect(gitOut(repo, ['status', '--short', '--branch'])).toContain('runtime/main...origin/main');
+    expect(gitOut(result.worktree!, ['show', 'HEAD:README.md'])).toContain('local dirty');
+  });
+
   it('blocks when runtime checkout has untracked changes', () => {
     const repo = path.join(tmpDir, 'repo-untracked');
     git(tmpDir, ['init', '-b', 'runtime/main', repo]);


### PR DESCRIPTION
## Summary
- let runtime workspace autocorrect repair clean checkouts that are behind origin/main
- handle behind+tracked-dirty by syncing when origin already contains the dirty file truth
- preserve non-redundant behind+dirty changes in an isolated worktree branch before resetting runtime

## Verification
- `pnpm exec vitest run tests/runtime-workspace-autocorrect.test.ts`
- `pnpm typecheck`