### PR TITLE
fix(pr): block closure on approved unmergeable PRs

### DIFF
--- a/src/autonomy-closure-health.ts
+++ b/src/autonomy-closure-health.ts
@@ -399,19 +399,21 @@ function prReviewConsensusStage(memoryDir: string): AutonomyClosureStageResult {
     || openPrGaps.snapshotStale
     || openPrGaps.readyUntracked.length > 0
     || openPrGaps.staleDrafts.length > 0
+    || openPrGaps.approvedBlocked.length > 0
   ) {
     const evidence: string[] = [];
     if (openPrGaps.snapshotMissing) evidence.push('open PR snapshot missing');
     if (openPrGaps.snapshotStale) evidence.push(`open PR snapshot stale: generatedAt=${openPrGaps.snapshotGeneratedAt ?? 'unknown'}`);
     evidence.push(...openPrGaps.readyUntracked.slice(0, 5).map(pr => `PR #${pr.number}: ready but not tracked for review (${pr.title})`));
     evidence.push(...openPrGaps.staleDrafts.slice(0, 5).map(pr => `PR #${pr.number}: stale draft needs triage (${pr.title})`));
+    evidence.push(...openPrGaps.approvedBlocked.slice(0, 5).map(pr => `PR #${pr.number}: approved but not mergeable (${pr.mergeStateStatus ?? pr.mergeable ?? 'unknown'}: ${pr.title})`));
 
     return {
       stage: 'pr-review-consensus',
-      status: 'warn',
+      status: openPrGaps.approvedBlocked.length > 0 ? 'blocked' : 'warn',
       summary: 'open PR lifecycle has unclosed tracking gaps',
       evidence,
-      repair: 'Run GitHub automation to refresh open-prs.json, queue PR review handoffs, and triage stale drafts.',
+      repair: 'Run GitHub automation to refresh open-prs.json, queue PR review handoffs, update approved conflicts, and triage stale drafts.',
     };
   }
   if (handoffs.length === 0) {

--- a/src/github.ts
+++ b/src/github.ts
@@ -311,6 +311,8 @@ interface ReviewablePR {
   createdAt?: string;
   updatedAt?: string;
   headRefName?: string;
+  mergeStateStatus?: string;
+  mergeable?: string;
 }
 
 export async function autoTrackPrReviewNeeds(): Promise<void> {
@@ -419,11 +421,13 @@ function toOpenPrSummary(pr: ReviewablePR): OpenPrSnapshotEntry {
     createdAt: pr.createdAt,
     updatedAt: pr.updatedAt,
     headRefName: pr.headRefName,
+    mergeStateStatus: pr.mergeStateStatus,
+    mergeable: pr.mergeable,
   };
 }
 
 async function listOpenPrsForLifecycle(): Promise<ReviewablePR[]> {
-  const baseFields = 'number,title,body,isDraft,reviewDecision,labels,url,createdAt,updatedAt,headRefName';
+  const baseFields = 'number,title,body,isDraft,reviewDecision,labels,url,createdAt,updatedAt,headRefName,mergeStateStatus,mergeable';
   try {
     const { stdout } = await gh(['pr', 'list', '--state', 'open', '--json', `${baseFields},reviewRequests`, '--limit', '50']);
     return JSON.parse(stdout);

--- a/src/pr-autopilot.ts
+++ b/src/pr-autopilot.ts
@@ -24,6 +24,7 @@ export interface PrClosureGaps {
   snapshotGeneratedAt?: string;
   readyUntracked: OpenPrSnapshotEntry[];
   staleDrafts: OpenPrSnapshotEntry[];
+  approvedBlocked: OpenPrSnapshotEntry[];
 }
 
 export interface IssueStateSummary {
@@ -74,6 +75,7 @@ export function evaluatePrClosureGaps(
       snapshotStale: false,
       readyUntracked: [],
       staleDrafts: [],
+      approvedBlocked: [],
     };
   }
 
@@ -88,6 +90,7 @@ export function evaluatePrClosureGaps(
     snapshotStale,
     snapshotGeneratedAt: snapshot.generatedAt,
     ...gaps,
+    approvedBlocked: findApprovedBlockedPrs(snapshot.prs),
   };
 }
 
@@ -119,6 +122,16 @@ export function findUntrackedPrs(
   }
 
   return { readyUntracked, staleDrafts };
+}
+
+export function findApprovedBlockedPrs(prs: OpenPrSnapshotEntry[]): OpenPrSnapshotEntry[] {
+  return prs.filter(pr => {
+    if (pr.isDraft) return false;
+    if (pr.reviewDecision !== 'APPROVED') return false;
+    const labels = new Set((pr.labels ?? []).map(label => label.toLowerCase()));
+    if (labels.has('hold')) return false;
+    return isBlockedMergeState(pr.mergeStateStatus) || isBlockedMergeable(pr.mergeable);
+  });
 }
 
 export function appendStaleDraftPrHandoffs(
@@ -199,7 +212,17 @@ function normalizePrSnapshotEntry(pr: OpenPrSnapshotEntry): OpenPrSnapshotEntry 
     createdAt: pr.createdAt ?? null,
     updatedAt: pr.updatedAt ?? null,
     headRefName: pr.headRefName ?? null,
+    mergeStateStatus: pr.mergeStateStatus ?? null,
+    mergeable: pr.mergeable ?? null,
   };
+}
+
+function isBlockedMergeState(value: string | null | undefined): boolean {
+  return ['DIRTY', 'BLOCKED', 'UNKNOWN'].includes(String(value ?? '').toUpperCase());
+}
+
+function isBlockedMergeable(value: string | null | undefined): boolean {
+  return ['CONFLICTING', 'UNKNOWN'].includes(String(value ?? '').toUpperCase());
 }
 
 function ageHours(iso: string | null | undefined, now: Date): number {

--- a/src/pr-lifecycle-governance.ts
+++ b/src/pr-lifecycle-governance.ts
@@ -16,6 +16,8 @@ export interface OpenPullRequestSummary extends PullRequestSummary {
   authorLogin?: string | null;
   labels?: string[];
   isDraft?: boolean;
+  mergeStateStatus?: string | null;
+  mergeable?: string | null;
 }
 
 export type PrReviewer = 'codex' | 'claude-code' | 'akari' | 'alex';

--- a/tests/pr-autopilot.test.ts
+++ b/tests/pr-autopilot.test.ts
@@ -6,6 +6,7 @@ import {
   appendStaleDraftPrHandoffs,
   evaluatePrClosureGaps,
   extractClosingIssueRefs,
+  findApprovedBlockedPrs,
   findUntrackedPrs,
   parseTrackedPrNumbers,
   shouldAutoCloseSupersededPr,
@@ -79,6 +80,17 @@ describe('PR autopilot closure', () => {
     expect(gaps.snapshotMissing).toBe(false);
     expect(gaps.snapshotStale).toBe(false);
     expect(gaps.readyUntracked.map(item => item.number)).toEqual([11]);
+  });
+
+  it('treats approved but conflicting PRs as unclosed lifecycle work', () => {
+    const blocked = findApprovedBlockedPrs([
+      pr({ number: 21, title: 'fix: approved clean', reviewDecision: 'APPROVED', mergeStateStatus: 'CLEAN', mergeable: 'MERGEABLE' }),
+      pr({ number: 22, title: 'fix: approved dirty', reviewDecision: 'APPROVED', mergeStateStatus: 'DIRTY', mergeable: 'CONFLICTING' }),
+      pr({ number: 23, title: 'fix: draft dirty', isDraft: true, reviewDecision: 'APPROVED', mergeStateStatus: 'DIRTY', mergeable: 'CONFLICTING' }),
+      pr({ number: 24, title: 'fix: held dirty', labels: ['hold'], reviewDecision: 'APPROVED', mergeStateStatus: 'DIRTY', mergeable: 'CONFLICTING' }),
+    ]);
+
+    expect(blocked.map(item => item.number)).toEqual([22]);
   });
 
   it('extracts only closing issue refs for superseded PR closure', () => {


### PR DESCRIPTION
## Summary
- include PR mergeability fields in the open PR lifecycle snapshot
- treat approved but DIRTY/CONFLICTING PRs as unclosed PR lifecycle work
- make autonomy closure block on approved PRs that cannot merge instead of reporting healthy

## Verification
- pnpm exec vitest run tests/pr-autopilot.test.ts tests/pr-lifecycle-governance.test.ts
- pnpm typecheck
- pnpm build
