### PR TITLE
fix(middleware): reuse duplicate provider hold during sweep

### DIFF
--- a/src/middleware-failure-self-healing.ts
+++ b/src/middleware-failure-self-healing.ts
@@ -390,7 +390,44 @@ async function ensureProviderHoldTask(
   task: MiddlewareTaskRecord,
   now: Date,
 ): Promise<string> {
-  const active = queryMemoryIndexSync(memoryDir, { type: ['task'], status: ['hold'] })
+  const active = findProviderHoldTask(memoryDir, hold, now);
+  if (active) return active.id;
+
+  try {
+    const entry = await appendMemoryIndexEntry(memoryDir, {
+      type: 'task',
+      status: 'hold',
+      summary: `Hold ${hold.provider} middleware delegation until provider quota resets`,
+      refs: [],
+      tags: ['middleware', 'provider-hold', 'self-healing'],
+      payload: {
+        origin: 'middleware-self-healing',
+        holdCondition: {
+          type: 'date-after',
+          value: hold.resumeAt,
+        },
+        provider_resource_hold: hold,
+        middleware_task_id: task.id,
+        middleware_worker: task.worker,
+        middleware_failure_bucket: 'budget-or-quota',
+        createdAt: now.toISOString(),
+      },
+    });
+    return entry.id;
+  } catch (error) {
+    if (/duplicate/i.test(String(error))) {
+      return findProviderHoldTask(memoryDir, hold, now)?.id ?? 'duplicate-existing-provider-hold';
+    }
+    throw error;
+  }
+}
+
+function findProviderHoldTask(
+  memoryDir: string,
+  hold: ProviderResourceHold,
+  now: Date,
+): { id: string } | undefined {
+  return queryMemoryIndexSync(memoryDir, { type: ['task'], status: ['hold'] })
     .find(entry => {
       const current = entry.payload?.provider_resource_hold as ProviderResourceHold | undefined;
       if (!current || current.type !== 'provider-quota') return false;
@@ -398,28 +435,6 @@ async function ensureProviderHoldTask(
       const resumeAt = Date.parse(current.resumeAt);
       return Number.isFinite(resumeAt) && resumeAt > now.getTime();
     });
-  if (active) return active.id;
-
-  const entry = await appendMemoryIndexEntry(memoryDir, {
-    type: 'task',
-    status: 'hold',
-    summary: `Hold ${hold.provider} middleware delegation until provider quota resets`,
-    refs: [],
-    tags: ['middleware', 'provider-hold', 'self-healing'],
-    payload: {
-      origin: 'middleware-self-healing',
-      holdCondition: {
-        type: 'date-after',
-        value: hold.resumeAt,
-      },
-      provider_resource_hold: hold,
-      middleware_task_id: task.id,
-      middleware_worker: task.worker,
-      middleware_failure_bucket: 'budget-or-quota',
-      createdAt: now.toISOString(),
-    },
-  });
-  return entry.id;
 }
 
 async function fetchMiddlewareTasks(baseUrl?: string, timeoutMs = 2500): Promise<MiddlewareTaskRecord[]> {

--- a/tests/middleware-failure-self-healing.test.ts
+++ b/tests/middleware-failure-self-healing.test.ts
@@ -196,6 +196,36 @@ describe('middleware failure self-healing', () => {
     expect(queryMemoryIndexSync(memoryDir, { type: ['task'], status: ['pending'] })).toHaveLength(1);
   });
 
+  it('reuses an existing duplicate provider hold instead of aborting the sweep', async () => {
+    const first = await classifyMiddlewareFailures(memoryDir, [{
+      id: 'task-budget-1',
+      worker: 'agent-brain',
+      status: 'failed',
+      task: 'Review delegated work as claude',
+      error: "Claude Code returned an error result: You're out of extra usage · resets 2:40am (Asia/Taipei)",
+      completedAt: '2026-05-06T16:31:00.000Z',
+    }], new Date('2026-05-06T16:30:00.000Z'));
+    const holdId = readMiddlewareFailureClassificationsSync(memoryDir)[0].providerHoldTaskId;
+
+    const second = await classifyMiddlewareFailures(memoryDir, [{
+      id: 'task-budget-2',
+      worker: 'agent-brain',
+      status: 'failed',
+      task: 'Review delegated work as claude again',
+      error: "Claude Code returned an error result: You're out of extra usage · resets 2:40am (Asia/Taipei)",
+      completedAt: '2026-05-06T16:32:00.000Z',
+    }], new Date('2026-05-06T16:31:00.000Z'));
+
+    expect(first).toEqual(expect.objectContaining({ classified: 1, held: 1 }));
+    expect(second).toEqual(expect.objectContaining({ classified: 1, held: 1 }));
+    expect(readMiddlewareFailureClassificationsSync(memoryDir)[0]).toEqual(expect.objectContaining({
+      taskId: 'task-budget-2',
+      providerHoldTaskId: holdId,
+      lifecycleAction: 'provider-hold',
+    }));
+    expect(queryMemoryIndexSync(memoryDir, { type: ['task'], status: ['hold'] })).toHaveLength(1);
+  });
+
   it('reclassifies a known task when better error-only signal changes the bucket', async () => {
     await classifyMiddlewareFailures(memoryDir, [{
       id: 'task-reclassify',


### PR DESCRIPTION
## Summary
- make middleware self-healing sweep duplicate-safe for provider quota hold tasks
- reuse an existing provider hold when appendMemoryIndexEntry rejects a duplicate
- add regression coverage so middleware-quality can self-clear after provider-hold duplicate cases

## Root Cause
 aborted when a budget/quota failure needed a provider hold but an equivalent hold task already existed. The duplicate exception stopped classification for all later failed middleware tasks, leaving middleware-quality degraded.

## Verification
- pnpm exec vitest run tests/middleware-failure-self-healing.test.ts tests/middleware-quality-health.test.ts
- pnpm typecheck
- pnpm build