### PR TITLE
fix(middleware): close brain-provider max-turn followups

### DIFF
--- a/src/middleware-failure-self-healing.ts
+++ b/src/middleware-failure-self-healing.ts
@@ -1,6 +1,6 @@
 import { appendFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
-import { appendMemoryIndexEntry, queryMemoryIndexSync } from './memory-index.js';
+import { appendMemoryIndexEntry, queryMemoryIndexSync, updateMemoryIndexEntry } from './memory-index.js';
 import { classifyProviderResourceHold, type ProviderResourceHold } from './provider-resource-guard.js';
 import {
   recordDelegationFailure,
@@ -81,6 +81,7 @@ export async function classifyMiddlewareFailures(
   tasks: MiddlewareTaskRecord[],
   now = new Date(),
 ): Promise<MiddlewareFailureSweepResult> {
+  await closeTerminalBrainMaxTurnFollowUps(memoryDir, now);
   const known = new Map(readMiddlewareFailureClassificationsSync(memoryDir).map(record => [record.taskId, record]));
   const failedTasks = tasks.filter(task => task.status === 'failed' && task.id);
   const result: MiddlewareFailureSweepResult = {
@@ -121,9 +122,9 @@ export async function classifyMiddlewareFailures(
       result.held++;
       lifecycleAction = 'provider-hold';
       resolution = `${resolution}; provider held until ${providerHold.resumeAt}; holdTask=${providerHoldTaskId}`;
-    } else if (bucket === 'max-turns' && task.worker === 'agent-brain') {
+    } else if (bucket === 'max-turns' && isTerminalBrainMaxTurnTask(task)) {
       lifecycleAction = 'terminal-cancelled';
-      resolution = `${resolution}; agent-brain cycle max-turns is terminal telemetry, not a decomposable work item`;
+      resolution = `${resolution}; brain-provider max-turns is terminal telemetry, not a decomposable work item`;
     } else if (bucket === 'max-turns') {
       followUpTaskId = await ensureMiddlewareFailureFollowUpTask(memoryDir, bucket, task, now);
       lifecycleAction = 'decompose';
@@ -169,6 +170,32 @@ export async function classifyMiddlewareFailures(
     slog('MIDDLEWARE-SELF-HEAL', `classified ${result.classified}/${result.failed} failed middleware task(s), held=${result.held}`);
   }
   return result;
+}
+
+export async function closeTerminalBrainMaxTurnFollowUps(memoryDir: string, now = new Date()): Promise<number> {
+  const followUps = queryMemoryIndexSync(memoryDir, { type: ['task'], status: ['pending', 'in_progress', 'hold'] })
+    .filter(entry => {
+      const payload = (entry.payload ?? {}) as Record<string, unknown>;
+      return payload.origin === 'middleware-self-healing'
+        && payload.middleware_failure_bucket === 'max-turns'
+        && isTerminalBrainMaxTurnText(String(payload.middleware_worker ?? ''), String(payload.failed_task_excerpt ?? ''));
+    });
+
+  let closed = 0;
+  for (const entry of followUps) {
+    const payload = (entry.payload ?? {}) as Record<string, unknown>;
+    const updated = await updateMemoryIndexEntry(memoryDir, entry.id, {
+      status: 'completed',
+      payload: {
+        ...payload,
+        terminal_resolution: 'brain-provider max-turns is terminal telemetry, not decomposable work',
+        terminal_resolved_at: now.toISOString(),
+      },
+      tags: [...new Set([...(entry.tags ?? []), 'terminal-cancelled'])],
+    });
+    if (updated) closed++;
+  }
+  return closed;
 }
 
 export function getMiddlewareFailureClassificationPath(memoryDir: string): string {
@@ -340,6 +367,21 @@ function middlewareFailureRepairPlan(
     summary: `Triage middleware failed task ${task.id ?? 'unknown'} (${bucket})`,
     acceptance: 'Failure is assigned to a known bucket, retried safely, held with a resume condition, or closed as terminal.',
   };
+}
+
+function isTerminalBrainMaxTurnTask(task: MiddlewareTaskRecord): boolean {
+  return isTerminalBrainMaxTurnText(task.worker ?? '', [
+    task.task,
+    failureOutputText(task),
+  ].filter(value => typeof value === 'string' && value.trim()).join('\n'));
+}
+
+function isTerminalBrainMaxTurnText(worker: string, text: string): boolean {
+  const lower = `${worker}\n${text}`.toLowerCase();
+  return worker.toLowerCase() === 'agent-brain'
+    || /mini-agent delegated brain provider/.test(lower)
+    || /return the requested result with concise evidence/.test(lower)
+    || /you are i'm kuro, alex's personal ai assistant/.test(lower);
 }
 
 async function ensureProviderHoldTask(

--- a/tests/middleware-failure-self-healing.test.ts
+++ b/tests/middleware-failure-self-healing.test.ts
@@ -7,6 +7,7 @@ import { readDelegationFailureRecordsSync } from '../src/delegation-failure-guar
 import {
   classifyMiddlewareFailureBucket,
   classifyMiddlewareFailures,
+  closeTerminalBrainMaxTurnFollowUps,
   readMiddlewareFailureClassificationsSync,
 } from '../src/middleware-failure-self-healing.js';
 
@@ -116,6 +117,54 @@ describe('middleware failure self-healing', () => {
       taskId: 'task-brain-turns',
       status: 'resolved',
     }));
+  });
+
+  it('treats delegated brain-provider prompts as terminal even when worker is mislabeled coder', async () => {
+    const result = await classifyMiddlewareFailures(memoryDir, [{
+      id: 'task-brain-coded',
+      worker: 'coder',
+      status: 'failed',
+      task: 'You are running as a mini-agent delegated brain provider. Return the requested result with concise evidence.',
+      error: 'Claude Code returned an error result: Reached maximum number of turns (30)',
+    }], new Date('2026-05-07T09:50:00.000Z'));
+
+    expect(result).toEqual(expect.objectContaining({ failed: 1, classified: 1, held: 0 }));
+    expect(readMiddlewareFailureClassificationsSync(memoryDir)[0]).toEqual(expect.objectContaining({
+      taskId: 'task-brain-coded',
+      bucket: 'max-turns',
+      lifecycleAction: 'terminal-cancelled',
+    }));
+    expect(queryMemoryIndexSync(memoryDir, { type: ['task'], status: ['pending'] })).toHaveLength(0);
+  });
+
+  it('closes legacy brain-provider max-turn follow-ups created before classifier fix', async () => {
+    const legacy = await appendMemoryIndexEntry(memoryDir, {
+      type: 'task',
+      status: 'pending',
+      summary: 'Decompose middleware task task-legacy after max-turns failure',
+      source: 'test',
+      tags: ['middleware', 'self-healing', 'max-turns'],
+      payload: {
+        origin: 'middleware-self-healing',
+        middleware_failure_task_id: 'task-legacy',
+        middleware_worker: 'coder',
+        middleware_failure_bucket: 'max-turns',
+        failed_task_excerpt: 'You are running as a mini-agent delegated brain provider. Return the requested result with concise evidence.',
+      },
+    });
+
+    expect(await closeTerminalBrainMaxTurnFollowUps(memoryDir, new Date('2026-05-07T09:51:00.000Z'))).toBe(1);
+
+    const completed = queryMemoryIndexSync(memoryDir, { type: ['task'], status: ['completed'] });
+    expect(completed).toEqual([
+      expect.objectContaining({
+        id: legacy.id,
+        payload: expect.objectContaining({
+          terminal_resolution: expect.stringContaining('brain-provider max-turns'),
+        }),
+        tags: expect.arrayContaining(['terminal-cancelled']),
+      }),
+    ]);
   });
 
   it('reuses an existing duplicate follow-up instead of aborting the sweep', async () => {


### PR DESCRIPTION
## Summary
- Treat delegated brain-provider max-turn failures as terminal even when middleware mislabels the worker as `coder`.
- Close legacy `middleware-self-healing` max-turn follow-up tasks that are really brain-provider terminal telemetry.
- Add regression coverage for mislabeled brain-provider failures and cleanup of existing stale follow-ups.

## Verification
- `pnpm exec vitest run tests/middleware-failure-self-healing.test.ts`
- `pnpm typecheck`
- `pnpm build`