### PR TITLE
feat(skills): promote Constraint Texture patterns

### DIFF
--- a/config/agent-capabilities.json
+++ b/config/agent-capabilities.json
@@ -233,6 +233,42 @@
       "writePolicy": "internal-service"
     },
     {
+      "service": "constraint-texture-analysis",
+      "kind": "workflow",
+      "defaultExpected": "constraint-texture",
+      "expectedEnv": [],
+      "credentialEnv": [],
+      "owner": "kuro",
+      "capabilities": ["token-roi-analysis", "waste-pattern-detection", "tension-navigation", "closed-loop-design", "capability-promotion"],
+      "trigger": {
+        "modes": ["reflect", "task", "act"],
+        "keywords": ["Constraint Texture", "token", "浪費", "空轉", "phantom", "PR 累積", "閉環", "效率", "pattern", "tension", "tradeoff", "stakeholder", "衝突", "張力", "取捨", "需求理解"],
+        "signals": ["no_action_cycles", "token_waste", "phantom_task", "pr_backlog", "middleware_failure", "requirement_tension", "stakeholder_conflict", "understanding_bottleneck", "repeated_success_path", "repeated_failure_path"],
+        "taskTypes": ["ops", "research", "plan", "debug", "design"],
+        "minPriority": 1
+      },
+      "requires": ["kg", "verification-before-completion"],
+      "combinesWith": ["kg-context-synthesis", "budget-aware-escalation", "task-decomposition", "autonomy-closure-workflow"],
+      "verifier": "analysis identifies thick/thin texture, names the highest-leverage constraint, and either closes it or records a promotion/repair candidate with evidence",
+      "contextFabric": {
+        "sources": ["KG", "skill-usage", "task-events", "middleware-events", "work-journal", "github-prs", "autonomy-closure"],
+        "writes": ["constraint-texture-report", "waste-pattern", "capability-promotion-candidate", "skill-usage"],
+        "learnsFrom": ["token-spend", "no-action-cycles", "phantom-tasks", "pr-backlog", "successful-repairs", "constraint-texture-paper:/Users/user/Workspace/constraint-texture-paper"],
+        "sharesWith": ["kg", "budget-aware-escalation", "task-decomposition", "autonomy-closure-workflow"],
+        "emergenceSignals": ["token_waste", "thin_texture_cycle", "requirement_tension", "stakeholder_conflict", "understanding_bottleneck", "cross_skill_pattern", "repeated_success_path", "repeated_failure_path"]
+      },
+      "iteration": {
+        "ledger": "memory/state/skill-usage.jsonl",
+        "minUses": 3,
+        "failureThreshold": 0.25,
+        "reviewCadenceDays": 3,
+        "updatePolicy": "self-edit-skill"
+      },
+      "readPolicy": "internal-service",
+      "writePolicy": "internal-service",
+      "notes": "Dogfood workflow grounded in /Users/user/Workspace/constraint-texture-paper. Use CT when understanding, integration, stakeholder tension, or competing requirements are the bottleneck. Prefer prescriptions/scripts/code when the task is deterministic, enumerative, safety-critical, or a known procedure."
+    },
+    {
       "service": "verification-before-completion",
       "kind": "skill",
       "defaultExpected": "verify-before-done",

--- a/src/agent-skill-manager.ts
+++ b/src/agent-skill-manager.ts
@@ -36,8 +36,11 @@ export interface SkillSelectionResult {
 export interface SkillUsageEvent {
   skill: string;
   outcome: 'success' | 'failure' | 'blocked' | 'superseded';
+  pattern?: string;
   taskId?: string;
   mode?: string;
+  savedTokensEstimate?: number;
+  savedMinutesEstimate?: number;
   combinedWith?: string[];
   verifier?: string;
   note?: string;
@@ -54,6 +57,25 @@ export interface SkillHealthSummary {
   failureRate: number;
   status: 'healthy' | 'watch' | 'iterate' | 'unused';
   suggestion?: string;
+}
+
+export interface PatternPromotionCandidate {
+  pattern: string;
+  uses: number;
+  successRate: number;
+  savedTokensEstimate: number;
+  savedMinutesEstimate: number;
+  skills: string[];
+  recommendedKind: 'skill' | 'workflow' | 'tool' | 'script' | 'cli' | 'code';
+  rationale: string[];
+  suggestedCapability: {
+    service: string;
+    kind: AgentOwnedIdentity['kind'] | 'script' | 'cli' | 'code';
+    capabilities: string[];
+    requires: string[];
+    combinesWith: string[];
+    verifier: string;
+  };
 }
 
 const LEDGER_FILE = 'skill-usage.jsonl';
@@ -172,6 +194,7 @@ export function buildAgentSkillOrchestrationPrompt(env: NodeJS.ProcessEnv = proc
     'Skills/workflows are managed capabilities, not static instructions. Select the smallest useful set, combine declared partners when their triggers align, and avoid running isolated skills when a workflow can close the loop.',
     'KG and file context are the context fabric for skills: use KG/file signals to select skills, write outcomes back to memory/KG ledgers, and let repeated cross-skill patterns become new or revised capabilities.',
     'After using a managed skill, leave observable evidence and record/enable iteration when the verifier fails, repeated use does not improve outcomes, or multiple skills reveal a reusable emergent pattern.',
+    'Promotion rule: repeated high-success patterns should become the most efficient capability form: skill for judgment, workflow for multi-step coordination, script/CLI for deterministic operations, code for always-on runtime behavior, or a hybrid when both judgment and execution are needed.',
     ...rows,
   ].join('\n');
 }
@@ -244,6 +267,62 @@ export function summarizeSkillHealth(
   });
 }
 
