### PR TITLE
feat(skills): close runtime skill usage loop

### DIFF
--- a/src/agent-skill-manager.ts
+++ b/src/agent-skill-manager.ts
@@ -33,6 +33,16 @@ export interface SkillSelectionResult {
   available: string[];
 }
 
+export interface SkillRuntimeSelectionInput {
+  hint?: string;
+  mode?: string;
+  trigger?: string | null;
+  context?: string;
+  taskType?: string;
+  priority?: number;
+  limit?: number;
+}
+
 export interface SkillUsageEvent {
   skill: string;
   outcome: 'success' | 'failure' | 'blocked' | 'superseded';
@@ -146,6 +156,12 @@ export function selectAgentSkills(
       score += 8;
       reasons.push('name-match');
     }
+    if (skill.service === 'constraint-texture-analysis'
+      && isKnownProcedureSlot(lowerHint)
+      && !hasConstraintTexturePositiveSignal(inputSignals, contextSignals, lowerHint)) {
+      score = 0;
+      reasons.push('suppressed:known-procedure-slot');
+    }
     if (missing.length > 0) score = 0;
 
     return toSelectionItem(skill, score, reasons);
@@ -196,6 +212,57 @@ export function buildAgentSkillOrchestrationPrompt(env: NodeJS.ProcessEnv = proc
     'After using a managed skill, leave observable evidence and record/enable iteration when the verifier fails, repeated use does not improve outcomes, or multiple skills reveal a reusable emergent pattern.',
     'Promotion rule: repeated high-success patterns should become the most efficient capability form: skill for judgment, workflow for multi-step coordination, script/CLI for deterministic operations, code for always-on runtime behavior, or a hybrid when both judgment and execution are needed.',
     ...rows,
+  ].join('\n');
+}
+
+export function inferSkillSelectionInput(input: SkillRuntimeSelectionInput): SkillSelectionInput {
+  const text = `${input.hint ?? ''}\n${input.trigger ?? ''}\n${input.context ?? ''}`.toLowerCase();
+  const signals = new Set<string>();
+  const contextSignals = new Set<string>();
+
+  addSignalIf(signals, /(token|cost|budget|浪費|空轉|no[- ]?action)/i, text, 'token_waste');
+  addSignalIf(signals, /(phantom|re[- ]?inject|stale task|重派|重生)/i, text, 'phantom_task');
+  addSignalIf(signals, /(pr backlog|pull request|review consensus|pr 累積|open pr)/i, text, 'pr_backlog');
+  addSignalIf(signals, /(middleware|delegate|worker|max[- ]?turns|stall|timeout)/i, text, 'middleware_failure');
+  addSignalIf(signals, /(max[- ]?turns|same task|retry|重試|卡住)/i, text, 'same_task_retries>=3');
+  addSignalIf(signals, /(test failure|vitest|tsc|typecheck|regression|failing test)/i, text, 'test_failure');
+  addSignalIf(signals, /(closure|autonomy|blocked|degraded|閉環)/i, text, 'autonomy_closure_blocked');
+  addSignalIf(signals, /(tension|tradeoff|stakeholder|conflict|competing requirement|張力|取捨|衝突)/i, text, 'requirement_tension');
+  addSignalIf(signals, /(complete|done|merge|deploy|ship|完成|部署)/i, text, 'before_done');
+
+  addSignalIf(contextSignals, /(same root cause|same_root_cause|root cause family)/i, text, 'same_root_cause_family');
+  addSignalIf(contextSignals, /(context conflict|conflicting context|脈絡衝突)/i, text, 'context_conflict');
+  addSignalIf(contextSignals, /(cross[- ]?skill|emergent|湧現|協作)/i, text, 'cross_skill_pattern');
+  addSignalIf(contextSignals, /(understanding bottleneck|理解瓶頸|需求理解)/i, text, 'understanding_bottleneck');
+  addSignalIf(contextSignals, /(stakeholder|利害關係|最受影響)/i, text, 'stakeholder_conflict');
+
+  return {
+    hint: input.hint,
+    mode: input.mode,
+    signals: [...signals],
+    contextSignals: [...contextSignals],
+    taskType: input.taskType ?? inferTaskType(text),
+    priority: input.priority,
+    limit: input.limit,
+  };
+}
+
+export function buildSelectedSkillPrompt(selection: SkillSelectionResult): string {
+  if (selection.selected.length === 0 && selection.blocked.length === 0) return '';
+  const selected = selection.selected.map(skill => {
+    const combo = skill.combinesWith.length > 0 ? `; use-with=${skill.combinesWith.join(',')}` : '';
+    const verifier = skill.verifier ? `; verifier=${skill.verifier}` : '';
+    return `- ${skill.service} (${skill.kind}, score=${skill.score}): reasons=${skill.reasons.join(',')}${combo}${verifier}`;
+  });
+  const blocked = selection.blocked.length > 0
+    ? ['Blocked managed skills:', ...selection.blocked.map(skill => `- ${skill.service}: missing=${skill.missing.join(',')}`)]
+    : [];
+  return [
+    '## Selected Managed Skills For This Cycle',
+    'Use these only if they still fit the observed task. If none fit, do the work normally and avoid forcing a skill.',
+    ...selected,
+    ...blocked,
+    'At cycle end, runtime records selected-skill usage automatically; leave concrete verifier evidence in the normal action/progress output.',
   ].join('\n');
 }
 
