### PR TITLE
feat(skills): add AI-native skill orchestration

### DIFF
--- a/config/agent-capabilities.json
+++ b/config/agent-capabilities.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "policy": "Every service, server, API, public account, API key, related AI, related human, and associated external account Kuro uses must be declared here or in a KURO_AGENT_CAPABILITIES_PATH overlay before use. Store secret values outside this file; only env var names belong here.",
+  "policy": "Every service, server, API, public account, API key, related AI, related human, associated external account, skill, workflow, tool, and context fabric Kuro uses must be declared here or in a KURO_AGENT_CAPABILITIES_PATH overlay before use. Store secret values outside this file; only env var names belong here.",
   "relationships": [
     {
       "id": "alex",
@@ -158,6 +158,13 @@
       "entrypoint": "KG_BASE_URL",
       "owner": "kuro",
       "capabilities": ["context-classification", "knowledge-linking", "provenance", "cross-ai-knowledge-exchange"],
+      "contextFabric": {
+        "sources": ["memory", "handoffs", "task-events", "agent-skill-usage", "discussions"],
+        "writes": ["entities", "edges", "provenance", "skill-patterns"],
+        "learnsFrom": ["skill-usage", "middleware-events", "autonomy-closure"],
+        "sharesWith": ["kuro", "middleware", "codex-cli", "claude-code-cli"],
+        "emergenceSignals": ["cross_skill_pattern", "context_conflict", "repeated_success_path", "repeated_failure_path"]
+      },
       "readPolicy": "internal-service",
       "writePolicy": "internal-service",
       "notes": "Knowledge graph context fabric; writes must carry source-agent provenance."
@@ -222,6 +229,250 @@
       "entrypoint": "MIDDLEWARE_URL",
       "owner": "kuro",
       "capabilities": ["delegation", "worker-routing", "background-tasks", "task-events"],
+      "readPolicy": "internal-service",
+      "writePolicy": "internal-service"
+    },
+    {
+      "service": "verification-before-completion",
+      "kind": "skill",
+      "defaultExpected": "verify-before-done",
+      "expectedEnv": [],
+      "credentialEnv": [],
+      "owner": "kuro",
+      "capabilities": ["guardrail", "verification", "completion-quality"],
+      "trigger": {
+        "modes": ["task", "act", "respond"],
+        "keywords": ["done", "complete", "ship", "merge", "deploy", "完成", "部署"],
+        "signals": ["before_done", "claiming_complete"],
+        "taskTypes": ["code", "ops", "publish"],
+        "minPriority": 1
+      },
+      "requires": [],
+      "combinesWith": ["autonomy-closure-workflow"],
+      "verifier": "completion claim includes executed command, observable artifact, and current health/status evidence",
+      "contextFabric": {
+        "sources": ["memory/state/work-journal.jsonl", "autonomy-closure", "git-status"],
+        "writes": ["skill-usage", "verification-evidence"],
+        "learnsFrom": ["failed-completion-claims", "ship-truth"],
+        "sharesWith": ["kg", "autonomy-closure-workflow"],
+        "emergenceSignals": ["claim_without_verification", "repeated_success_path"]
+      },
+      "iteration": {
+        "ledger": "memory/state/skill-usage.jsonl",
+        "minUses": 3,
+        "failureThreshold": 0.25,
+        "reviewCadenceDays": 7,
+        "updatePolicy": "self-edit-skill"
+      },
+      "readPolicy": "internal-service",
+      "writePolicy": "internal-service",
+      "notes": "Guardrail skill: prevents Kuro from declaring completion before command/artifact/health verification."
+    },
+    {
+      "service": "systematic-debugging",
+      "kind": "skill",
+      "defaultExpected": "diagnose-loop",
+      "expectedEnv": [],
+      "credentialEnv": [],
+      "owner": "kuro",
+      "capabilities": ["diagnosis", "reproduction", "hypothesis-testing", "regression-test"],
+      "trigger": {
+        "modes": ["task", "act"],
+        "keywords": ["bug", "fail", "error", "broken", "regression", "debug", "diagnose", "失敗", "壞掉"],
+        "signals": ["test_failure", "runtime_error", "middleware_failure"],
+        "taskTypes": ["debug", "code", "ops"],
+        "minPriority": 1
+      },
+      "requires": ["verification-before-completion"],
+      "combinesWith": ["budget-aware-escalation", "kg-context-synthesis"],
+      "verifier": "root cause has a reproduction or falsifier, a fix, and a regression check",
+      "contextFabric": {
+        "sources": ["logs", "test-health", "KG", "work-journal"],
+        "writes": ["root-cause", "falsifier", "regression-check", "skill-usage"],
+        "learnsFrom": ["previous-diagnoses", "middleware-failures", "test-failures"],
+        "sharesWith": ["kg", "verification-before-completion"],
+        "emergenceSignals": ["repeated_failure_path", "same_root_cause_family", "context_conflict"]
+      },
+      "iteration": {
+        "ledger": "memory/state/skill-usage.jsonl",
+        "minUses": 4,
+        "failureThreshold": 0.34,
+        "reviewCadenceDays": 7,
+        "updatePolicy": "self-edit-skill"
+      },
+      "readPolicy": "internal-service",
+      "writePolicy": "internal-service"
+    },
+    {
+      "service": "budget-aware-escalation",
+      "kind": "workflow",
+      "defaultExpected": "budget-aware-escalation",
+      "expectedEnv": [],
+      "credentialEnv": [],
+      "owner": "kuro",
+      "capabilities": ["strategy-switch", "decompose", "pause-rabbit-hole", "escalate"],
+      "trigger": {
+        "modes": ["task", "act"],
+        "keywords": ["rabbit hole", "stuck", "same issue", "max turns", "quota", "budget", "燒", "卡住"],
+        "signals": ["same_task_retries>=3", "cost_cap_near", "max_turns_failure", "repeated_failure"],
+        "taskTypes": ["debug", "research", "ops"],
+        "minPriority": 1
+      },
+      "requires": ["middleware", "kg"],
+      "combinesWith": ["systematic-debugging", "task-decomposition"],
+      "verifier": "same blocker is not retried with the same method after threshold; next action is decomposed, escalated, or switched",
+      "contextFabric": {
+        "sources": ["budget-telemetry", "middleware-events", "task-events", "KG"],
+        "writes": ["strategy-switch", "decomposition-request", "skill-usage"],
+        "learnsFrom": ["max-turns-failures", "cost-cap-events", "same-task-retries"],
+        "sharesWith": ["kg", "middleware", "task-decomposition"],
+        "emergenceSignals": ["same_task_retries>=3", "max_turns_failure", "cost_cap_near", "repeated_failure_path"]
+      },
+      "iteration": {
+        "ledger": "memory/state/skill-usage.jsonl",
+        "minUses": 3,
+        "failureThreshold": 0.2,
+        "reviewCadenceDays": 3,
+        "updatePolicy": "propose-change"
+      },
+      "readPolicy": "internal-service",
+      "writePolicy": "internal-service",
+      "notes": "AI-native workflow: changes strategy when repeated attempts burn cycles/tokens without convergence."
+    },
+    {
+      "service": "task-decomposition",
+      "kind": "workflow",
+      "defaultExpected": "agent-team-task-breakdown",
+      "expectedEnv": [],
+      "credentialEnv": [],
+      "owner": "kuro",
+      "capabilities": ["pm", "task-breakdown", "acceptance-criteria", "progress-reporting"],
+      "trigger": {
+        "modes": ["task", "respond", "act"],
+        "keywords": ["做完", "完整", "分解", "需求", "進度", "pm", "team", "front", "backend", "design"],
+        "signals": ["complex_task", "multi_role_task", "unclear_acceptance"],
+        "taskTypes": ["plan", "code", "create", "ops"],
+        "minPriority": 1
+      },
+      "requires": ["kg", "middleware"],
+      "combinesWith": ["verification-before-completion", "progress-reporting"],
+      "verifier": "task has explicit subgoals, acceptance criteria, owner/role, progress state, and completion summary",
+      "contextFabric": {
+        "sources": ["inbox", "HEARTBEAT.md", "NEXT.md", "KG", "task-events"],
+        "writes": ["task-graph", "acceptance-criteria", "progress-state", "skill-usage"],
+        "learnsFrom": ["completed-task-shapes", "blocked-task-shapes", "cross-role-work"],
+        "sharesWith": ["kg", "middleware", "progress-reporting"],
+        "emergenceSignals": ["complex_task", "multi_role_task", "unclear_acceptance", "cross_skill_pattern"]
+      },
+      "iteration": {
+        "ledger": "memory/state/skill-usage.jsonl",
+        "minUses": 3,
+        "failureThreshold": 0.3,
+        "reviewCadenceDays": 7,
+        "updatePolicy": "self-edit-skill"
+      },
+      "readPolicy": "internal-service",
+      "writePolicy": "internal-service"
+    },
+    {
+      "service": "progress-reporting",
+      "kind": "skill",
+      "defaultExpected": "progress-and-summary",
+      "expectedEnv": [],
+      "credentialEnv": [],
+      "owner": "kuro",
+      "capabilities": ["progress-update", "completion-summary", "stakeholder-communication"],
+      "trigger": {
+        "modes": ["task", "respond"],
+        "keywords": ["進度", "報告", "總結", "完成", "status", "summary"],
+        "signals": ["long_running_task", "milestone_reached", "completed"],
+        "taskTypes": ["plan", "code", "ops", "create"]
+      },
+      "requires": [],
+      "combinesWith": ["task-decomposition", "verification-before-completion"],
+      "verifier": "progress update names completed artifact, current blocker if any, and next autonomous action",
+      "contextFabric": {
+        "sources": ["task-events", "work-journal", "git-status", "middleware-events"],
+        "writes": ["progress-report", "completion-summary", "skill-usage"],
+        "learnsFrom": ["user-feedback", "missed-update-events"],
+        "sharesWith": ["kg", "task-decomposition"],
+        "emergenceSignals": ["long_running_task", "milestone_reached", "completed"]
+      },
+      "iteration": {
+        "ledger": "memory/state/skill-usage.jsonl",
+        "minUses": 5,
+        "failureThreshold": 0.25,
+        "reviewCadenceDays": 7,
+        "updatePolicy": "self-edit-skill"
+      },
+      "readPolicy": "internal-service",
+      "writePolicy": "internal-service"
+    },
+    {
+      "service": "kg-context-synthesis",
+      "kind": "workflow",
+      "defaultExpected": "kg-context-synthesis",
+      "expectedEnv": [],
+      "credentialEnv": [],
+      "owner": "kuro",
+      "capabilities": ["context-retrieval", "classification", "knowledge-linking", "cross-ai-synthesis"],
+      "trigger": {
+        "modes": ["learn", "task", "reflect"],
+        "keywords": ["脈絡", "context", "kg", "knowledge", "關聯", "統整", "分析"],
+        "signals": ["context_conflict", "cross_ai_knowledge", "stale_discussion"],
+        "taskTypes": ["research", "plan", "debug"]
+      },
+      "requires": ["kg"],
+      "combinesWith": ["task-decomposition", "systematic-debugging"],
+      "verifier": "answer or task plan cites current KG/file context and records unresolved conflicts",
+      "contextFabric": {
+        "sources": ["KG", "memory/topics", "handoffs", "relations", "discussion-lifecycle"],
+        "writes": ["context-summary", "conflict-record", "knowledge-link", "skill-usage"],
+        "learnsFrom": ["cross-ai-knowledge", "stale-discussions", "context-conflicts"],
+        "sharesWith": ["kg", "systematic-debugging", "task-decomposition"],
+        "emergenceSignals": ["context_conflict", "cross_ai_knowledge", "stale_discussion", "cross_skill_pattern"]
+      },
+      "iteration": {
+        "ledger": "memory/state/skill-usage.jsonl",
+        "minUses": 3,
+        "failureThreshold": 0.34,
+        "reviewCadenceDays": 7,
+        "updatePolicy": "propose-change"
+      },
+      "readPolicy": "internal-service",
+      "writePolicy": "internal-service"
+    },
+    {
+      "service": "autonomy-closure-workflow",
+      "kind": "workflow",
+      "defaultExpected": "autonomy-closure",
+      "expectedEnv": [],
+      "credentialEnv": [],
+      "owner": "kuro",
+      "capabilities": ["health-gate", "self-repair", "ship-truth", "memory-truth", "middleware-quality"],
+      "trigger": {
+        "modes": ["act", "task"],
+        "keywords": ["closure", "healthy", "blocked", "degraded", "閉環", "健康"],
+        "signals": ["autonomy_closure_blocked", "autonomy_closure_degraded", "before_deploy"],
+        "taskTypes": ["ops", "code"]
+      },
+      "requires": ["kg", "middleware", "verification-before-completion"],
+      "combinesWith": ["budget-aware-escalation", "progress-reporting"],
+      "verifier": "GET /api/dashboard/autonomy-closure reports no blocking stages and no unresolved repair task",
+      "contextFabric": {
+        "sources": ["health-endpoints", "KG", "middleware", "memory-state-truth", "ship-truth"],
+        "writes": ["closure-snapshot", "repair-task", "skill-usage"],
+        "learnsFrom": ["closure-regressions", "phantom-tasks", "deploy-results"],
+        "sharesWith": ["kg", "middleware", "verification-before-completion"],
+        "emergenceSignals": ["autonomy_closure_blocked", "autonomy_closure_degraded", "phantom_task", "repeated_success_path"]
+      },
+      "iteration": {
+        "ledger": "memory/state/skill-usage.jsonl",
+        "minUses": 3,
+        "failureThreshold": 0.2,
+        "reviewCadenceDays": 3,
+        "updatePolicy": "self-edit-skill"
+      },
       "readPolicy": "internal-service",
       "writePolicy": "internal-service"
     }

--- a/src/agent-owned-identity.ts
+++ b/src/agent-owned-identity.ts
@@ -16,10 +16,41 @@ export interface AgentCapabilitySpec {
   entrypoint?: string;
   owner?: string;
   capabilities?: string[];
+  trigger?: AgentSkillTriggerSpec;
+  requires?: string[];
+  combinesWith?: string[];
+  verifier?: string;
+  iteration?: AgentSkillIterationSpec;
+  contextFabric?: AgentContextFabricSpec;
   readPolicy: AgentInboundPolicy;
   writePolicy: AgentOutboundPolicy;
   profileUrl?: string;
   notes?: string;
+}
+
+export interface AgentSkillTriggerSpec {
+  modes?: string[];
+  keywords?: string[];
+  signals?: string[];
+  taskTypes?: string[];
+  minPriority?: number;
+}
+
+export interface AgentSkillIterationSpec {
+  ledger?: string;
+  reviewCadenceDays?: number;
+  minUses?: number;
+  failureThreshold?: number;
+  staleAfterDays?: number;
+  updatePolicy?: 'self-edit-skill' | 'propose-change' | 'disable-on-failure' | 'human-review';
+}
+
+export interface AgentContextFabricSpec {
+  sources?: string[];
+  writes?: string[];
+  learnsFrom?: string[];
+  sharesWith?: string[];
+  emergenceSignals?: string[];
 }
 
 interface AgentCapabilityRegistryFile {
@@ -57,6 +88,12 @@ export interface AgentOwnedIdentity {
   entrypoint?: string;
   owner?: string;
   capabilities: string[];
+  trigger?: AgentSkillTriggerSpec;
+  requires: string[];
+  combinesWith: string[];
+  verifier?: string;
+  iteration?: AgentSkillIterationSpec;
+  contextFabric?: AgentContextFabricSpec;
   profileUrl?: string;
   actor: 'kuro';
   inboundReads: AgentInboundPolicy;
@@ -226,6 +263,12 @@ export function getAgentOwnedIdentity(
     entrypoint: spec.entrypoint,
     owner: spec.owner,
     capabilities: spec.capabilities ?? [],
+    trigger: spec.trigger,
+    requires: spec.requires ?? [],
+    combinesWith: spec.combinesWith ?? [],
+    verifier: spec.verifier,
+    iteration: spec.iteration,
+    contextFabric: spec.contextFabric,
     profileUrl: spec.profileUrl,
     actor: 'kuro',
     inboundReads: spec.readPolicy,
@@ -327,6 +370,12 @@ function mergeCapabilitySpec(base: AgentCapabilitySpec, patch: AgentCapabilitySp
     expectedEnv: patch.expectedEnv.length > 0 ? patch.expectedEnv : base.expectedEnv,
     credentialEnv: patch.credentialEnv.length > 0 ? patch.credentialEnv : base.credentialEnv,
     capabilities: patch.capabilities && patch.capabilities.length > 0 ? patch.capabilities : base.capabilities,
+    trigger: patch.trigger ?? base.trigger,
+    requires: patch.requires && patch.requires.length > 0 ? patch.requires : base.requires,
+    combinesWith: patch.combinesWith && patch.combinesWith.length > 0 ? patch.combinesWith : base.combinesWith,
+    verifier: patch.verifier ?? base.verifier,
+    iteration: patch.iteration ?? base.iteration,
+    contextFabric: patch.contextFabric ?? base.contextFabric,
   };
 }
 
@@ -356,11 +405,61 @@ function validateCapabilitySpec(raw: AgentCapabilitySpec, registryPath: string):
     entrypoint: raw.entrypoint,
     owner: raw.owner,
     capabilities: Array.isArray(raw.capabilities) ? raw.capabilities.filter(Boolean) : [],
+    trigger: validateTriggerSpec(raw.trigger, raw.service),
+    requires: Array.isArray(raw.requires) ? raw.requires.filter(Boolean) : [],
+    combinesWith: Array.isArray(raw.combinesWith) ? raw.combinesWith.filter(Boolean) : [],
+    verifier: raw.verifier,
+    iteration: validateIterationSpec(raw.iteration, raw.service),
+    contextFabric: validateContextFabricSpec(raw.contextFabric, raw.service),
     readPolicy: raw.readPolicy,
     writePolicy: raw.writePolicy,
     profileUrl: raw.profileUrl,
     notes: raw.notes,
   };
+}
+
+function validateContextFabricSpec(raw: AgentContextFabricSpec | undefined, service: string): AgentContextFabricSpec | undefined {
+  if (raw === undefined) return undefined;
+  if (!raw || typeof raw !== 'object') throw new Error(`invalid capability ${service}: contextFabric must be an object`);
+  return {
+    sources: Array.isArray(raw.sources) ? raw.sources.filter(Boolean) : [],
+    writes: Array.isArray(raw.writes) ? raw.writes.filter(Boolean) : [],
+    learnsFrom: Array.isArray(raw.learnsFrom) ? raw.learnsFrom.filter(Boolean) : [],
+    sharesWith: Array.isArray(raw.sharesWith) ? raw.sharesWith.filter(Boolean) : [],
+    emergenceSignals: Array.isArray(raw.emergenceSignals) ? raw.emergenceSignals.filter(Boolean) : [],
+  };
+}
+
+function validateTriggerSpec(raw: AgentSkillTriggerSpec | undefined, service: string): AgentSkillTriggerSpec | undefined {
+  if (raw === undefined) return undefined;
+  if (!raw || typeof raw !== 'object') throw new Error(`invalid capability ${service}: trigger must be an object`);
+  return {
+    modes: Array.isArray(raw.modes) ? raw.modes.filter(Boolean) : [],
+    keywords: Array.isArray(raw.keywords) ? raw.keywords.map(k => String(k).toLowerCase()).filter(Boolean) : [],
+    signals: Array.isArray(raw.signals) ? raw.signals.filter(Boolean) : [],
+    taskTypes: Array.isArray(raw.taskTypes) ? raw.taskTypes.filter(Boolean) : [],
+    minPriority: typeof raw.minPriority === 'number' ? raw.minPriority : undefined,
+  };
+}
+
+function validateIterationSpec(raw: AgentSkillIterationSpec | undefined, service: string): AgentSkillIterationSpec | undefined {
+  if (raw === undefined) return undefined;
+  if (!raw || typeof raw !== 'object') throw new Error(`invalid capability ${service}: iteration must be an object`);
+  if (raw.updatePolicy && !['self-edit-skill', 'propose-change', 'disable-on-failure', 'human-review'].includes(raw.updatePolicy)) {
+    throw new Error(`invalid capability ${service}: iteration.updatePolicy is invalid`);
+  }
+  return {
+    ledger: raw.ledger,
+    reviewCadenceDays: numberOrUndefined(raw.reviewCadenceDays),
+    minUses: numberOrUndefined(raw.minUses),
+    failureThreshold: numberOrUndefined(raw.failureThreshold),
+    staleAfterDays: numberOrUndefined(raw.staleAfterDays),
+    updatePolicy: raw.updatePolicy,
+  };
+}
+
+function numberOrUndefined(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
 }
 
 function validateRelationshipSpec(raw: AgentRelationshipSpec, registryPath: string): AgentRelationshipSpec {

--- a/src/agent-skill-manager.ts
+++ b/src/agent-skill-manager.ts
@@ -1,0 +1,270 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import {
+  type AgentCapabilitySpec,
+  type AgentOwnedIdentity,
+  listAgentCapabilities,
+} from './agent-owned-identity.js';
+
+export interface SkillSelectionInput {
+  hint?: string;
+  mode?: string;
+  signals?: string[];
+  contextSignals?: string[];
+  taskType?: string;
+  priority?: number;
+  limit?: number;
+}
+
+export interface SkillSelectionItem {
+  service: string;
+  kind: AgentOwnedIdentity['kind'];
+  score: number;
+  reasons: string[];
+  requires: string[];
+  combinesWith: string[];
+  verifier?: string;
+  contextFabric?: AgentOwnedIdentity['contextFabric'];
+}
+
+export interface SkillSelectionResult {
+  selected: SkillSelectionItem[];
+  blocked: Array<{ service: string; missing: string[] }>;
+  available: string[];
+}
+
+export interface SkillUsageEvent {
+  skill: string;
+  outcome: 'success' | 'failure' | 'blocked' | 'superseded';
+  taskId?: string;
+  mode?: string;
+  combinedWith?: string[];
+  verifier?: string;
+  note?: string;
+  ts?: string;
+}
+
+export interface SkillHealthSummary {
+  skill: string;
+  uses: number;
+  success: number;
+  failure: number;
+  blocked: number;
+  lastUsedAt?: string;
+  failureRate: number;
+  status: 'healthy' | 'watch' | 'iterate' | 'unused';
+  suggestion?: string;
+}
+
+const LEDGER_FILE = 'skill-usage.jsonl';
+
+export function listManagedSkills(env: NodeJS.ProcessEnv = process.env): AgentOwnedIdentity[] {
+  return listAgentCapabilities(env).filter(cap => {
+    return (cap.kind === 'skill' || cap.kind === 'workflow') && cap.status === 'active';
+  });
+}
+
+export function selectAgentSkills(
+  input: SkillSelectionInput,
+  env: NodeJS.ProcessEnv = process.env,
+): SkillSelectionResult {
+  const all = listAgentCapabilities(env);
+  const activeNames = new Set(all.filter(cap => cap.status === 'active').map(cap => cap.service));
+  const candidates = all.filter(cap => (cap.kind === 'skill' || cap.kind === 'workflow') && cap.status === 'active');
+  const lowerHint = (input.hint ?? '').toLowerCase();
+  const inputSignals = new Set((input.signals ?? []).map(s => s.toLowerCase()));
+  const contextSignals = new Set((input.contextSignals ?? []).map(s => s.toLowerCase()));
+  const blocked: SkillSelectionResult['blocked'] = [];
+
+  const scored = candidates.map(skill => {
+    const missing = skill.requires.filter(req => !activeNames.has(req));
+    if (missing.length > 0) blocked.push({ service: skill.service, missing });
+    const reasons: string[] = [];
+    let score = 0;
+    const trigger = skill.trigger;
+
+    if (trigger?.modes?.length && input.mode && trigger.modes.includes(input.mode)) {
+      score += 25;
+      reasons.push(`mode:${input.mode}`);
+    }
+    for (const keyword of trigger?.keywords ?? []) {
+      if (lowerHint.includes(keyword.toLowerCase())) {
+        score += 10;
+        reasons.push(`keyword:${keyword}`);
+      }
+    }
+    for (const signal of trigger?.signals ?? []) {
+      if (inputSignals.has(signal.toLowerCase())) {
+        score += 18;
+        reasons.push(`signal:${signal}`);
+      }
+    }
+    for (const signal of skill.contextFabric?.emergenceSignals ?? []) {
+      if (contextSignals.has(signal.toLowerCase()) || inputSignals.has(signal.toLowerCase())) {
+        score += 14;
+        reasons.push(`context:${signal}`);
+      }
+    }
+    for (const source of skill.contextFabric?.sources ?? []) {
+      if (lowerHint.includes(source.toLowerCase())) {
+        score += 6;
+        reasons.push(`context-source:${source}`);
+      }
+    }
+    if (trigger?.taskTypes?.length && input.taskType && trigger.taskTypes.includes(input.taskType)) {
+      score += 16;
+      reasons.push(`taskType:${input.taskType}`);
+    }
+    if (typeof trigger?.minPriority === 'number' && typeof input.priority === 'number' && input.priority <= trigger.minPriority) {
+      score += 12;
+      reasons.push(`priority<=${trigger.minPriority}`);
+    }
+    if (skill.kind === 'workflow' && score > 0) score += 5;
+    if (!trigger && lowerHint.includes(skill.service.toLowerCase())) {
+      score += 8;
+      reasons.push('name-match');
+    }
+    if (missing.length > 0) score = 0;
+
+    return toSelectionItem(skill, score, reasons);
+  }).filter(item => item.score > 0);
+
+  const byName = new Map(scored.map(item => [item.service, item]));
+  for (const item of [...scored]) {
+    for (const partner of item.combinesWith) {
+      if (byName.has(partner) || !activeNames.has(partner)) continue;
+      const partnerCap = candidates.find(skill => skill.service === partner);
+      if (!partnerCap) continue;
+      const partnerItem = toSelectionItem(partnerCap, Math.max(1, Math.floor(item.score / 2)), [`combined-with:${item.service}`]);
+      byName.set(partner, partnerItem);
+    }
+  }
+
+  const selected = [...byName.values()]
+    .sort((a, b) => b.score - a.score || a.service.localeCompare(b.service))
+    .slice(0, input.limit ?? 5);
+
+  return {
+    selected,
+    blocked,
+    available: candidates.map(skill => skill.service).sort(),
+  };
+}
+
+export function buildAgentSkillOrchestrationPrompt(env: NodeJS.ProcessEnv = process.env): string {
+  const skills = listManagedSkills(env);
+  if (skills.length === 0) return '';
+  const rows = skills.map(skill => {
+    const trigger = [
+      ...(skill.trigger?.modes ?? []).map(x => `mode:${x}`),
+      ...(skill.trigger?.signals ?? []).map(x => `signal:${x}`),
+      ...(skill.trigger?.keywords ?? []).slice(0, 4).map(x => `kw:${x}`),
+    ].join(',') || 'manual/contextual';
+    const combo = skill.combinesWith.length > 0 ? `; combines=${skill.combinesWith.join(',')}` : '';
+    const verifier = skill.verifier ? `; verifier=${skill.verifier}` : '';
+    const fabric = skill.contextFabric?.sources?.length
+      ? `; context=${skill.contextFabric.sources.join(',')}`
+      : '';
+    return `- ${skill.service}: trigger=${trigger}${combo}${fabric}${verifier}`;
+  });
+  return [
+    '## AI-Native Skill Orchestration',
+    'Skills/workflows are managed capabilities, not static instructions. Select the smallest useful set, combine declared partners when their triggers align, and avoid running isolated skills when a workflow can close the loop.',
+    'KG and file context are the context fabric for skills: use KG/file signals to select skills, write outcomes back to memory/KG ledgers, and let repeated cross-skill patterns become new or revised capabilities.',
+    'After using a managed skill, leave observable evidence and record/enable iteration when the verifier fails, repeated use does not improve outcomes, or multiple skills reveal a reusable emergent pattern.',
+    ...rows,
+  ].join('\n');
+}
+
+export function recordSkillUsage(memoryDir: string, event: SkillUsageEvent): SkillUsageEvent {
+  const normalized: SkillUsageEvent = {
+    ...event,
+    skill: event.skill.trim(),
+    ts: event.ts ?? new Date().toISOString(),
+    combinedWith: event.combinedWith ?? [],
+  };
+  if (!normalized.skill) throw new Error('skill is required');
+  const filePath = skillUsageLedgerPath(memoryDir);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.appendFileSync(filePath, JSON.stringify(normalized) + '\n', 'utf-8');
+  return normalized;
+}
+
+export function readSkillUsage(memoryDir: string): SkillUsageEvent[] {
+  const filePath = skillUsageLedgerPath(memoryDir);
+  if (!fs.existsSync(filePath)) return [];
+  const events: SkillUsageEvent[] = [];
+  for (const line of fs.readFileSync(filePath, 'utf-8').split('\n')) {
+    if (!line.trim()) continue;
+    try {
+      const parsed = JSON.parse(line) as SkillUsageEvent;
+      if (parsed.skill && parsed.outcome) events.push(parsed);
+    } catch {
+      // Ignore malformed telemetry; health remains best-effort.
+    }
+  }
+  return events;
+}
+
+export function summarizeSkillHealth(
+  memoryDir: string,
+  env: NodeJS.ProcessEnv = process.env,
+): SkillHealthSummary[] {
+  const events = readSkillUsage(memoryDir);
+  const bySkill = new Map<string, SkillUsageEvent[]>();
+  for (const event of events) {
+    const list = bySkill.get(event.skill) ?? [];
+    list.push(event);
+    bySkill.set(event.skill, list);
+  }
+
+  return listManagedSkills(env).map(skill => {
+    const list = bySkill.get(skill.service) ?? [];
+    const uses = list.length;
+    const success = list.filter(event => event.outcome === 'success').length;
+    const failure = list.filter(event => event.outcome === 'failure').length;
+    const blocked = list.filter(event => event.outcome === 'blocked').length;
+    const failureRate = uses > 0 ? (failure + blocked) / uses : 0;
+    const threshold = skill.iteration?.failureThreshold ?? 0.34;
+    const minUses = skill.iteration?.minUses ?? 3;
+    const lastUsedAt = list.map(event => event.ts).filter(Boolean).sort().at(-1);
+    let status: SkillHealthSummary['status'] = 'healthy';
+    let suggestion: string | undefined;
+    if (uses === 0) {
+      status = 'unused';
+      suggestion = 'No ledger evidence yet; use only when trigger matches and record outcome.';
+    } else if (uses >= minUses && failureRate >= threshold) {
+      status = 'iterate';
+      suggestion = iterationSuggestion(skill, failureRate);
+    } else if (failureRate > 0) {
+      status = 'watch';
+      suggestion = 'Some failed/blocked outcomes; keep recording verifier evidence.';
+    }
+    return { skill: skill.service, uses, success, failure, blocked, lastUsedAt, failureRate, status, suggestion };
+  });
+}
+
+function toSelectionItem(skill: AgentOwnedIdentity, score: number, reasons: string[]): SkillSelectionItem {
+  return {
+    service: skill.service,
+    kind: skill.kind,
+    score,
+    reasons,
+    requires: skill.requires,
+    combinesWith: skill.combinesWith,
+    verifier: skill.verifier,
+    contextFabric: skill.contextFabric,
+  };
+}
+
+function skillUsageLedgerPath(memoryDir: string): string {
+  return path.join(memoryDir, 'state', LEDGER_FILE);
+}
+
+function iterationSuggestion(skill: AgentOwnedIdentity, failureRate: number): string {
+  const policy = skill.iteration?.updatePolicy ?? 'propose-change';
+  if (policy === 'disable-on-failure') return `Failure rate ${failureRate.toFixed(2)} exceeds threshold; disable or replace this capability overlay before further autonomous use.`;
+  if (policy === 'self-edit-skill') return `Failure rate ${failureRate.toFixed(2)} exceeds threshold; revise the skill/workflow instructions and verifier, then record a new trial.`;
+  if (policy === 'human-review') return `Failure rate ${failureRate.toFixed(2)} exceeds threshold; escalate for Alex review before changing behavior.`;
+  return `Failure rate ${failureRate.toFixed(2)} exceeds threshold; propose a registry/skill update with verifier evidence.`;
+}

--- a/src/api.ts
+++ b/src/api.ts
@@ -177,6 +177,7 @@ import { syncMyelinToKnowledge } from './myelin-kg-sync.js';
 import { readActorOutcomeStatsSync } from './actor-outcome-stats.js';
 import type { WorkIntent } from './brain-types.js';
 import { listAgentCapabilities, loadAgentRelationshipRegistry } from './agent-owned-identity.js';
+import { selectAgentSkills, summarizeSkillHealth } from './agent-skill-manager.js';
 
 // =============================================================================
 // Server Log Helper (re-exported from utils to avoid circular deps)
@@ -946,7 +947,7 @@ export function createApi(port = 3001): express.Express {
   app.use(createRateLimiter());
 
   // Request logging middleware (skip noisy polling endpoints)
-  const SILENT_PATHS = new Set(['/health', '/status', '/api/dashboard/behaviors', '/api/dashboard/learning', '/api/dashboard/journal', '/api/dashboard/cognition', '/api/dashboard/capabilities', '/api/dashboard/agent-arsenal', '/api/dashboard/context', '/api/dashboard/inner-state', '/api/dashboard/work-closure', '/api/events', '/api/room/stream', '/api/memory/structured', '/api/memory/history', '/api/memory/files']);
+  const SILENT_PATHS = new Set(['/health', '/status', '/api/dashboard/behaviors', '/api/dashboard/learning', '/api/dashboard/journal', '/api/dashboard/cognition', '/api/dashboard/capabilities', '/api/dashboard/agent-arsenal', '/api/dashboard/agent-skills/select', '/api/dashboard/context', '/api/dashboard/inner-state', '/api/dashboard/work-closure', '/api/events', '/api/room/stream', '/api/memory/structured', '/api/memory/history', '/api/memory/files']);
   app.use((req: Request, res: Response, next: NextFunction) => {
     if (SILENT_PATHS.has(req.path)) { next(); return; }
     const start = Date.now();
@@ -2581,9 +2582,23 @@ export function createApi(port = 3001): express.Express {
     res.json({
       capabilities: listAgentCapabilities(),
       relationships: loadAgentRelationshipRegistry(),
+      skillHealth: summarizeSkillHealth(getMemoryRootDir()),
       registryPath: process.env.KURO_AGENT_CAPABILITIES_PATH || 'config/agent-capabilities.json',
       policy: 'new services/servers/APIs/tools/accounts/related AIs or humans must be registry-managed before use',
     });
+  });
+
+  app.get('/api/dashboard/agent-skills/select', (req: Request, res: Response) => {
+    const signals = String(req.query.signals ?? '').split(',').map(s => s.trim()).filter(Boolean);
+    const contextSignals = String(req.query.contextSignals ?? '').split(',').map(s => s.trim()).filter(Boolean);
+    res.json(selectAgentSkills({
+      hint: String(req.query.hint ?? ''),
+      mode: typeof req.query.mode === 'string' ? req.query.mode : undefined,
+      signals,
+      contextSignals,
+      taskType: typeof req.query.taskType === 'string' ? req.query.taskType : undefined,
+      priority: typeof req.query.priority === 'string' ? Number(req.query.priority) : undefined,
+    }));
   });
 
   // Forge slots — worktree allocation health for dashboard tile (W7 F-d)

--- a/src/prompt-builder.ts
+++ b/src/prompt-builder.ts
@@ -23,6 +23,7 @@ import { readState } from './feedback-loops.js';
 import { slog } from './utils.js';
 import { getActiveDelegationSummaries } from './delegation.js';
 import { buildAgentOwnedIdentityPrompt, buildAgentRelationshipPrompt } from './agent-owned-identity.js';
+import { buildAgentSkillOrchestrationPrompt } from './agent-skill-manager.js';
 
 // =============================================================================
 // Cycle Responsibility Guide — Observe→Act→Gate thinking structure
@@ -212,6 +213,7 @@ ${taskStatusLine}
 ${cycleResponsibilityGuide}
 ${buildAgentOwnedIdentityPrompt()}
 ${buildAgentRelationshipPrompt()}
+${buildAgentSkillOrchestrationPrompt()}
 ${focusSection}${reflectNudge}${avoidList}
 
 ## Response Format
@@ -257,6 +259,7 @@ ${taskStatusLine}
 ${cycleResponsibilityGuide}
 ${buildAgentOwnedIdentityPrompt()}
 ${buildAgentRelationshipPrompt()}
+${buildAgentSkillOrchestrationPrompt()}
 ${avoidList}
 
 ## 做正事

--- a/tests/agent-owned-identity.test.ts
+++ b/tests/agent-owned-identity.test.ts
@@ -120,6 +120,17 @@ describe('agent-owned identity boundary', () => {
           credentialEnv: [],
           entrypoint: 'pnpm exec playwright',
           capabilities: ['browser-test', 'screenshot'],
+          trigger: { keywords: ['browser'], signals: ['visual_check'] },
+          requires: ['browser-cdp'],
+          combinesWith: ['verification-before-completion'],
+          verifier: 'screenshot captured',
+          contextFabric: {
+            sources: ['KG', 'screenshots'],
+            writes: ['visual-evidence'],
+            learnsFrom: ['visual-regressions'],
+            sharesWith: ['kg'],
+            emergenceSignals: ['visual_regression'],
+          },
           readPolicy: 'internal-service',
           writePolicy: 'internal-service',
         },
@@ -153,6 +164,13 @@ describe('agent-owned identity boundary', () => {
       kind: 'tool',
       entrypoint: 'pnpm exec playwright',
       capabilities: ['browser-test', 'screenshot'],
+      requires: ['browser-cdp'],
+      combinesWith: ['verification-before-completion'],
+      verifier: 'screenshot captured',
+      contextFabric: expect.objectContaining({
+        sources: ['KG', 'screenshots'],
+        emergenceSignals: ['visual_regression'],
+      }),
     }));
     expect(getAgentOwnedIdentity('linkedin', env)).toEqual(expect.objectContaining({
       expected: 'kuro-agent',

--- a/tests/agent-skill-manager.test.ts
+++ b/tests/agent-skill-manager.test.ts
@@ -1,0 +1,170 @@
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  buildAgentSkillOrchestrationPrompt,
+  listManagedSkills,
+  recordSkillUsage,
+  selectAgentSkills,
+  summarizeSkillHealth,
+} from '../src/agent-skill-manager.js';
+
+function registryFile(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'skill-manager-registry-'));
+  const registryPath = join(dir, 'agent-capabilities.json');
+  writeFileSync(registryPath, JSON.stringify({
+    version: 1,
+    capabilities: [
+      {
+        service: 'kg',
+        kind: 'api',
+        defaultExpected: 'kg',
+        expectedEnv: [],
+        credentialEnv: [],
+        readPolicy: 'internal-service',
+        writePolicy: 'internal-service',
+      },
+      {
+        service: 'debug-loop',
+        kind: 'skill',
+        defaultExpected: 'debug-loop',
+        expectedEnv: [],
+        credentialEnv: [],
+        capabilities: ['debug'],
+        trigger: {
+          modes: ['task'],
+          keywords: ['bug', 'failure'],
+          signals: ['test_failure'],
+          taskTypes: ['debug'],
+          minPriority: 1,
+        },
+        requires: ['kg'],
+        combinesWith: ['budget-escalation'],
+        verifier: 'reproduction plus regression test',
+        contextFabric: {
+          sources: ['KG', 'logs'],
+          writes: ['root-cause', 'skill-usage'],
+          learnsFrom: ['previous-diagnoses'],
+          sharesWith: ['kg'],
+          emergenceSignals: ['same_root_cause_family'],
+        },
+        iteration: {
+          ledger: 'memory/state/skill-usage.jsonl',
+          minUses: 2,
+          failureThreshold: 0.5,
+          updatePolicy: 'self-edit-skill',
+        },
+        readPolicy: 'internal-service',
+        writePolicy: 'internal-service',
+      },
+      {
+        service: 'budget-escalation',
+        kind: 'workflow',
+        defaultExpected: 'budget-escalation',
+        expectedEnv: [],
+        credentialEnv: [],
+        trigger: {
+          signals: ['max_turns_failure'],
+          keywords: ['stuck'],
+        },
+        contextFabric: {
+          emergenceSignals: ['repeated_failure_path'],
+        },
+        readPolicy: 'internal-service',
+        writePolicy: 'internal-service',
+      },
+      {
+        service: 'blocked-skill',
+        kind: 'skill',
+        defaultExpected: 'blocked-skill',
+        expectedEnv: [],
+        credentialEnv: [],
+        trigger: { keywords: ['blocked'] },
+        requires: ['missing-tool'],
+        readPolicy: 'internal-service',
+        writePolicy: 'internal-service',
+      },
+    ],
+  }), 'utf-8');
+  return registryPath;
+}
+
+describe('agent skill manager', () => {
+  it('selects matching skills and declared collaborators', () => {
+    const env = { KURO_AGENT_CAPABILITIES_PATH: registryFile() } as NodeJS.ProcessEnv;
+    const result = selectAgentSkills({
+      hint: 'debug this bug failure',
+      mode: 'task',
+      signals: ['test_failure'],
+      taskType: 'debug',
+      priority: 0,
+    }, env);
+
+    expect(result.selected.map(item => item.service)).toEqual(['debug-loop', 'budget-escalation']);
+    expect(result.selected[0]).toEqual(expect.objectContaining({
+      verifier: 'reproduction plus regression test',
+      contextFabric: expect.objectContaining({
+        sources: ['KG', 'logs'],
+        writes: ['root-cause', 'skill-usage'],
+      }),
+    }));
+  });
+
+  it('uses KG/context emergence signals as trigger input', () => {
+    const env = { KURO_AGENT_CAPABILITIES_PATH: registryFile() } as NodeJS.ProcessEnv;
+    const result = selectAgentSkills({
+      contextSignals: ['same_root_cause_family'],
+    }, env);
+
+    expect(result.selected[0]).toEqual(expect.objectContaining({
+      service: 'debug-loop',
+      reasons: expect.arrayContaining(['context:same_root_cause_family']),
+    }));
+  });
+
+  it('reports blocked skills with missing dependencies', () => {
+    const env = { KURO_AGENT_CAPABILITIES_PATH: registryFile() } as NodeJS.ProcessEnv;
+    const result = selectAgentSkills({ hint: 'blocked' }, env);
+
+    expect(result.selected.some(item => item.service === 'blocked-skill')).toBe(false);
+    expect(result.blocked).toEqual(expect.arrayContaining([
+      { service: 'blocked-skill', missing: ['missing-tool'] },
+    ]));
+  });
+
+  it('summarizes usage health for self-iteration', () => {
+    const env = { KURO_AGENT_CAPABILITIES_PATH: registryFile() } as NodeJS.ProcessEnv;
+    const memoryDir = mkdtempSync(join(tmpdir(), 'skill-manager-memory-'));
+
+    recordSkillUsage(memoryDir, { skill: 'debug-loop', outcome: 'failure', note: 'no reproduction' });
+    recordSkillUsage(memoryDir, { skill: 'debug-loop', outcome: 'blocked', note: 'missing logs' });
+
+    expect(summarizeSkillHealth(memoryDir, env)).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        skill: 'debug-loop',
+        uses: 2,
+        status: 'iterate',
+        suggestion: expect.stringContaining('revise the skill/workflow instructions'),
+      }),
+    ]));
+  });
+
+  it('renders skill orchestration prompt with context fabric', () => {
+    const env = { KURO_AGENT_CAPABILITIES_PATH: registryFile() } as NodeJS.ProcessEnv;
+    const prompt = buildAgentSkillOrchestrationPrompt(env);
+
+    expect(prompt).toContain('AI-Native Skill Orchestration');
+    expect(prompt).toContain('KG and file context are the context fabric');
+    expect(prompt).toContain('debug-loop');
+    expect(prompt).toContain('context=KG,logs');
+  });
+
+  it('lists only active skill and workflow capabilities as managed skills', () => {
+    const env = { KURO_AGENT_CAPABILITIES_PATH: registryFile() } as NodeJS.ProcessEnv;
+    expect(listManagedSkills(env).map(skill => skill.service)).toEqual(expect.arrayContaining([
+      'debug-loop',
+      'budget-escalation',
+    ]));
+  });
+});


### PR DESCRIPTION
## Summary
- add managed skill/workflow metadata to the agent arsenal registry: triggers, dependencies, collaborators, verifiers, iteration policy, and KG/file context fabric
- add skill selector that can combine compatible skills and use KG/context emergence signals as trigger inputs
- add skill usage ledger helpers and health summaries for self-iteration
- expose skill health and skill selection through dashboard APIs
- inject AI-native skill orchestration contract into autonomous prompts

## Verification
- pnpm exec vitest run tests/agent-skill-manager.test.ts tests/agent-owned-identity.test.ts tests/github-identity.test.ts
- pnpm typecheck
- pnpm build