### PR TITLE
fix(scheduler): phantom guard for P0 prompt-header injection (#257)

### DIFF
--- a/src/memory-index.ts
+++ b/src/memory-index.ts
@@ -1702,10 +1702,15 @@ export function getHighPriorityPendingCount(memDir: string): number {
 
 /** Get P0 task preview strings for priority prefix injection. */
 export function getP0TaskPreviews(memoryDir: string): string[] {
+  // Phantom guard (issue #186 / #257): task-type entries must exist in
+  // task-events.jsonl. Phantom tasks (visible only via relations.jsonl) are
+  // skipped so they don't re-inject into the heartbeat prompt each cycle.
+  const taskEventIds = new Set(getCachedBucket(memoryDir, 'task-events').keys());
   return queryMemoryIndexSync(memoryDir, {
     type: ['task', 'goal'],
     status: ['pending', 'in_progress'],
   })
+    .filter(t => t.type !== 'task' || taskEventIds.has(t.id))
     .filter(t => getTaskPriority(t) === 0)
     .map(t => `P0: ${t.summary ?? t.id}`);
 }

--- a/tests/scheduler-phantom-guard.test.ts
+++ b/tests/scheduler-phantom-guard.test.ts
@@ -19,6 +19,7 @@ import {
   appendMemoryIndexEntry,
   getTaskEventsPath,
   getMemoryIndexPath,
+  getP0TaskPreviews,
   incrementTaskStaleness,
   invalidateIndexCache,
   queryMemoryIndexSync,
@@ -147,5 +148,68 @@ describe('issue #186 — phantom task guard in incrementTaskStaleness', () => {
     const staleIds = staleResult.map(s => s.id);
     expect(staleIds).toContain(real.id);
     expect(staleIds).not.toContain(phantomId);
+  });
+});
+
+describe('issue #257 — phantom task guard in getP0TaskPreviews', () => {
+  function injectPhantomP0(id: string, summary: string): void {
+    const relationsPath = getMemoryIndexPath(tmpDir);
+    const dir = path.dirname(relationsPath);
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+    fs.appendFileSync(relationsPath, JSON.stringify({
+      id,
+      ts: new Date().toISOString(),
+      type: 'task',
+      status: 'pending',
+      refs: [],
+      summary,
+      payload: { priority: 0 },
+    }) + '\n', 'utf-8');
+    invalidateIndexCache();
+  }
+
+  it('phantom P0 task in relations.jsonl is excluded from preview list', () => {
+    const phantomId = 'task-1778139204128-8c';
+    injectPhantomP0(phantomId, 'Decompose middleware task task-1778139204128-8c after max-turns failure');
+
+    // Phantom IS visible in the merged index
+    const merged = queryMemoryIndexSync(tmpDir, { type: ['task'], status: ['pending'] });
+    expect(merged.some(e => e.id === phantomId)).toBe(true);
+
+    // But getP0TaskPreviews should filter it out
+    const previews = getP0TaskPreviews(tmpDir);
+    expect(previews.some(p => p.includes(phantomId))).toBe(false);
+    expect(previews.some(p => p.includes('max-turns failure'))).toBe(false);
+  });
+
+  it('real P0 task in task-events.jsonl still appears in preview list', async () => {
+    await appendMemoryIndexEntry(tmpDir, {
+      type: 'task',
+      status: 'pending',
+      summary: 'Critical P0 deployment blocker',
+      payload: { priority: 0 },
+    });
+    invalidateIndexCache();
+
+    const previews = getP0TaskPreviews(tmpDir);
+    expect(previews.some(p => p.includes('Critical P0 deployment blocker'))).toBe(true);
+  });
+
+  it('phantom P0 excluded while real P0 still shown (mixed scenario)', async () => {
+    const phantomId = 'task-1778139697719-8i';
+    injectPhantomP0(phantomId, 'Decompose middleware task task-1778139697719-8i after max-turns failure');
+
+    await appendMemoryIndexEntry(tmpDir, {
+      type: 'task',
+      status: 'pending',
+      summary: 'Real P0 incident response',
+      payload: { priority: 0 },
+    });
+    invalidateIndexCache();
+
+    const previews = getP0TaskPreviews(tmpDir);
+    expect(previews.some(p => p.includes('Real P0 incident response'))).toBe(true);
+    expect(previews.some(p => p.includes(phantomId))).toBe(false);
+    expect(previews.some(p => p.includes('max-turns failure'))).toBe(false);
   });
 });


### PR DESCRIPTION
Closes #257

## Summary
- Apply task-events presence check (same pattern as #186 phantom guard) to `getP0TaskPreviews()`, so phantom task entries that exist only in `relations.jsonl` no longer leak into the heartbeat P0 header.
- Goals (relations bucket) still pass through unchanged; only `type=task` entries are gated on `task-events.jsonl` membership.
- Three regression tests in `tests/scheduler-phantom-guard.test.ts` cover phantom-only excluded, real P0 still shown, and mixed phantom+real.

## Why this fixes the heartbeat loop
Heartbeat had been re-surfacing `Decompose middleware task X after max-turns failure` for 5+ cycles in a row. Diagnosis in #257 traced this to phantom task IDs (e.g. `task-1778139204128-8c`) showing up in `relations.jsonl` but absent from `task-events.jsonl` — so the P0 preview kept rendering items the agent could never act on. Filtering on real task-events presence stops the re-injection at source.

Acceptance criteria 3 from the issue (`P0 prompt-header injection should resolve task IDs against the actual index`) is the visible symptom and is addressed here. Criteria 1–2 (dedup ledger semantics, N-cycle escalation in `middleware-failure-self-healing.ts`) remain open as follow-up scope.

## Verification
- [x] `npx vitest run tests/scheduler-phantom-guard.test.ts` → 7/7 pass (3 new for #257)
- [x] `pnpm typecheck` → clean
- [x] Pre-existing 3 failures in `tests/runtime-workspace-autocorrect.test.ts` are unrelated; this branch reduces total failures from 5 → 3
- [ ] Observe a heartbeat cycle post-merge to confirm phantom P0 no longer surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)