### PR TITLE
fix(autonomy): close remaining runtime loops

### DIFF
--- a/src/autonomy-closure-health.ts
+++ b/src/autonomy-closure-health.ts
@@ -10,6 +10,7 @@ import { evaluatePrClosureGaps } from './pr-autopilot.js';
 import { evaluateKgExternalMemoryTruth, evaluateMemoryStateTruth } from './external-memory-health.js';
 import { evaluateMiddlewareQuality } from './middleware-quality-health.js';
 import { readClassifiedMiddlewareTaskIds } from './middleware-failure-self-healing.js';
+import { getFeature } from './features.js';
 
 export type AutonomyClosureStage =
   | 'runtime-workspace'
@@ -478,6 +479,22 @@ function memoryStateTruthStage(memoryDir: string, repoRoot: string): AutonomyClo
 }
 
 function kgContextFabricStage(memoryDir: string, now: Date): AutonomyClosureStageResult {
+  const retrieval = getFeature('kg-retrieval-augment');
+  const jit = getFeature('kg-jit-augment');
+  const push = getFeature('kg-service-push');
+  const features = [retrieval, jit, push].filter((feature): feature is Exclude<typeof feature, null> => feature !== null);
+  const disabled = features
+    .filter(feature => !feature.enabled)
+    .map(feature => feature.name);
+  if (disabled.length > 0) {
+    return {
+      stage: 'kg-context-fabric',
+      status: 'warn',
+      summary: `KG context feature(s) disabled: ${disabled.join(', ')}`,
+      evidence: disabled,
+      repair: 'Re-enable KG retrieval/JIT/push features so KG remains the shared context, classification, linking, and analysis fabric.',
+    };
+  }
   const result = evaluateKgExternalMemoryTruth(memoryDir, now);
   return {
     stage: 'kg-context-fabric',

--- a/src/dispatcher.ts
+++ b/src/dispatcher.ts
@@ -299,7 +299,7 @@ function buildSkeletonPrompt(persona: string): string {
 - <kuro:inner>state</kuro:inner> — working memory (overwrite each cycle)
 - <kuro:cycle-state>focus: ...\nintent: ...\noutcome: shipped|progressed|stalled|abandoned\nartifacts: commit:x\ncloses: cycle-xxx\nmood: 1-5 note</kuro:cycle-state> — cross-cycle continuity (→ KG → next cycle <continuity>)
 - <kuro:remember topic="t">content</kuro:remember> — save memory
-- <kuro:task-queue op="create|update|delete" type="task|goal" status="pending|in_progress|completed|abandoned|hold" id="opt" priority="opt" verify="name:pass|fail">title</kuro:task-queue>
+- <kuro:task-queue op="create|update|delete|resolve" type="task|goal" status="pending|in_progress|completed|abandoned|hold" id="opt" ids="comma,opt" priority="opt" verify="name:pass|fail">title</kuro:task-queue>
 - <kuro:show url="URL">desc</kuro:show> — TG notification
 - <kuro:fetch url="URL" /> — web fetch (max 5/cycle)
 - <kuro:plan acceptance="observable end state">goal</kuro:plan> — **primary**: brain auto-builds DAG (trivial→1-node, complex→multi-node with dependsOn). Use for any task that might decompose.
@@ -363,7 +363,7 @@ Messages must be self-contained: explicit background, specific references (msg I
 - <kuro:inner>state</kuro:inner> — working memory (overwrite each cycle)
 - <kuro:cycle-state>focus: ...\nintent: ...\noutcome: shipped|progressed|stalled|abandoned\nartifacts: commit:x\ncloses: cycle-xxx\nmood: 1-5 note</kuro:cycle-state> — cross-cycle continuity (→ KG → next cycle <continuity>)
 - <kuro:remember topic="t">content</kuro:remember> — save memory
-- <kuro:task-queue op="create|update|delete" type="task|goal" status="pending|in_progress|completed|abandoned|hold" id="opt" priority="opt" verify="name:pass|fail">title</kuro:task-queue>
+- <kuro:task-queue op="create|update|delete|resolve" type="task|goal" status="pending|in_progress|completed|abandoned|hold" id="opt" ids="comma,opt" priority="opt" verify="name:pass|fail">title</kuro:task-queue>
 - <kuro:show url="URL">desc</kuro:show> — TG notification
 - <kuro:fetch url="URL" /> — web fetch (max 5/cycle)
 - <kuro:plan acceptance="observable end state">goal</kuro:plan> — **primary**: brain auto-builds DAG (trivial→1-node, complex→multi-node with dependsOn). Use for any task that might decompose.
@@ -465,7 +465,7 @@ CT 沒在工作的信號：回覆換掉 CT 詞彙後完全等價。在下游加 
 
 - Remember: <kuro:remember>...</kuro:remember> or <kuro:remember topic="topic">...</kuro:remember>
 - Scheduled tasks: <kuro:task schedule="cron or description">task content</kuro:task>
-- Task queue: <kuro:task-queue op="create|update|delete" type="task|goal" status="pending|in_progress|completed|abandoned|hold" id="optional" origin="optional" priority="optional" verify="name:pass|fail|unknown[:detail],...">title</kuro:task-queue>
+- Task queue: <kuro:task-queue op="create|update|delete|resolve" type="task|goal" status="pending|in_progress|completed|abandoned|hold" id="optional" ids="comma,optional" origin="optional" priority="optional" verify="name:pass|fail|unknown[:detail],...">title</kuro:task-queue>
 - Show to user (sends TG notification): <kuro:show url="URL">description</kuro:show>
 
 - Use <kuro:inner>...</kuro:inner> to update working memory (scratch pad, persists across cycles). Overwrite each time with full current state. Include atmosphere note at end (conversation tone/depth).
@@ -588,7 +588,7 @@ export function parseTags(response: string): ParsedTags {
   const taskQueueActions: ParsedTags['taskQueueActions'] = [];
   for (const t of byName('kuro:task-queue')) {
     const opRaw = attr(t.attributes, 'op') ?? 'create';
-    if (!['create', 'update', 'delete'].includes(opRaw)) continue;
+    if (!['create', 'update', 'delete', 'resolve'].includes(opRaw)) continue;
     const op = opRaw as ParsedTags['taskQueueActions'][number]['op'];
     const typeRaw = attr(t.attributes, 'type');
     const statusRaw = attr(t.attributes, 'status');
@@ -614,6 +614,7 @@ export function parseTags(response: string): ParsedTags {
     taskQueueActions.push({
       op,
       id: attr(t.attributes, 'id'),
+      ids: parseIdList(attr(t.attributes, 'ids')),
       type: typeRaw === 'task' || typeRaw === 'goal' ? typeRaw : undefined,
       status: safeStatus,
       origin: attr(t.attributes, 'origin'),
@@ -937,6 +938,14 @@ export function parseTags(response: string): ParsedTags {
   return { remembers, tasks, taskQueueActions, archive, impulses, threads, chats, asks, shows, summaries, dones, progresses, delegates, plans, fetches, schedule, inner, cycleState, goal, goalQueue, goalAdvance, goalProgress, goalDone, goalAbandon, understands, directionChanges, agoraPosts, supersedes, validates, excludes, kgFeedbacks, kgPositions, pledges, goalPipeline, cleanContent };
 }
 
+function parseIdList(raw: string | undefined): string[] | undefined {
+  if (!raw) return undefined;
+  const ids = raw.split(',')
+    .map(id => id.trim())
+    .filter(Boolean);
+  return ids.length > 0 ? ids : undefined;
+}
+
 // =============================================================================
 // extractDecisionBlock — parse ## Decision header from agent response
 // =============================================================================
@@ -1258,6 +1267,43 @@ export async function postProcess(
 
   if (tags.taskQueueActions.length > 0) tagsProcessed.push('task-queue');
   for (const action of tags.taskQueueActions) {
+    if (action.op === 'resolve') {
+      const ids = [...new Set([...(action.ids ?? []), ...(action.id ? [action.id] : [])])];
+      if (ids.length === 0) {
+        slog('WARN', 'task-queue resolve skipped: no id or ids provided');
+        continue;
+      }
+      for (const id of ids) {
+        const current = queryMemoryIndexSync(memoryDir, { id, limit: 1 })[0];
+        if (!current) {
+          slog('WARN', `task-queue resolve skipped: no task found for id=${id}`);
+          continue;
+        }
+        const currentPayload = (current.payload ?? {}) as Record<string, unknown>;
+        try {
+          const updated = await updateTask(memoryDir, id, {
+            type: action.type ?? (current.type as 'task' | 'goal' | undefined),
+            title: action.title ?? current.summary,
+            status: action.status ?? 'completed',
+            origin: action.origin ?? (currentPayload.origin as string | undefined),
+            priority: action.priority ?? (currentPayload.priority as number | undefined),
+            verify: action.verify
+              ? action.verify.map(v => ({ ...v, updatedAt: new Date().toISOString() }))
+              : (currentPayload.verify as VerifyResult[] | undefined),
+            staleWarning: undefined,
+          });
+          if (updated) {
+            eventBus.emit('action:task', { content: `resolved:${id}`, entry: updated });
+          } else {
+            slog('WARN', `task-queue resolve returned null for id=${id}`);
+          }
+        } catch (err) {
+          slog('WARN', `task-queue resolve failed for id=${id}: ${err instanceof Error ? err.message : err}`);
+        }
+      }
+      continue;
+    }
+
     // Constraint Texture: stale task action gate — deferring stale tasks requires block_reason
     if (action.op === 'update' && action.status === 'hold' && action.id) {
       const target = queryMemoryIndexSync(memoryDir, { id: action.id, limit: 1 })[0];

--- a/src/github.ts
+++ b/src/github.ts
@@ -383,6 +383,21 @@ export async function autoTrackPrReviewNeeds(): Promise<void> {
   }
   const draftHandoffs = appendStaleDraftPrHandoffs(nextActiveContent, staleDrafts, today);
   nextActiveContent = draftHandoffs.content;
+  for (const pr of staleDrafts) {
+    const inboxId = writeInboxItem({
+      source: 'github',
+      from: 'system',
+      content: `Triage stale draft PR #${pr.number}: ${pr.title}`,
+      meta: {
+        prNumber: String(pr.number),
+        lifecycle: 'stale-draft',
+        createdAt: pr.createdAt ?? '',
+        updatedAt: pr.updatedAt ?? '',
+        ...(pr.url ? { url: pr.url } : {}),
+      },
+    });
+    if (inboxId) inboxCount++;
+  }
   nextActiveContent = reconcilePrReviewHandoffs(nextActiveContent, assignments);
   if (nextActiveContent !== activeContent) fs.writeFileSync(activePath, nextActiveContent, 'utf-8');
   if (newRows.length > 0 || draftHandoffs.appended > 0 || inboxCount > 0) {

--- a/src/housekeeping.ts
+++ b/src/housekeeping.ts
@@ -28,6 +28,8 @@ import { spawnDelegation } from './delegation.js';
 import { reconcileMiddlewareCommitmentsSafe } from './middleware-truth-reconciler.js';
 import { rotateDecisionLogs } from './decision-log-rotation.js';
 import { sweepMiddlewareFailures } from './middleware-failure-self-healing.js';
+import { classifyMemoryRepoPath } from './memory-repo-policy.js';
+import { getFeature, setEnabled } from './features.js';
 import type { MemoryIndexEntry } from './memory-index.js';
 import type { InboxItem, ParsedTags } from './types.js';
 
@@ -714,6 +716,10 @@ export async function runHousekeeping(): Promise<void> {
   await expireOldInboxItems().catch(() => {});
   await syncHandoffStatus().catch(() => {});
   await decayStaleTasks().catch(() => {});
+  ensureCriticalContextFeatures();
+  await snapshotExternalMemoryChanges(getMemoryRootDir()).catch(err => {
+    slog('MEMORY-SNAPSHOT', `snapshot skipped: ${err instanceof Error ? err.message : String(err)}`);
+  });
 
   // KG auto-ingest: check every 5 cycles if enough new writes have accumulated
   if (cycleCounter % 5 === 0) {
@@ -748,6 +754,70 @@ export async function runHousekeeping(): Promise<void> {
       if (removed > 0) slog('HOUSEKEEPING', `forensic gc removed ${removed} file(s)`);
     } catch { /* fail-open */ }
   }
+}
+
+export interface ExternalMemorySnapshotResult {
+  status: 'skipped' | 'committed';
+  reason?: string;
+  files: string[];
+  commit?: string;
+}
+
+export async function snapshotExternalMemoryChanges(memoryDir: string): Promise<ExternalMemorySnapshotResult> {
+  if (!fs.existsSync(path.join(memoryDir, '.git'))) {
+    return { status: 'skipped', reason: 'not a git-backed memory workspace', files: [] };
+  }
+
+  const status = await execGit(memoryDir, ['status', '--porcelain']);
+  const files = parseTrackableMemoryStatus(status.stdout);
+  if (files.length === 0) {
+    return { status: 'skipped', reason: 'no trackable curated memory changes', files: [] };
+  }
+
+  await execGit(memoryDir, ['add', '--', ...files]);
+  const staged = await execGit(memoryDir, ['diff', '--cached', '--name-only']);
+  const stagedFiles = staged.stdout.split('\n').map(line => line.trim()).filter(Boolean);
+  if (stagedFiles.length === 0) {
+    return { status: 'skipped', reason: 'no staged curated memory changes', files: [] };
+  }
+
+  await execGit(memoryDir, [
+    '-c', 'user.name=mini-agent',
+    '-c', 'user.email=mini-agent@local',
+    'commit',
+    '-m', 'chore(memory): snapshot curated state',
+  ]);
+  const commit = (await execGit(memoryDir, ['rev-parse', '--short', 'HEAD'])).stdout.trim();
+  slog('MEMORY-SNAPSHOT', `committed ${stagedFiles.length} curated memory file(s): ${commit}`);
+  return { status: 'committed', files: stagedFiles, commit };
+}
+
+function ensureCriticalContextFeatures(): void {
+  for (const name of ['kg-retrieval-augment', 'kg-jit-augment', 'kg-service-push']) {
+    const feature = getFeature(name);
+    if (feature && !feature.enabled) setEnabled(name, true);
+  }
+}
+
+function parseTrackableMemoryStatus(status: string): string[] {
+  const files = new Set<string>();
+  for (const line of status.split('\n')) {
+    if (!line.trim()) continue;
+    const rawPath = line.slice(3).trim();
+    const relPath = rawPath.includes(' -> ') ? rawPath.split(' -> ').pop()?.trim() ?? rawPath : rawPath;
+    if (!relPath || relPath.startsWith('"')) continue;
+    const classification = classifyMemoryRepoPath(relPath);
+    if (classification.track) files.add(relPath);
+  }
+  return [...files].sort();
+}
+
+async function execGit(cwd: string, args: string[]): Promise<{ stdout: string; stderr: string }> {
+  return execFileAsync('git', args, {
+    cwd,
+    encoding: 'utf-8',
+    maxBuffer: 5 * 1024 * 1024,
+  });
 }
 
 // =============================================================================

--- a/src/middleware-failure-self-healing.ts
+++ b/src/middleware-failure-self-healing.ts
@@ -41,6 +41,7 @@ export interface MiddlewareFailureClassification {
   seenAt: string;
   providerHold?: ProviderResourceHold;
   providerHoldTaskId?: string;
+  followUpTaskId?: string;
   delegationFailureSignature?: string;
 }
 
@@ -101,6 +102,7 @@ export async function classifyMiddlewareFailures(
     }, now);
 
     let providerHoldTaskId: string | undefined;
+    let followUpTaskId: string | undefined;
     let delegationStatus: DelegationFailureStatus = 'resolved';
     let resolution = `middleware failed task classified as ${bucket}`;
 
@@ -109,10 +111,17 @@ export async function classifyMiddlewareFailures(
       result.held++;
       resolution = `${resolution}; provider held until ${providerHold.resumeAt}; holdTask=${providerHoldTaskId}`;
     } else if (bucket === 'max-turns') {
-      resolution = `${resolution}; terminal max-turn failure should be retried only after task decomposition or prompt/context shrink`;
+      followUpTaskId = await ensureMiddlewareFailureFollowUpTask(memoryDir, bucket, task, now);
+      resolution = `${resolution}; created decomposition follow-up ${followUpTaskId}`;
     } else if (bucket === 'offline' || bucket === 'stall-or-timeout') {
+      followUpTaskId = await ensureMiddlewareFailureFollowUpTask(memoryDir, bucket, task, now);
       delegationStatus = 'needs_human';
-      resolution = `${resolution}; middleware lane needs operator inspection before retry`;
+      resolution = `${resolution}; created lane recovery follow-up ${followUpTaskId}`;
+    } else if (bucket === 'workspace-isolation' || bucket === 'other') {
+      followUpTaskId = await ensureMiddlewareFailureFollowUpTask(memoryDir, bucket, task, now);
+      resolution = `${resolution}; created repair follow-up ${followUpTaskId}`;
+    } else if (bucket === 'cancelled') {
+      resolution = `${resolution}; user/system cancellation treated as terminal unless it recurs`;
     }
 
     transitionDelegationFailureStatus(
@@ -131,6 +140,7 @@ export async function classifyMiddlewareFailures(
       seenAt: now.toISOString(),
       ...(providerHold ? { providerHold } : {}),
       ...(providerHoldTaskId ? { providerHoldTaskId } : {}),
+      ...(followUpTaskId ? { followUpTaskId } : {}),
       delegationFailureSignature: delegationDecision.record.signature,
     });
     result.classified++;
@@ -200,11 +210,81 @@ function parseClassification(line: string): MiddlewareFailureClassification | nu
       seenAt: raw.seenAt,
       ...(isProviderHold(raw.providerHold) ? { providerHold: raw.providerHold } : {}),
       ...(typeof raw.providerHoldTaskId === 'string' ? { providerHoldTaskId: raw.providerHoldTaskId } : {}),
+      ...(typeof raw.followUpTaskId === 'string' ? { followUpTaskId: raw.followUpTaskId } : {}),
       ...(typeof raw.delegationFailureSignature === 'string' ? { delegationFailureSignature: raw.delegationFailureSignature } : {}),
     };
   } catch {
     return null;
   }
+}
+
+async function ensureMiddlewareFailureFollowUpTask(
+  memoryDir: string,
+  bucket: MiddlewareFailureBucket,
+  task: MiddlewareTaskRecord,
+  now: Date,
+): Promise<string> {
+  const taskId = task.id ?? 'unknown';
+  const active = queryMemoryIndexSync(memoryDir, { type: ['task'], status: ['pending', 'in_progress', 'hold'] })
+    .find(entry => {
+      const payload = (entry.payload ?? {}) as Record<string, unknown>;
+      return payload.origin === 'middleware-self-healing'
+        && payload.middleware_failure_task_id === taskId
+        && payload.middleware_failure_bucket === bucket;
+    });
+  if (active) return active.id;
+
+  const plan = middlewareFailureRepairPlan(bucket, task);
+  const entry = await appendMemoryIndexEntry(memoryDir, {
+    type: 'task',
+    status: plan.status,
+    summary: plan.summary,
+    refs: [],
+    tags: ['middleware', 'self-healing', bucket],
+    payload: {
+      origin: 'middleware-self-healing',
+      middleware_failure_task_id: taskId,
+      middleware_worker: task.worker,
+      middleware_failure_bucket: bucket,
+      failed_task_excerpt: String(task.task ?? '').slice(0, 500),
+      acceptance_criteria: plan.acceptance,
+      createdAt: now.toISOString(),
+    },
+  });
+  return entry.id;
+}
+
+function middlewareFailureRepairPlan(
+  bucket: MiddlewareFailureBucket,
+  task: MiddlewareTaskRecord,
+): { status: 'pending' | 'hold'; summary: string; acceptance: string } {
+  const worker = task.worker ?? 'unknown worker';
+  if (bucket === 'max-turns') {
+    return {
+      status: 'pending',
+      summary: `Decompose middleware task ${task.id ?? 'unknown'} after max-turns failure`,
+      acceptance: 'Original delegation is split into smaller tasks or retry policy marks it terminal with evidence.',
+    };
+  }
+  if (bucket === 'offline' || bucket === 'stall-or-timeout') {
+    return {
+      status: 'pending',
+      summary: `Recover middleware ${worker} lane after ${bucket} failure`,
+      acceptance: 'Middleware lane health probe passes, circuit breaker/backoff is updated, or lane is intentionally held.',
+    };
+  }
+  if (bucket === 'workspace-isolation') {
+    return {
+      status: 'pending',
+      summary: `Repair middleware workspace isolation for task ${task.id ?? 'unknown'}`,
+      acceptance: 'Worker retry uses an isolated worktree with required dependencies or records a durable bypass policy.',
+    };
+  }
+  return {
+    status: 'pending',
+    summary: `Triage middleware failed task ${task.id ?? 'unknown'} (${bucket})`,
+    acceptance: 'Failure is assigned to a known bucket, retried safely, held with a resume condition, or closed as terminal.',
+  };
 }
 
 async function ensureProviderHoldTask(

--- a/src/types.ts
+++ b/src/types.ts
@@ -323,8 +323,9 @@ export interface ParsedTags {
   remembers: Array<{ content: string; topic?: string; ref?: string }>;
   tasks: Array<{ content: string; schedule?: string }>;
   taskQueueActions: Array<{
-    op: 'create' | 'update' | 'delete';
+    op: 'create' | 'update' | 'delete' | 'resolve';
     id?: string;
+    ids?: string[];
     type?: 'task' | 'goal';
     status?: 'pending' | 'in_progress' | 'completed' | 'abandoned' | 'hold';
     origin?: string;

--- a/tests/dispatcher.test.ts
+++ b/tests/dispatcher.test.ts
@@ -34,6 +34,7 @@ describe('parseTags', () => {
     expect(result.taskQueueActions[0]).toEqual({
       op: 'create',
       id: undefined,
+      ids: undefined,
       type: 'goal',
       status: 'in_progress',
       origin: 'perception',
@@ -43,8 +44,25 @@ describe('parseTags', () => {
         { name: 'test', status: 'unknown', detail: undefined },
       ],
       title: 'Implement queue',
+      blockReason: undefined,
     });
     expect(result.cleanContent).toBe('');
+  });
+
+  it('parses <kuro:task-queue> resolve tag with ids', () => {
+    const result = parseTags('<kuro:task-queue op="resolve" ids="idx-a, idx-b">done</kuro:task-queue>');
+    expect(result.taskQueueActions[0]).toEqual({
+      op: 'resolve',
+      id: undefined,
+      ids: ['idx-a', 'idx-b'],
+      type: undefined,
+      status: undefined,
+      origin: undefined,
+      priority: undefined,
+      verify: undefined,
+      title: 'done',
+      blockReason: undefined,
+    });
   });
 
   it('parses <kuro:chat> tags', () => {

--- a/tests/middleware-failure-self-healing.test.ts
+++ b/tests/middleware-failure-self-healing.test.ts
@@ -73,7 +73,7 @@ describe('middleware failure self-healing', () => {
     expect(readDelegationFailureRecordsSync(memoryDir)[0].frequency).toBe(1);
   });
 
-  it('classifies max-turn failures without creating provider holds', async () => {
+  it('classifies max-turn failures and creates a decomposition follow-up', async () => {
     const result = await classifyMiddlewareFailures(memoryDir, [{
       id: 'task-turns',
       worker: 'coder',
@@ -86,8 +86,11 @@ describe('middleware failure self-healing', () => {
     expect(readMiddlewareFailureClassificationsSync(memoryDir)[0]).toEqual(expect.objectContaining({
       bucket: 'max-turns',
       status: 'classified',
+      followUpTaskId: expect.any(String),
     }));
-    expect(queryMemoryIndexSync(memoryDir, { type: ['task'], status: ['hold'] })).toHaveLength(0);
+    const followUps = queryMemoryIndexSync(memoryDir, { type: ['task'], status: ['pending'] });
+    expect(followUps).toHaveLength(1);
+    expect(followUps[0].summary).toContain('Decompose middleware task task-turns');
   });
 
   it('reclassifies a known task when better error-only signal changes the bucket', async () => {


### PR DESCRIPTION
## Summary
- add first-class `kuro:task-queue op="resolve"` support so Kuro can close multiple queued tasks by id
- autosnapshot curated external memory changes and keep KG context features enabled by housekeeping
- make KG feature state visible to autonomy closure health
- convert middleware failure buckets into follow-up repair/hold tasks
- route stale draft PRs into inbox as well as handoffs so autonomous PR governance continues

## Verification
- `pnpm typecheck`
- `pnpm build`
- `pnpm test -- tests/dispatcher.test.ts tests/middleware-failure-self-healing.test.ts tests/pr-autopilot.test.ts tests/github-verification-autorepair.test.ts tests/middleware-quality-health.test.ts tests/external-memory-health.test.ts` (Vitest ran full suite: 90 files, 712 passed, 2 skipped)
- `MINI_AGENT_MEMORY_DIR=/Users/user/Workspace/mini-agent-memory/memory pnpm check:autonomy-closure -- --json` -> healthy, score 100