### PR TITLE
feat(identity): gate public write provenance

### DIFF
--- a/scripts/record-public-write-identity.ts
+++ b/scripts/record-public-write-identity.ts
@@ -1,0 +1,39 @@
+import { recordPublicWriteProvenance } from '../src/public-write-identity.js';
+import { getMemoryRootDir } from '../src/memory-paths.js';
+
+const args = parseArgs(process.argv.slice(2));
+if (!args.service || !args.action || !args.subject || !args.actual) {
+  process.stderr.write('usage: pnpm tsx scripts/record-public-write-identity.ts --service github --action pr.create --subject PR#261 --actual miles990 [--expected kuro-agent] [--source connector] [--status open|resolved|acknowledged] [--resolution text]\n');
+  process.exit(2);
+}
+
+const record = recordPublicWriteProvenance(getMemoryRootDir(), {
+  service: args.service,
+  action: args.action,
+  subject: args.subject,
+  actualActor: args.actual,
+  expectedActor: args.expected,
+  source: args.source ?? 'manual-observation',
+  status: args.status as 'open' | 'resolved' | 'acknowledged' | undefined,
+  resolution: args.resolution,
+  evidence: args.evidence ? [args.evidence] : [],
+});
+
+console.log(JSON.stringify(record, null, 2));
+
+function parseArgs(raw: string[]): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (let i = 0; i < raw.length; i++) {
+    const item = raw[i];
+    if (!item.startsWith('--')) continue;
+    const key = item.slice(2);
+    const next = raw[i + 1];
+    if (next && !next.startsWith('--')) {
+      out[key] = next;
+      i++;
+    } else {
+      out[key] = 'true';
+    }
+  }
+  return out;
+}