+export function suggestPatternPromotions(
+  memoryDir: string,
+  env: NodeJS.ProcessEnv = process.env,
+): PatternPromotionCandidate[] {
+  const events = readSkillUsage(memoryDir).filter(event => event.pattern?.trim());
+  const byPattern = new Map<string, SkillUsageEvent[]>();
+  for (const event of events) {
+    const key = normalizePattern(event.pattern ?? '');
+    if (!key) continue;
+    const list = byPattern.get(key) ?? [];
+    list.push(event);
+    byPattern.set(key, list);
+  }
+
+  const active = new Set(listAgentCapabilities(env).map(cap => cap.service));
+  const candidates: PatternPromotionCandidate[] = [];
+  for (const [pattern, list] of byPattern) {
+    const uses = list.length;
+    const success = list.filter(event => event.outcome === 'success').length;
+    const successRate = uses > 0 ? success / uses : 0;
+    const savedTokensEstimate = sum(list.map(event => event.savedTokensEstimate));
+    const savedMinutesEstimate = sum(list.map(event => event.savedMinutesEstimate));
+    if (uses < 3 || successRate < 0.67) continue;
+
+    const skills = unique(list.flatMap(event => [event.skill, ...(event.combinedWith ?? [])]));
+    const recommendedKind = choosePromotionKind(pattern, list, savedTokensEstimate, savedMinutesEstimate);
+    const service = `pattern-${slugify(pattern)}`;
+    if (active.has(service)) continue;
+    const rationale = promotionRationale(recommendedKind, uses, successRate, savedTokensEstimate, savedMinutesEstimate);
+    candidates.push({
+      pattern,
+      uses,
+      successRate,
+      savedTokensEstimate,
+      savedMinutesEstimate,
+      skills,
+      recommendedKind,
+      rationale,
+      suggestedCapability: {
+        service,
+        kind: recommendedKind === 'script' || recommendedKind === 'cli' || recommendedKind === 'code' ? 'tool' : recommendedKind,
+        capabilities: ['promoted-pattern', recommendedKind, ...skills.slice(0, 4)],
+        requires: skills.filter(skill => active.has(skill)),
+        combinesWith: skills.filter(skill => active.has(skill)).slice(0, 4),
+        verifier: `pattern "${pattern}" keeps successRate >= 0.67 over next 3 uses and reduces repeated reasoning/tool overhead`,
+      },
+    });
+  }
+
+  return candidates.sort((a, b) => {
+    const aValue = a.uses * a.successRate + a.savedTokensEstimate / 10_000 + a.savedMinutesEstimate / 60;
+    const bValue = b.uses * b.successRate + b.savedTokensEstimate / 10_000 + b.savedMinutesEstimate / 60;
+    return bValue - aValue;
+  });
+}
+
 function toSelectionItem(skill: AgentOwnedIdentity, score: number, reasons: string[]): SkillSelectionItem {
   return {
     service: skill.service,
@@ -267,4 +346,51 @@ function iterationSuggestion(skill: AgentOwnedIdentity, failureRate: number): st
   if (policy === 'self-edit-skill') return `Failure rate ${failureRate.toFixed(2)} exceeds threshold; revise the skill/workflow instructions and verifier, then record a new trial.`;
   if (policy === 'human-review') return `Failure rate ${failureRate.toFixed(2)} exceeds threshold; escalate for Alex review before changing behavior.`;
   return `Failure rate ${failureRate.toFixed(2)} exceeds threshold; propose a registry/skill update with verifier evidence.`;
+}
+
+function choosePromotionKind(
+  pattern: string,
+  events: SkillUsageEvent[],
+  savedTokensEstimate: number,
+  savedMinutesEstimate: number,
+): PatternPromotionCandidate['recommendedKind'] {
+  const text = `${pattern} ${events.map(event => event.note ?? '').join(' ')}`.toLowerCase();
+  const skills = unique(events.flatMap(event => [event.skill, ...(event.combinedWith ?? [])]));
+  if (/(deterministic|repeatable|shell|curl|git|json|parse|format|deploy|snapshot|固定|重複|可腳本)/i.test(text)) {
+    return savedMinutesEstimate >= 30 || savedTokensEstimate >= 10_000 ? 'cli' : 'script';
+  }
+  if (/(always-on|runtime|gate|health|scheduler|autonomy|自動|常駐|閉環)/i.test(text)) return 'code';
+  if (skills.length >= 3 || /(multi-step|pipeline|workflow|handoff|協作|多步)/i.test(text)) return 'workflow';
+  return 'skill';
+}
+
+function promotionRationale(
+  kind: PatternPromotionCandidate['recommendedKind'],
+  uses: number,
+  successRate: number,
+  savedTokensEstimate: number,
+  savedMinutesEstimate: number,
+): string[] {
+  return [
+    `${uses} repeated use(s) with successRate=${successRate.toFixed(2)}`,
+    ...(savedTokensEstimate > 0 ? [`estimated token savings=${Math.round(savedTokensEstimate)}`] : []),
+    ...(savedMinutesEstimate > 0 ? [`estimated time savings=${Math.round(savedMinutesEstimate)}m`] : []),
+    `recommended as ${kind} because that is the lowest-overhead durable form for this pattern`,
+  ];
+}
+
+function normalizePattern(pattern: string): string {
+  return pattern.trim().replace(/\s+/g, ' ').slice(0, 160);
+}
+
+function slugify(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 72) || 'unnamed';
+}
+
+function sum(values: Array<number | undefined>): number {
+  return values.reduce<number>((total, value) => total + (typeof value === 'number' && Number.isFinite(value) ? value : 0), 0);
+}
+
+function unique(values: string[]): string[] {
+  return [...new Set(values.map(value => value.trim()).filter(Boolean))];
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -177,7 +177,7 @@ import { syncMyelinToKnowledge } from './myelin-kg-sync.js';
 import { readActorOutcomeStatsSync } from './actor-outcome-stats.js';
 import type { WorkIntent } from './brain-types.js';
 import { listAgentCapabilities, loadAgentRelationshipRegistry } from './agent-owned-identity.js';
-import { selectAgentSkills, summarizeSkillHealth } from './agent-skill-manager.js';
+import { selectAgentSkills, summarizeSkillHealth, suggestPatternPromotions } from './agent-skill-manager.js';
 
 // =============================================================================
 // Server Log Helper (re-exported from utils to avoid circular deps)
@@ -947,7 +947,7 @@ export function createApi(port = 3001): express.Express {
   app.use(createRateLimiter());
 
   // Request logging middleware (skip noisy polling endpoints)
-  const SILENT_PATHS = new Set(['/health', '/status', '/api/dashboard/behaviors', '/api/dashboard/learning', '/api/dashboard/journal', '/api/dashboard/cognition', '/api/dashboard/capabilities', '/api/dashboard/agent-arsenal', '/api/dashboard/agent-skills/select', '/api/dashboard/context', '/api/dashboard/inner-state', '/api/dashboard/work-closure', '/api/events', '/api/room/stream', '/api/memory/structured', '/api/memory/history', '/api/memory/files']);
+  const SILENT_PATHS = new Set(['/health', '/status', '/api/dashboard/behaviors', '/api/dashboard/learning', '/api/dashboard/journal', '/api/dashboard/cognition', '/api/dashboard/capabilities', '/api/dashboard/agent-arsenal', '/api/dashboard/agent-skills/select', '/api/dashboard/agent-skills/promotions', '/api/dashboard/context', '/api/dashboard/inner-state', '/api/dashboard/work-closure', '/api/events', '/api/room/stream', '/api/memory/structured', '/api/memory/history', '/api/memory/files']);
   app.use((req: Request, res: Response, next: NextFunction) => {
     if (SILENT_PATHS.has(req.path)) { next(); return; }
     const start = Date.now();
@@ -2583,6 +2583,7 @@ export function createApi(port = 3001): express.Express {
       capabilities: listAgentCapabilities(),
       relationships: loadAgentRelationshipRegistry(),
       skillHealth: summarizeSkillHealth(getMemoryRootDir()),
+      patternPromotions: suggestPatternPromotions(getMemoryRootDir()),
       registryPath: process.env.KURO_AGENT_CAPABILITIES_PATH || 'config/agent-capabilities.json',
       policy: 'new services/servers/APIs/tools/accounts/related AIs or humans must be registry-managed before use',
     });
@@ -2599,6 +2600,14 @@ export function createApi(port = 3001): express.Express {
       taskType: typeof req.query.taskType === 'string' ? req.query.taskType : undefined,
       priority: typeof req.query.priority === 'string' ? Number(req.query.priority) : undefined,
     }));
+  });
+
+  app.get('/api/dashboard/agent-skills/promotions', (_req: Request, res: Response) => {
+    res.json({
+      promotions: suggestPatternPromotions(getMemoryRootDir()),
+      ledger: 'memory/state/skill-usage.jsonl',
+      policy: 'Repeated high-success patterns should be promoted into the lowest-overhead durable form: skill, workflow, script, CLI, code, or hybrid capability.',
+    });
   });
 
   // Forge slots — worktree allocation health for dashboard tile (W7 F-d)

