### PR TITLE
fix(memory): preserve episodic notes and reject malformed inner state

### DIFF
--- a/src/memory.ts
+++ b/src/memory.ts
@@ -1916,36 +1916,10 @@ export class InstanceMemory {
       // 添加新內容
       const newContent = current + `\n[${timestamp}] ${content}`;
 
-      // Warm rotate: 限制每日筆數
-      // Group lines into entries: each entry starts with [timestamp] and includes all following lines
-      const lines = newContent.split('\n');
-      const header: string[] = [];
-      const entries: string[][] = [];
-      let currentEntry: string[] | null = null;
-
-      for (const line of lines) {
-        if (line.startsWith('#') && !currentEntry) {
-          header.push(line);
-        } else if (/^\[[\d:]+\]/.test(line)) {
-          // New timestamp entry — save previous and start new
-          if (currentEntry) entries.push(currentEntry);
-          currentEntry = [line];
-        } else if (currentEntry) {
-          currentEntry.push(line);
-        } else {
-          header.push(line);
-        }
-      }
-      if (currentEntry) entries.push(currentEntry);
-
-      // 如果超過 warmLimit，移除最舊的（保留完整 entry）
-      if (entries.length > this.warmLimit) {
-        const trimmed = entries.slice(-this.warmLimit);
-        const finalContent = [...header, ...trimmed.flat()].join('\n');
-        await fs.writeFile(dailyPath, finalContent, 'utf-8');
-      } else {
-        await fs.writeFile(dailyPath, newContent, 'utf-8');
-      }
+      // Daily notes are episodic truth, not a context cache. warmLimit may be
+      // used by readers, but writes must remain append-only to avoid deleting
+      // earlier same-day user/agent context.
+      await fs.writeFile(dailyPath, newContent, 'utf-8');
     });
   }
 

--- a/src/tag-parser.ts
+++ b/src/tag-parser.ts
@@ -57,6 +57,7 @@ function parseInternal(input: string, options?: ParseOptions): ParseState {
     stack: [],
     ranges: [],
   };
+  const REQUIRE_CLOSED_TAGS = new Set(['kuro:inner', 'kuro:cycle-state']);
 
   const parser = new Parser({
     onopentag(name, attributes) {
@@ -82,6 +83,10 @@ function parseInternal(input: string, options?: ParseOptions): ParseState {
 
       const closeStart = parser.startIndex;
       const closeEnd = parser.endIndex;
+      const closeToken = input.slice(closeStart, closeEnd + 1);
+      if (REQUIRE_CLOSED_TAGS.has(name) && closeToken !== `</${name}>`) {
+        return;
+      }
       const selfClosing = closeStart <= entry.openEnd;
       const contentStart = Math.min(entry.openEnd + 1, input.length);
       const contentEnd = selfClosing ? contentStart : Math.max(contentStart, closeStart);
@@ -131,9 +136,12 @@ function parseInternal(input: string, options?: ParseOptions): ParseState {
 
   // Graceful fallback for malformed/unclosed tags.
   // Cap content to prevent pollution (e.g. unclosed <kuro:task> absorbing entire response).
+  // State-bearing tags are intentionally excluded: accepting malformed working
+  // memory can overwrite durable state with prompt-wrapper fragments.
   const UNCLOSED_CONTENT_CAP = 500;
   for (const entry of state.stack) {
     if (!entry.tracked) continue;
+    if (REQUIRE_CLOSED_TAGS.has(entry.name)) continue;
     const contentStart = Math.min(entry.openEnd + 1, input.length);
     let contentEnd = input.length;
     let raw = input.slice(entry.start);

--- a/tests/dispatcher.test.ts
+++ b/tests/dispatcher.test.ts
@@ -140,4 +140,9 @@ describe('parseTags', () => {
     const result = parseTags('<kuro:inner>Tracking: `<kuro:schedule>` usage</kuro:inner>');
     expect(result.inner).toContain('`<kuro:schedule>`');
   });
+
+  it('does not accept unclosed inner tags as working memory', () => {
+    const result = parseTags('<kuro:inner>\n</foreground_reply_mode>\n</parameter>\n</invoke>');
+    expect(result.inner).toBeUndefined();
+  });
 });

--- a/tests/memory.test.ts
+++ b/tests/memory.test.ts
@@ -299,7 +299,7 @@ describe('InstanceMemory', () => {
   });
 
   describe('warm rotation', () => {
-    it('should trim daily notes exceeding warm limit', async () => {
+    it('should keep daily notes append-only even when exceeding warm limit', async () => {
       // Warm limit is 10
       for (let i = 0; i < 15; i++) {
         await memory.appendDailyNote(`Entry ${i}`);
@@ -307,8 +307,8 @@ describe('InstanceMemory', () => {
 
       const daily = await memory.readDailyNotes();
       const entryLines = daily.split('\n').filter(l => l.match(/^\[/));
-      expect(entryLines.length).toBeLessThanOrEqual(10);
-      // Should keep the latest entries
+      expect(entryLines.length).toBe(15);
+      expect(daily).toContain('Entry 0');
       expect(daily).toContain('Entry 14');
     });
   });


### PR DESCRIPTION
## Summary
- keep daily notes append-only so warm-limit writes cannot delete same-day episodic context
- reject malformed/unclosed state-bearing tags such as <kuro:inner> so prompt wrapper fragments cannot overwrite working memory
- update regression tests for both failure modes

## Verification
- pnpm exec vitest run tests/dispatcher.test.ts tests/memory.test.ts
- pnpm typecheck
- pnpm build