### PR TITLE
fix(memory): sanitize daily note ingress

### DIFF
--- a/src/memory.ts
+++ b/src/memory.ts
@@ -69,6 +69,32 @@ import { recordCascadeMetric } from './cascade.js';
 import { appendProvenance, memoryIdForContent } from './memory-provenance.js';
 import { getMemoryRootDir, getMemoryStateRootDir } from './memory-paths.js';
 
+const PROMPT_WRAPPER_LINE_RE = /^<\/?(?:foreground_reply_mode|cached_perception|parameter|invoke|tool_result|user_context)>$/i;
+const PROMPT_DIRECTIVE_LINE_RE = /^\((?:Generate response as Kuro|continue the conversation organically)[^)]+\)$/i;
+const SKILL_DIRECTIVE_LINE_RE = /^<Use the Skill tool\b[^>]*>$/i;
+
+export function sanitizeDailyNoteContent(content: string): string {
+  let text = content
+    .replace(/<think>[\s\S]*?<\/think>/gi, '')
+    .replace(/<ktml:thinking>[\s\S]*?<\/ktml:thinking>/gi, '')
+    .replace(/<thinking>[\s\S]*?<\/thinking>/gi, '');
+
+  const lines = text.split('\n')
+    .filter(line => {
+      const trimmed = line.trim();
+      if (!trimmed) return true;
+      if (PROMPT_WRAPPER_LINE_RE.test(trimmed)) return false;
+      if (PROMPT_DIRECTIVE_LINE_RE.test(trimmed)) return false;
+      if (SKILL_DIRECTIVE_LINE_RE.test(trimmed)) return false;
+      return true;
+    });
+
+  text = lines.join('\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+  return text;
+}
+
 // =============================================================================
 // Write-time Dedup — Jaccard word similarity (zero LLM cost)
 // =============================================================================
@@ -1894,6 +1920,9 @@ export class InstanceMemory {
    * 附加到今日日記（支援 Warm rotate）
    */
   async appendDailyNote(content: string): Promise<void> {
+    const sanitizedContent = sanitizeDailyNoteContent(content);
+    if (!sanitizedContent) return;
+
     const dailyDir = path.join(this.memoryDir, 'daily');
     await ensureDir(dailyDir);
 
@@ -1914,7 +1943,7 @@ export class InstanceMemory {
       }
 
       // 添加新內容
-      const newContent = current + `\n[${timestamp}] ${content}`;
+      const newContent = current + `\n[${timestamp}] ${sanitizedContent}`;
 
       // Daily notes are episodic truth, not a context cache. warmLimit may be
       // used by readers, but writes must remain append-only to avoid deleting
@@ -1943,7 +1972,10 @@ export class InstanceMemory {
 
     // 2. 寫入 Warm storage (daily notes)
     const prefix = role === 'user' ? '(alex)' : '(kuro)';
-    await this.appendDailyNote(`${prefix} ${content}`);
+    const sanitizedContent = sanitizeDailyNoteContent(content);
+    if (sanitizedContent) {
+      await this.appendDailyNote(`${prefix} ${sanitizedContent}`);
+    }
   }
 
   /**

--- a/tests/memory.test.ts
+++ b/tests/memory.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import os from 'node:os';
-import { InstanceMemory, getSkillsPrompt, setCustomExtensions, type CycleMode } from '../src/memory.js';
+import { InstanceMemory, getSkillsPrompt, sanitizeDailyNoteContent, setCustomExtensions, type CycleMode } from '../src/memory.js';
 
 // Use a temp dir for test isolation
 let testDir: string;
@@ -127,6 +127,35 @@ describe('InstanceMemory', () => {
       await memory.appendConversation('user', 'Test message');
       const daily = await memory.readDailyNotes();
       expect(daily).toContain('(alex) Test message');
+    });
+
+    it('should remove prompt wrapper debris from daily notes', async () => {
+      await memory.appendConversation('assistant', [
+        "(Generate response as Kuro to user's message)",
+        '<think>private reasoning must not become episodic memory</think>',
+        '</foreground_reply_mode>',
+        '</parameter>',
+        'Visible reply',
+      ].join('\n'));
+
+      const daily = await memory.readDailyNotes();
+      expect(daily).toContain('(kuro) Visible reply');
+      expect(daily).not.toContain('foreground_reply_mode');
+      expect(daily).not.toContain('parameter');
+      expect(daily).not.toContain('private reasoning');
+      expect(daily).not.toContain('Generate response as Kuro');
+    });
+
+    it('should skip daily note entries that contain only prompt wrapper debris', async () => {
+      await memory.appendConversation('assistant', [
+        '</foreground_reply_mode>',
+        '</parameter>',
+        '</invoke>',
+      ].join('\n'));
+
+      const daily = await memory.readDailyNotes();
+      const entryLines = daily.split('\n').filter(l => l.match(/^\[/));
+      expect(entryLines).toHaveLength(0);
     });
 
     // clearHotBuffer was removed (dead code cleanup)
@@ -310,6 +339,16 @@ describe('InstanceMemory', () => {
       expect(entryLines.length).toBe(15);
       expect(daily).toContain('Entry 0');
       expect(daily).toContain('Entry 14');
+    });
+  });
+
+  describe('sanitizeDailyNoteContent', () => {
+    it('preserves normal content while removing known non-conversation wrappers', () => {
+      expect(sanitizeDailyNoteContent([
+        '<Use the Skill tool to invoke skills as needed>',
+        '正常回覆',
+        '</cached_perception>',
+      ].join('\n'))).toBe('正常回覆');
     });
   });
 


### PR DESCRIPTION
## Summary
- sanitize daily note writes before they become episodic memory
- strip prompt wrapper debris and thinking blocks from conversation history
- skip entries that contain only wrapper debris

## Verification
- pnpm exec vitest run tests/memory.test.ts tests/dispatcher.test.ts
- pnpm typecheck
- pnpm build