@@ -393,4 +460,32 @@ function sum(values: Array<number | undefined>): number {
 
 function unique(values: string[]): string[] {
   return [...new Set(values.map(value => value.trim()).filter(Boolean))];
+}
+
+function addSignalIf(target: Set<string>, pattern: RegExp, text: string, signal: string): void {
+  if (pattern.test(text)) target.add(signal);
+}
+
+function inferTaskType(text: string): string | undefined {
+  if (/(tension|stakeholder|tradeoff|設計|design|需求|取捨)/i.test(text)) return 'design';
+  if (/(bug|debug|fail|error|regression|root cause|壞掉|失敗)/i.test(text)) return 'debug';
+  if (/(deploy|health|runtime|middleware|closure|scheduler|ops|部署|閉環)/i.test(text)) return 'ops';
+  if (/(code|test|typecheck|build|src\/|\.ts\b|\.js\b)/i.test(text)) return 'code';
+  if (/(research|paper|arxiv|論文|研究)/i.test(text)) return 'research';
+  if (/(plan|prd|task|分解|規劃)/i.test(text)) return 'plan';
+  return undefined;
+}
+
+function isKnownProcedureSlot(text: string): boolean {
+  return /(return json|json with fields|schema|format only|deterministic|known procedure|checklist|enumerat|type signature|api contract|固定格式|已知程序|列舉|格式)/i.test(text);
+}
+
+function hasConstraintTexturePositiveSignal(inputSignals: Set<string>, contextSignals: Set<string>, hint: string): boolean {
+  return inputSignals.has('requirement_tension')
+    || inputSignals.has('token_waste')
+    || inputSignals.has('phantom_task')
+    || contextSignals.has('understanding_bottleneck')
+    || contextSignals.has('stakeholder_conflict')
+    || contextSignals.has('cross_skill_pattern')
+    || /(constraint texture|tension|tradeoff|stakeholder|understanding bottleneck|張力|取捨|理解瓶頸)/i.test(hint);
 }

--- a/src/autonomy-closure-notifier.ts
+++ b/src/autonomy-closure-notifier.ts
@@ -1,0 +1,73 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+export interface AutonomyClosureNotificationSnapshot {
+  status: string;
+  score: number;
+  blockingStages: string[];
+  warningStages: string[];
+  recommendedTask: {
+    title: string;
+    acceptanceCriteria?: string;
+  } | null;
+  stages: Array<{
+    stage: string;
+    status: string;
+    summary: string;
+    evidence?: string[];
+  }>;
+}
+
+export function autonomyClosureSignature(snapshot: AutonomyClosureNotificationSnapshot): string {
+  return JSON.stringify({
+    status: snapshot.status,
+    blockingStages: snapshot.blockingStages,
+    warningStages: snapshot.warningStages,
+    recommendedTask: snapshot.recommendedTask?.title ?? null,
+  });
+}
+
+export function shouldNotifyAutonomyClosureBlock(
+  snapshot: AutonomyClosureNotificationSnapshot,
+  previousSignature: string | null,
+): boolean {
+  if (snapshot.blockingStages.length === 0) return false;
+  return autonomyClosureSignature(snapshot) !== previousSignature;
+}
+
+export function buildAutonomyClosureBlockMessage(snapshot: AutonomyClosureNotificationSnapshot): string {
+  const blocking = snapshot.blockingStages.join(', ') || 'none';
+  const warnings = snapshot.warningStages.length > 0 ? snapshot.warningStages.join(', ') : 'none';
+  const evidence = snapshot.blockingStages
+    .map(stageName => snapshot.stages.find(stage => stage.stage === stageName))
+    .filter(Boolean)
+    .map(stage => `- ${stage!.stage}: ${stage!.summary}${stage!.evidence?.[0] ? ` — ${stage!.evidence[0]}` : ''}`);
+  return [
+    `⚠️ Autonomy closure blocked (score ${snapshot.score})`,
+    `blocking: ${blocking}`,
+    `warnings: ${warnings}`,
+    snapshot.recommendedTask ? `next: ${snapshot.recommendedTask.title}` : null,
+    ...evidence,
+  ].filter(Boolean).join('\n');
+}
+
+export function readAutonomyClosureNotificationSignature(stateDir: string): string | null {
+  const filePath = notificationStatePath(stateDir);
+  try {
+    if (!fs.existsSync(filePath)) return null;
+    const parsed = JSON.parse(fs.readFileSync(filePath, 'utf-8')) as { signature?: string };
+    return typeof parsed.signature === 'string' ? parsed.signature : null;
+  } catch {
+    return null;
+  }
+}
+
+export function writeAutonomyClosureNotificationSignature(stateDir: string, signature: string): void {
+  const filePath = notificationStatePath(stateDir);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify({ signature, updatedAt: new Date().toISOString() }, null, 2), 'utf-8');
+}
+
+function notificationStatePath(stateDir: string): string {
+  return path.join(stateDir, 'autonomy-closure-notifier.json');
+}

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -117,6 +117,20 @@ import { routeInboxItems } from './task-graph.js';
 import { triageRouting, logTriageBypass } from './myelin-fleet.js';
 import { initSharedKnowledge, observe as kbObserve, getKnowledgeSummary } from './shared-knowledge.js';
 import type { Phase0Results } from './preprocess.js';