--- a/tests/agent-skill-manager.test.ts
+++ b/tests/agent-skill-manager.test.ts
@@ -8,6 +8,7 @@ import {
   recordSkillUsage,
   selectAgentSkills,
   summarizeSkillHealth,
+  suggestPatternPromotions,
 } from '../src/agent-skill-manager.js';
 
 function registryFile(): string {
@@ -22,6 +23,36 @@ function registryFile(): string {
         defaultExpected: 'kg',
         expectedEnv: [],
         credentialEnv: [],
+        readPolicy: 'internal-service',
+        writePolicy: 'internal-service',
+      },
+      {
+        service: 'constraint-texture-analysis',
+        kind: 'workflow',
+        defaultExpected: 'constraint-texture',
+        expectedEnv: [],
+        credentialEnv: [],
+        capabilities: ['token-roi-analysis', 'capability-promotion'],
+        trigger: {
+          modes: ['reflect', 'task'],
+          keywords: ['Constraint Texture', 'token', 'phantom', '空轉', 'tension', 'stakeholder', '取捨'],
+          signals: ['token_waste', 'phantom_task', 'requirement_tension', 'stakeholder_conflict', 'understanding_bottleneck'],
+          taskTypes: ['ops', 'design'],
+        },
+        requires: ['kg'],
+        combinesWith: ['debug-loop', 'budget-escalation'],
+        verifier: 'names thick/thin texture and records a promotion candidate',
+        contextFabric: {
+          sources: ['KG', 'skill-usage', 'task-events'],
+          writes: ['constraint-texture-report', 'capability-promotion-candidate'],
+          emergenceSignals: ['token_waste', 'thin_texture_cycle', 'requirement_tension', 'stakeholder_conflict', 'understanding_bottleneck', 'cross_skill_pattern'],
+        },
+        iteration: {
+          ledger: 'memory/state/skill-usage.jsonl',
+          minUses: 3,
+          failureThreshold: 0.25,
+          updatePolicy: 'self-edit-skill',
+        },
         readPolicy: 'internal-service',
         writePolicy: 'internal-service',
       },
@@ -101,7 +132,7 @@ describe('agent skill manager', () => {
       priority: 0,
     }, env);
 
-    expect(result.selected.map(item => item.service)).toEqual(['debug-loop', 'budget-escalation']);
+    expect(result.selected.map(item => item.service)).toEqual(expect.arrayContaining(['debug-loop', 'budget-escalation']));
     expect(result.selected[0]).toEqual(expect.objectContaining({
       verifier: 'reproduction plus regression test',
       contextFabric: expect.objectContaining({
@@ -120,6 +151,46 @@ describe('agent skill manager', () => {
     expect(result.selected[0]).toEqual(expect.objectContaining({
       service: 'debug-loop',
       reasons: expect.arrayContaining(['context:same_root_cause_family']),
+    }));
+  });
+
+  it('selects Constraint Texture for token waste and phantom task analysis', () => {
+    const env = { KURO_AGENT_CAPABILITIES_PATH: registryFile() } as NodeJS.ProcessEnv;
+    const result = selectAgentSkills({
+      hint: 'Constraint Texture 看 token 浪費和 phantom task',
+      mode: 'reflect',
+      signals: ['token_waste', 'phantom_task'],
+      taskType: 'ops',
+    }, env);
+
+    expect(result.selected.map(item => item.service)).toEqual(expect.arrayContaining([
+      'constraint-texture-analysis',
+      'debug-loop',
+      'budget-escalation',
+    ]));
+    expect(result.selected[0]).toEqual(expect.objectContaining({
+      service: 'constraint-texture-analysis',
+      contextFabric: expect.objectContaining({
+        writes: ['constraint-texture-report', 'capability-promotion-candidate'],
+      }),
+    }));
+  });
+
+  it('selects Constraint Texture when requirements are in tension', () => {
+    const env = { KURO_AGENT_CAPABILITIES_PATH: registryFile() } as NodeJS.ProcessEnv;
+    const result = selectAgentSkills({
+      hint: 'stakeholder tension and 需求取捨，需要理解瓶頸',
+      mode: 'reflect',
+      signals: ['requirement_tension', 'stakeholder_conflict', 'understanding_bottleneck'],
+      taskType: 'design',
+    }, env);
+
+    expect(result.selected[0]).toEqual(expect.objectContaining({
+      service: 'constraint-texture-analysis',
+      reasons: expect.arrayContaining([
+        'signal:requirement_tension',
+        'context:stakeholder_conflict',
+      ]),
     }));
   });
 
@@ -157,14 +228,68 @@ describe('agent skill manager', () => {
     expect(prompt).toContain('AI-Native Skill Orchestration');
     expect(prompt).toContain('KG and file context are the context fabric');
     expect(prompt).toContain('debug-loop');
+    expect(prompt).toContain('constraint-texture-analysis');
     expect(prompt).toContain('context=KG,logs');
+    expect(prompt).toContain('Promotion rule');
   });
 
   it('lists only active skill and workflow capabilities as managed skills', () => {
     const env = { KURO_AGENT_CAPABILITIES_PATH: registryFile() } as NodeJS.ProcessEnv;
     expect(listManagedSkills(env).map(skill => skill.service)).toEqual(expect.arrayContaining([
+      'constraint-texture-analysis',
       'debug-loop',
       'budget-escalation',
     ]));
+  });
+
+  it('promotes repeated deterministic patterns into script or CLI candidates', () => {
+    const env = { KURO_AGENT_CAPABILITIES_PATH: registryFile() } as NodeJS.ProcessEnv;
+    const memoryDir = mkdtempSync(join(tmpdir(), 'skill-manager-memory-'));
+
+    for (let i = 0; i < 3; i += 1) {
+      recordSkillUsage(memoryDir, {
+        skill: 'constraint-texture-analysis',
+        outcome: 'success',
+        pattern: 'deterministic git deploy lock health snapshot',
+        savedTokensEstimate: 4_000,
+        savedMinutesEstimate: 12,
+        combinedWith: ['budget-escalation'],
+        note: 'repeatable shell/git/json health snapshot',
+      });
+    }
+
+    expect(suggestPatternPromotions(memoryDir, env)[0]).toEqual(expect.objectContaining({
+      pattern: 'deterministic git deploy lock health snapshot',
+      recommendedKind: 'cli',
+      suggestedCapability: expect.objectContaining({
+        service: 'pattern-deterministic-git-deploy-lock-health-snapshot',
+        kind: 'tool',
+        requires: expect.arrayContaining(['constraint-texture-analysis', 'budget-escalation']),
+      }),
+    }));
+  });
+
+  it('promotes repeated always-on guardrail patterns into runtime code candidates', () => {
+    const env = { KURO_AGENT_CAPABILITIES_PATH: registryFile() } as NodeJS.ProcessEnv;
+    const memoryDir = mkdtempSync(join(tmpdir(), 'skill-manager-memory-'));
+
+    for (let i = 0; i < 3; i += 1) {
+      recordSkillUsage(memoryDir, {
+        skill: 'constraint-texture-analysis',
+        outcome: 'success',
+        pattern: 'always-on autonomy health gate for phantom task suppression',
+        savedTokensEstimate: 2_000,
+        combinedWith: ['debug-loop', 'budget-escalation'],
+        note: 'runtime gate should close loop automatically',
+      });
+    }
+
+    expect(suggestPatternPromotions(memoryDir, env)[0]).toEqual(expect.objectContaining({
+      recommendedKind: 'code',
+      suggestedCapability: expect.objectContaining({
+        kind: 'tool',
+        verifier: expect.stringContaining('successRate >= 0.67'),
+      }),
+    }));
   });
 });


### PR DESCRIPTION
## Summary
- dogfoods Constraint Texture as a managed AI-native workflow grounded in `/Users/user/Workspace/constraint-texture-paper`
- adds pattern promotion telemetry so repeated successful skill usage can become skill/workflow/script/CLI/runtime-code candidates
- exposes promotion candidates through `/api/dashboard/agent-arsenal` and `/api/dashboard/agent-skills/promotions`

## Verification
- `python3 -m json.tool config/agent-capabilities.json >/dev/null`
- `pnpm exec vitest run tests/agent-skill-manager.test.ts tests/agent-owned-identity.test.ts tests/github-identity.test.ts`
- `pnpm typecheck && pnpm build`