--- a/src/agent-owned-identity.ts
+++ b/src/agent-owned-identity.ts
@@ -301,6 +301,7 @@ export function buildAgentOwnedIdentityPrompt(env: NodeJS.ProcessEnv = process.e
     'Kuro has her own accounts and managed APIs. Read/observe and write/act are different permissions.',
     'It is OK to observe through Alex-authorized accounts when the task is only reading context. It is NOT OK to publish, comment, create issues/PRs, send mail, vote, react, follow, or post under Alex\'s account.',
     'Any outbound public action done in Kuro\'s name must use Kuro-owned credentials. If only Alex\'s account is available, do read-only research/prep and record the write blocker.',
+    'Every outbound public write must leave provenance: service/action/subject/expected actor/actual actor/source. Connector or browser writes that cannot prove Kuro-owned identity are blockers, not invisible successes.',
     'All services, servers, APIs, accounts, and API keys Kuro uses must be added to this registry first, with read/write policy and credential env names. Do not add one-off hidden account logic in scripts.',
     'This registry is Kuro\'s arsenal/tool room: tools, skills, workflows, models, servers, and services can be added, modified, disabled, or deleted through registry overlays.',
     'New capability rule: before using a new external/internal service, add or update config/agent-capabilities.json or KURO_AGENT_CAPABILITIES_PATH, then verify identity/credential boundaries.',

--- a/src/api.ts
+++ b/src/api.ts
@@ -177,6 +177,7 @@ import { syncMyelinToKnowledge } from './myelin-kg-sync.js';
 import { readActorOutcomeStatsSync } from './actor-outcome-stats.js';
 import type { WorkIntent } from './brain-types.js';
 import { listAgentCapabilities, loadAgentRelationshipRegistry } from './agent-owned-identity.js';
+import { evaluatePublicWriteIdentity } from './public-write-identity.js';
 import { selectAgentSkills, summarizeSkillHealth, suggestPatternPromotions } from './agent-skill-manager.js';
 
 // =============================================================================
@@ -947,7 +948,7 @@ export function createApi(port = 3001): express.Express {
   app.use(createRateLimiter());
 
   // Request logging middleware (skip noisy polling endpoints)
-  const SILENT_PATHS = new Set(['/health', '/status', '/api/dashboard/behaviors', '/api/dashboard/learning', '/api/dashboard/journal', '/api/dashboard/cognition', '/api/dashboard/capabilities', '/api/dashboard/agent-arsenal', '/api/dashboard/agent-skills/select', '/api/dashboard/agent-skills/promotions', '/api/dashboard/context', '/api/dashboard/inner-state', '/api/dashboard/work-closure', '/api/events', '/api/room/stream', '/api/memory/structured', '/api/memory/history', '/api/memory/files']);
+  const SILENT_PATHS = new Set(['/health', '/status', '/api/dashboard/behaviors', '/api/dashboard/learning', '/api/dashboard/journal', '/api/dashboard/cognition', '/api/dashboard/capabilities', '/api/dashboard/agent-arsenal', '/api/dashboard/public-write-identity', '/api/dashboard/agent-skills/select', '/api/dashboard/agent-skills/promotions', '/api/dashboard/context', '/api/dashboard/inner-state', '/api/dashboard/work-closure', '/api/events', '/api/room/stream', '/api/memory/structured', '/api/memory/history', '/api/memory/files']);
   app.use((req: Request, res: Response, next: NextFunction) => {
     if (SILENT_PATHS.has(req.path)) { next(); return; }
     const start = Date.now();
@@ -2582,11 +2583,16 @@ export function createApi(port = 3001): express.Express {
     res.json({
       capabilities: listAgentCapabilities(),
       relationships: loadAgentRelationshipRegistry(),
+      publicWriteIdentity: evaluatePublicWriteIdentity(getMemoryRootDir()),
       skillHealth: summarizeSkillHealth(getMemoryRootDir()),
       patternPromotions: suggestPatternPromotions(getMemoryRootDir()),
       registryPath: process.env.KURO_AGENT_CAPABILITIES_PATH || 'config/agent-capabilities.json',
       policy: 'new services/servers/APIs/tools/accounts/related AIs or humans must be registry-managed before use',
     });
+  });
+
+  app.get('/api/dashboard/public-write-identity', (_req: Request, res: Response) => {
+    res.json(evaluatePublicWriteIdentity(getMemoryRootDir()));
   });
 
   app.get('/api/dashboard/agent-skills/select', (req: Request, res: Response) => {

--- a/src/autonomy-closure-health.ts
+++ b/src/autonomy-closure-health.ts
@@ -11,6 +11,7 @@ import { evaluateKgExternalMemoryTruth, evaluateMemoryStateTruth } from './exter
 import { evaluateMiddlewareQuality } from './middleware-quality-health.js';
 import { readClassifiedMiddlewareTaskIds } from './middleware-failure-self-healing.js';
 import { getFeature } from './features.js';
+import { evaluatePublicWriteIdentity } from './public-write-identity.js';
 
 export type AutonomyClosureStage =
   | 'runtime-workspace'
@@ -18,6 +19,7 @@ export type AutonomyClosureStage =
   | 'test-health'
   | 'issue-autopilot'
   | 'pr-review-consensus'
+  | 'public-write-identity'
   | 'ship-and-deploy'
   | 'self-improvement'
   | 'memory-context'
@@ -73,6 +75,7 @@ export function evaluateAutonomyClosure(
     testHealthStage(memoryDir),
     issueAutopilotStage(openTasks),
     prReviewConsensusStage(memoryDir),
+    publicWriteIdentityStage(memoryDir),
     shipAndDeployStage(correction),
     selfImprovementStage(openTasks),
     memoryContextStage(memoryDir, repoRoot),
@@ -101,6 +104,40 @@ export function evaluateAutonomyClosure(
     warningStages,
     recommendedTask: buildRecommendedTask(stages, status),
     correction,
+  };
+}
+
+function publicWriteIdentityStage(memoryDir: string): AutonomyClosureStageResult {
+  const snapshot = evaluatePublicWriteIdentity(memoryDir);
+  if (snapshot.status === 'blocked') {
+    return {
+      stage: 'public-write-identity',
+      status: 'blocked',
+      summary: snapshot.summary,
+      evidence: snapshot.openMismatches.slice(0, 5).map(record =>
+        `${record.service} ${record.action} ${record.subject}: expected=${record.expectedActor} actual=${record.actualActor} source=${record.source}`,
+      ),
+      repair: 'Stop that outbound channel until it uses Kuro-owned credentials; record a resolved provenance entry only after the account boundary is fixed.',
+    };
+  }
+  if (snapshot.status === 'warn') {
+    return {
+      stage: 'public-write-identity',
+      status: 'warn',
+      summary: snapshot.summary,
+      evidence: snapshot.unknownActors.slice(0, 5).map(record =>
+        `${record.service} ${record.action} ${record.subject}: actor unverified source=${record.source}`,
+      ),
+      repair: 'Record the actual public actor after each outbound write, or use a managed tool path that records it automatically.',
+    };
+  }
+  return {
+    stage: 'public-write-identity',
+    status: 'ok',
+    summary: snapshot.summary,
+    evidence: snapshot.recent.slice(0, 5).map(record =>
+      `${record.service} ${record.action} ${record.subject}: ${record.actualActor}`,
+    ),
   };
 }
 

--- a/src/github.ts
+++ b/src/github.ts
@@ -46,7 +46,8 @@ import {
   type IssueStateSummary,
   type OpenPrSnapshotEntry,
 } from './pr-autopilot.js';
-import { assertKuroGithubIdentity, kuroGithubCliEnv } from './github-identity.js';
+import { assertKuroGithubIdentity, expectedKuroGithubLogin, kuroGithubCliEnv } from './github-identity.js';
+import { recordPublicWriteProvenance } from './public-write-identity.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -58,10 +59,42 @@ async function gh(args: string[], timeout = 15000): Promise<{ stdout: string; st
     timeout,
     env: kuroGithubCliEnv(),
   });
+  recordGithubPublicWrite(args, result.stdout).catch(() => {});
   return {
     stdout: result.stdout,
     stderr: result.stderr,
   };
+}
+
+async function recordGithubPublicWrite(args: string[], stdout: string): Promise<void> {
+  const action = classifyGithubPublicWrite(args);
+  if (!action) return;
+  const subject = subjectFromGithubWrite(args, stdout);
+  recordPublicWriteProvenance(getMemoryRootDir(), {
+    service: 'github',
+    action,
+    subject,
+    actualActor: expectedKuroGithubLogin(),
+    source: `gh ${args.slice(0, 3).join(' ')}`,
+    evidence: [`args=${args.join(' ')}`],
+  });
+}
+
+function classifyGithubPublicWrite(args: string[]): string | undefined {
+  const [resource, command] = args;
+  if (resource === 'issue' && ['create', 'close', 'comment', 'edit'].includes(command ?? '')) return `issue.${command}`;
+  if (resource === 'pr' && ['create', 'merge', 'review', 'comment', 'close', 'edit', 'update-branch'].includes(command ?? '')) return `pr.${command}`;
+  if (resource === 'api' && args.some(arg => ['POST', 'PATCH', 'PUT', 'DELETE'].includes(arg))) return 'api.write';
+  return undefined;
+}
+
+function subjectFromGithubWrite(args: string[], stdout: string): string {
+  const url = stdout.trim().split('\n').find(line => /^https:\/\/github\.com\//.test(line.trim()));
+  if (url) return url.trim();
+  const index = args.findIndex(arg => /^(issue|pr)$/.test(args[0]) && /^\d+$/.test(arg));
+  if (index >= 0) return `${args[0]}#${args[index]}`;
+  if (args[0] === 'api') return args.find(arg => arg.includes('/repos/')) ?? 'github-api';
+  return args.slice(0, 4).join(' ');
 }
 
 /** Check if gh CLI is available and authenticated */

--- a/src/public-write-identity.ts
+++ b/src/public-write-identity.ts
@@ -1,0 +1,139 @@
+import { appendFileSync, existsSync, mkdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { getAgentOwnedIdentity, type AgentOwnedService } from './agent-owned-identity.js';
+
+const LEDGER_FILE = 'public-write-provenance.jsonl';
+
+export type PublicWriteStatus = 'open' | 'resolved' | 'acknowledged';
+
+export interface PublicWriteProvenanceInput {
+  service: AgentOwnedService;
+  action: string;
+  subject: string;
+  actualActor: string;
+  expectedActor?: string;
+  intentActor?: 'kuro' | 'alex' | 'human' | string;
+  source?: string;
+  status?: PublicWriteStatus;
+  resolution?: string;
+  observedAt?: Date;
+  evidence?: string[];
+}
+
+export interface PublicWriteProvenanceRecord {
+  id: string;
+  observedAt: string;
+  service: AgentOwnedService;
+  action: string;
+  subject: string;
+  expectedActor: string;
+  actualActor: string;
+  intentActor: string;
+  source: string;
+  status: PublicWriteStatus;
+  resolution?: string;
+  evidence: string[];
+}
+
+export interface PublicWriteIdentitySnapshot {
+  status: 'ok' | 'warn' | 'blocked';
+  expected: Record<string, string>;
+  openMismatches: PublicWriteProvenanceRecord[];
+  unknownActors: PublicWriteProvenanceRecord[];
+  recent: PublicWriteProvenanceRecord[];
+  summary: string;
+}
+
+export function recordPublicWriteProvenance(
+  memoryDir: string,
+  input: PublicWriteProvenanceInput,
+  env: NodeJS.ProcessEnv = process.env,
+): PublicWriteProvenanceRecord {
+  const identity = getAgentOwnedIdentity(input.service, env);
+  const record: PublicWriteProvenanceRecord = {
+    id: `pub-${randomUUID()}`,
+    observedAt: (input.observedAt ?? new Date()).toISOString(),
+    service: input.service,
+    action: input.action,
+    subject: input.subject,
+    expectedActor: normalizeActor(input.service, input.expectedActor ?? identity.expected),
+    actualActor: normalizeActor(input.service, input.actualActor),
+    intentActor: input.intentActor ?? 'kuro',
+    source: input.source ?? 'runtime',
+    status: input.status ?? 'open',
+    ...(input.resolution ? { resolution: input.resolution } : {}),
+    evidence: input.evidence ?? [],
+  };
+  appendFileSync(ensureLedger(memoryDir), JSON.stringify(record) + '\n', 'utf-8');
+  return record;
+}
+
+export function readPublicWriteProvenanceSync(memoryDir: string): PublicWriteProvenanceRecord[] {
+  const filePath = ensureLedger(memoryDir);
+  const latest = new Map<string, PublicWriteProvenanceRecord>();
+  for (const line of readFileSync(filePath, 'utf-8').split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      const record = JSON.parse(trimmed) as PublicWriteProvenanceRecord;
+      if (!record.id || !record.service || !record.action) continue;
+      latest.set(record.id, {
+        ...record,
+        evidence: Array.isArray(record.evidence) ? record.evidence : [],
+      });
+    } catch {
+      // Ignore partial JSONL writes.
+    }
+  }
+  return [...latest.values()].sort((a, b) => b.observedAt.localeCompare(a.observedAt));
+}
+
+export function evaluatePublicWriteIdentity(
+  memoryDir: string,
+  env: NodeJS.ProcessEnv = process.env,
+): PublicWriteIdentitySnapshot {
+  const recent = readPublicWriteProvenanceSync(memoryDir).slice(0, 50);
+  const expected: Record<string, string> = {};
+  for (const record of recent) {
+    try {
+      expected[record.service] = getAgentOwnedIdentity(record.service, env).expected;
+    } catch {
+      expected[record.service] = record.expectedActor;
+    }
+  }
+
+  const active = recent.filter(record => record.status === 'open' && record.intentActor === 'kuro');
+  const openMismatches = active.filter(record =>
+    normalizeActor(record.service, record.actualActor) !== normalizeActor(record.service, record.expectedActor),
+  );
+  const unknownActors = active.filter(record => !record.actualActor || record.actualActor === 'unknown');
+  const status = openMismatches.length > 0 ? 'blocked' : unknownActors.length > 0 ? 'warn' : 'ok';
+  const summary = status === 'blocked'
+    ? `${openMismatches.length} Kuro public write(s) used the wrong account`
+    : status === 'warn'
+      ? `${unknownActors.length} Kuro public write(s) have unverified account provenance`
+      : `${recent.length} public write provenance record(s), no open mismatch`;
+
+  return { status, expected, openMismatches, unknownActors, recent, summary };
+}
+
+export function publicWriteLedgerPath(memoryDir: string): string {
+  return path.join(memoryDir, 'index', LEDGER_FILE);
+}
+
+export function normalizeActor(service: string, value: string): string {
+  const trimmed = String(value ?? '').trim();
+  if (!trimmed) return 'unknown';
+  if (service === 'github') return trimmed.replace(/^@/, '').replace(/\/+$/, '').split('/').pop()?.replace(/\.git$/, '') ?? trimmed;
+  if (service === 'x' || service === 'devto') return trimmed.replace(/^@/, '').replace(/\/+$/, '').split('/').pop()?.replace(/^@/, '') ?? trimmed;
+  return trimmed.toLowerCase();
+}
+
+function ensureLedger(memoryDir: string): string {
+  const dir = path.join(memoryDir, 'index');
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  const filePath = path.join(dir, LEDGER_FILE);
+  if (!existsSync(filePath)) appendFileSync(filePath, '', 'utf-8');
+  return filePath;
+}

--- a/tests/agent-owned-identity.test.ts
+++ b/tests/agent-owned-identity.test.ts
@@ -41,6 +41,8 @@ describe('agent-owned identity boundary', () => {
     expect(prompt).toContain('Read/observe and write/act are different permissions');
     expect(prompt).toContain('It is OK to observe through Alex-authorized accounts');
     expect(prompt).toContain('It is NOT OK to publish');
+    expect(prompt).toContain('Every outbound public write must leave provenance');
+    expect(prompt).toContain('Connector or browser writes that cannot prove Kuro-owned identity are blockers');
     expect(prompt).toContain('writes=kuro-owned-required');
     expect(prompt).toContain('All services, servers, APIs, accounts, and API keys Kuro uses must be added to this registry first');
     expect(prompt).toContain('New capability rule: before using a new external/internal service');

--- a/tests/autonomy-closure-health.test.ts
+++ b/tests/autonomy-closure-health.test.ts
@@ -73,6 +73,30 @@ describe('autonomy closure health', () => {
     expect(tasks).toHaveLength(1);
   });
 
+  it('blocks closure when a Kuro-intended public write used the wrong account', () => {
+    writeFileSync(path.join(tmpDir, 'state/task-events.jsonl'), '', 'utf-8');
+    writeFileSync(path.join(tmpDir, 'index/relations.jsonl'), '', 'utf-8');
+    writeFileSync(path.join(tmpDir, 'index/public-write-provenance.jsonl'), JSON.stringify({
+      id: 'pub-mismatch',
+      observedAt: '2026-05-07T10:00:00.000Z',
+      service: 'github',
+      action: 'pr.create',
+      subject: 'PR #261',
+      expectedActor: 'kuro-agent',
+      actualActor: 'miles990',
+      intentActor: 'kuro',
+      source: 'codex-github-connector',
+      status: 'open',
+      evidence: [],
+    }) + '\n', 'utf-8');
+
+    const snapshot = evaluateAutonomyClosure(tmpDir, { repoRoot });
+
+    expect(snapshot.status).toBe('blocked');
+    expect(snapshot.blockingStages).toContain('public-write-identity');
+    expect(snapshot.stages.find(s => s.stage === 'public-write-identity')?.evidence[0]).toContain('expected=kuro-agent actual=miles990');
+  });
+
   it('closes active autonomy closure task after blockers resolve', async () => {
     writeFileSync(
       path.join(tmpDir, 'state/task-events.jsonl'),

--- a/tests/public-write-identity.test.ts
+++ b/tests/public-write-identity.test.ts
@@ -1,0 +1,77 @@
+import { mkdirSync, mkdtempSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  evaluatePublicWriteIdentity,
+  publicWriteLedgerPath,
+  recordPublicWriteProvenance,
+} from '../src/public-write-identity.js';
+
+describe('public write identity provenance', () => {
+  it('blocks Kuro-intended public writes made by Alex-owned GitHub identity', () => {
+    const memoryDir = mkMemoryDir();
+    recordPublicWriteProvenance(memoryDir, {
+      service: 'github',
+      action: 'pr.create',
+      subject: 'PR #261',
+      actualActor: 'miles990',
+      expectedActor: 'kuro-agent',
+      source: 'codex-github-connector',
+    });
+
+    const snapshot = evaluatePublicWriteIdentity(memoryDir, {
+      KURO_GITHUB_LOGIN: 'kuro-agent',
+    } as NodeJS.ProcessEnv);
+
+    expect(snapshot.status).toBe('blocked');
+    expect(snapshot.openMismatches[0]).toEqual(expect.objectContaining({
+      service: 'github',
+      actualActor: 'miles990',
+      expectedActor: 'kuro-agent',
+    }));
+  });
+
+  it('does not block resolved historical mismatches after the mechanism records resolution', () => {
+    const memoryDir = mkMemoryDir();
+    recordPublicWriteProvenance(memoryDir, {
+      service: 'github',
+      action: 'pr.create',
+      subject: 'PR #261',
+      actualActor: 'miles990',
+      expectedActor: 'kuro-agent',
+      source: 'codex-github-connector',
+      status: 'resolved',
+      resolution: 'connector path retired; future writes use Kuro-owned gh token',
+    });
+
+    const snapshot = evaluatePublicWriteIdentity(memoryDir, {
+      KURO_GITHUB_LOGIN: 'kuro-agent',
+    } as NodeJS.ProcessEnv);
+
+    expect(snapshot.status).toBe('ok');
+    expect(snapshot.openMismatches).toHaveLength(0);
+    expect(snapshot.recent).toHaveLength(1);
+  });
+
+  it('normalizes GitHub profile URLs and creates the ledger path', () => {
+    const memoryDir = mkMemoryDir();
+    const record = recordPublicWriteProvenance(memoryDir, {
+      service: 'github',
+      action: 'issue.create',
+      subject: 'https://github.com/miles990/mini-agent/issues/1',
+      actualActor: 'https://github.com/kuro-agent/',
+      expectedActor: 'kuro-agent',
+    });
+
+    expect(record.actualActor).toBe('kuro-agent');
+    expect(evaluatePublicWriteIdentity(memoryDir).status).toBe('ok');
+    expect(publicWriteLedgerPath(memoryDir)).toContain('public-write-provenance.jsonl');
+  });
+});
+
+function mkMemoryDir(): string {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'mini-agent-public-write-'));
+  mkdirSync(path.join(dir, 'index'), { recursive: true });
+  return dir;
+}


### PR DESCRIPTION
## Summary
- add public write provenance ledger for account-bound outbound actions
- add autonomy closure stage and dashboard endpoint for Kuro-owned public write identity
- record runtime GitHub public writes made through the managed gh path
- add a manual recording script for connector/browser observations

## Verification
- pnpm exec vitest run tests/public-write-identity.test.ts tests/autonomy-closure-health.test.ts tests/agent-owned-identity.test.ts tests/github-identity.test.ts
- pnpm typecheck
- pnpm build