+import {
+  buildSelectedSkillPrompt,
+  inferSkillSelectionInput,
+  recordSkillUsage,
+  selectAgentSkills,
+  type SkillSelectionResult,
+} from './agent-skill-manager.js';
+import {
+  autonomyClosureSignature,
+  buildAutonomyClosureBlockMessage,
+  readAutonomyClosureNotificationSignature,
+  shouldNotifyAutonomyClosureBlock,
+  writeAutonomyClosureNotificationSignature,
+} from './autonomy-closure-notifier.js';
 
 // =============================================================================
 // Types
@@ -212,6 +226,72 @@ function clearForegroundDelegation(taskId: string): void {
       fs.writeFileSync(fpath, JSON.stringify(remaining, null, 2));
     }
   } catch { /* fire-and-forget */ }
+}
+
+function recordRuntimeSkillUsage(input: {
+  memoryDir: string;
+  selection: SkillSelectionResult;
+  cycle: number;
+  mode: string;
+  action: string | null;
+  tags: string[];
+  sideEffects: string[];
+  error?: string;
+}): void {
+  if (input.selection.selected.length === 0) return;
+  const hasObservableWork = Boolean(input.action) || input.tags.length > 0 || input.sideEffects.length > 0;
+  const outcome = input.error
+    ? 'blocked'
+    : hasObservableWork
+      ? 'success'
+      : 'failure';
+  const pattern = inferRuntimeSkillPattern(input.selection, input.action, input.tags);
+  for (const skill of input.selection.selected) {
+    try {
+      recordSkillUsage(input.memoryDir, {
+        skill: skill.service,
+        outcome,
+        pattern,
+        taskId: `cycle-${input.cycle}`,
+        mode: input.mode,
+        combinedWith: skill.combinesWith,
+        verifier: skill.verifier,
+        note: [
+          `cycle=${input.cycle}`,
+          `reasons=${skill.reasons.join(',')}`,
+          input.error ? `error=${input.error}` : null,
+          input.action ? `action=${input.action.slice(0, 160)}` : null,
+          input.tags.length > 0 ? `tags=${input.tags.join(',')}` : null,
+        ].filter(Boolean).join(' | '),
+      });
+    } catch (err) {
+      slog('SKILL', `usage ledger write failed for ${skill.service}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+}
+
+function inferRuntimeSkillPattern(selection: SkillSelectionResult, action: string | null, tags: string[]): string {
+  const top = selection.selected[0];
+  const tagPart = tags.length > 0 ? tags.join('+').toLowerCase() : 'no-tags';
+  const actionPart = action
+    ? action.toLowerCase().replace(/https?:\/\/\S+/g, '').replace(/[^a-z0-9\u4e00-\u9fff]+/g, ' ').trim().slice(0, 80)
+    : 'no-action';
+  return `${top.service}:${tagPart}:${actionPart}`.slice(0, 160);
+}
+
+function notifyAutonomyClosureBlockIfChanged(
+  stateDir: string,
+  closure: Parameters<typeof shouldNotifyAutonomyClosureBlock>[0],
+): void {
+  try {
+    const previous = readAutonomyClosureNotificationSignature(stateDir);
+    if (!shouldNotifyAutonomyClosureBlock(closure, previous)) return;
+    const message = buildAutonomyClosureBlockMessage(closure);
+    sendChat(message, { directReply: true });
+    writeAutonomyClosureNotificationSignature(stateDir, autonomyClosureSignature(closure));
+  } catch (err) {
+    slog('AUTONOMY', `closure notification failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
 }
 
 // =============================================================================
@@ -2303,6 +2383,7 @@ export class AgentLoop {
         } else {
           const task = await ensureAutonomyClosureTask(memDir, closure);
           slog('AUTONOMY', `closure ${closure.status} score=${closure.score} blocking=${closure.blockingStages.join(',') || 'none'} task=${task?.id.slice(0, 12) ?? 'none'}`);
+          notifyAutonomyClosureBlockIfChanged(getInstanceDir(getCurrentInstanceId()), closure);
         }
       } catch (e) { slog('WARN', `autonomy closure health failed: ${e}`); }
 
@@ -2502,8 +2583,29 @@ export class AgentLoop {
             ? 'act' as import('./memory.js').CycleMode
             : (cycleIntent?.mode ?? detectCycleModeFn(context, currentTriggerReason, this.consecutiveLearnCycles, { hasPendingTasks, hasHighPriorityTasks, consecutiveIdleCycles: this.consecutiveIdleCycles }));
 
+      const runtimeSkillSelection = selectAgentSkills(inferSkillSelectionInput({
+        hint: [
+          cycleIntent?.reason,
+          cycleIntent?.focus,
+          currentTriggerReason,
+          schedulerTaskPrefix,
+          priorityPrefix,
+        ].filter(Boolean).join('\n'),
+        mode: cycleMode,
+        trigger: currentTriggerReason,
+        context: context.slice(0, 20_000),
+        priority: hasHighPriorityTasks ? 0 : hasPendingTasks ? 1 : 2,
+        limit: 5,
+      }));
+      const selectedSkillPrompt = buildSelectedSkillPrompt(runtimeSkillSelection);
+      if (runtimeSkillSelection.selected.length > 0) {
+        slog('SKILL', `cycle#${this.cycleCount} selected=${runtimeSkillSelection.selected.map(skill => `${skill.service}:${skill.score}`).join(',')}`);
+      }
+
       // Idle mode: replace prompt entirely with a lightweight idle prompt to avoid noop spirals
-      const effectivePrompt = cycleMode === 'idle' ? buildIdlePrompt() : prompt;
+      const effectivePrompt = cycleMode === 'idle'
+        ? buildIdlePrompt()
+        : prompt + (selectedSkillPrompt ? `\n\n${selectedSkillPrompt}` : '');
 
       // Intelligent model routing: decide Opus vs Sonnet based on cycle characteristics
       const modelRoute = routeModel({
@@ -3277,6 +3379,17 @@ export class AgentLoop {
         trigger: currentTriggerReason,
         tags: cycleTagsProcessed,
         sideEffects: cycleSideEffects,
+      });
+
+      recordRuntimeSkillUsage({
+        memoryDir: getMemoryRootDir(),
+        selection: runtimeSkillSelection,
+        cycle: this.cycleCount,
+        mode: cycleMode,
+        action,
+        tags: cycleTagsProcessed,
+        sideEffects: cycleSideEffects,
+        error: errorClassification?.type,
       });
 
       // ── Emit Activity Stream (side-effect cycles only, for Activity Monitor) ──

--- a/tests/agent-skill-manager.test.ts
+++ b/tests/agent-skill-manager.test.ts
@@ -4,6 +4,8 @@ import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import {
   buildAgentSkillOrchestrationPrompt,
+  buildSelectedSkillPrompt,
+  inferSkillSelectionInput,
   listManagedSkills,
   recordSkillUsage,
   selectAgentSkills,
@@ -192,6 +194,48 @@ describe('agent skill manager', () => {
         'context:stakeholder_conflict',
       ]),
     }));
+  });
+
+  it('infers runtime signals so Constraint Texture is selected at the right time', () => {
+    const env = { KURO_AGENT_CAPABILITIES_PATH: registryFile() } as NodeJS.ProcessEnv;
+    const input = inferSkillSelectionInput({
+      hint: 'stakeholder tension and competing requirements',
+      mode: 'reflect',
+      context: '理解瓶頸：需要處理最受影響 stakeholder 的取捨',
+      priority: 0,
+    });
+    const result = selectAgentSkills(input, env);
+
+    expect(input.signals).toEqual(expect.arrayContaining(['requirement_tension']));
+    expect(input.contextSignals).toEqual(expect.arrayContaining(['understanding_bottleneck', 'stakeholder_conflict']));
+    expect(result.selected[0]?.service).toBe('constraint-texture-analysis');
+  });
+
+  it('does not force Constraint Texture onto deterministic procedure slots', () => {
+    const env = { KURO_AGENT_CAPABILITIES_PATH: registryFile() } as NodeJS.ProcessEnv;
+    const input = inferSkillSelectionInput({
+      hint: 'return JSON with fields id name status',
+      mode: 'task',
+      context: 'deterministic schema output only',
+      priority: 2,
+    });
+    const result = selectAgentSkills(input, env);
+
+    expect(result.selected.map(skill => skill.service)).not.toContain('constraint-texture-analysis');
+  });
+
+  it('renders selected skills as a cycle-local prompt section', () => {
+    const env = { KURO_AGENT_CAPABILITIES_PATH: registryFile() } as NodeJS.ProcessEnv;
+    const result = selectAgentSkills(inferSkillSelectionInput({
+      hint: 'Constraint Texture token waste phantom task',
+      mode: 'reflect',
+      priority: 0,
+    }), env);
+    const prompt = buildSelectedSkillPrompt(result);
+
+    expect(prompt).toContain('Selected Managed Skills For This Cycle');
+    expect(prompt).toContain('constraint-texture-analysis');
+    expect(prompt).toContain('runtime records selected-skill usage automatically');
   });
 
   it('reports blocked skills with missing dependencies', () => {

--- a/tests/autonomy-closure-notifier.test.ts
+++ b/tests/autonomy-closure-notifier.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import {
+  autonomyClosureSignature,
+  buildAutonomyClosureBlockMessage,
+  shouldNotifyAutonomyClosureBlock,
+} from '../src/autonomy-closure-notifier.js';
+
+const blockedSnapshot = {
+  status: 'blocked',
+  score: 62,
+  blockingStages: ['task-execution'],
+  warningStages: ['memory-state-truth'],
+  recommendedTask: { title: 'P0 autonomy closure: repair task-execution' },
+  stages: [
+    {
+      stage: 'task-execution',
+      status: 'blocked',
+      summary: '1 task(s) exhausted autonomous retries',
+      evidence: ['idx-github-i hold: P0 GitHub issue #256'],
+    },
+  ],
+};
+
+describe('autonomy closure notifier', () => {
+  it('notifies when a blocking signature first appears', () => {
+    expect(shouldNotifyAutonomyClosureBlock(blockedSnapshot, null)).toBe(true);
+  });
+
+  it('does not notify repeatedly for the same blocking signature', () => {
+    expect(shouldNotifyAutonomyClosureBlock(blockedSnapshot, autonomyClosureSignature(blockedSnapshot))).toBe(false);
+  });
+
+  it('does not notify when there are no blocking stages', () => {
+    expect(shouldNotifyAutonomyClosureBlock({
+      ...blockedSnapshot,
+      status: 'healthy',
+      blockingStages: [],
+    }, null)).toBe(false);
+  });
+
+  it('renders blocking evidence and next action', () => {
+    const message = buildAutonomyClosureBlockMessage(blockedSnapshot);
+
+    expect(message).toContain('Autonomy closure blocked');
+    expect(message).toContain('blocking: task-execution');
+    expect(message).toContain('next: P0 autonomy closure: repair task-execution');
+    expect(message).toContain('idx-github-i hold');
+  });
+});


### PR DESCRIPTION
## Summary
- selects managed skills per runtime cycle from trigger/context signals and injects a cycle-local selected-skill prompt
- records selected skill usage outcomes to `memory/state/skill-usage.jsonl` so skill health/promotion stops being empty
- suppresses Constraint Texture for deterministic/schema slots unless CT-positive signals are present
- notifies Alex/room when autonomy closure blocking signature changes instead of hiding it only in dashboard JSON

## Root Cause Addressed
Autonomy closure blocking was detected internally but not surfaced on transition. Separately, managed skills existed in registry/API but runtime cycles did not automatically select or ledger them.

## Verification
- `pnpm exec vitest run tests/agent-skill-manager.test.ts tests/autonomy-closure-notifier.test.ts tests/agent-owned-identity.test.ts tests/github-identity.test.ts`
- `pnpm typecheck && pnpm build`
