### PR TITLE
fix(scheduler): skip stale correction tasks when gate is clean

### DIFF
--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -12,7 +12,7 @@ import { queryMemoryIndexSync, updateMemoryIndexEntry, type MemoryIndexEntry } f
 import { slog } from './utils.js';
 import { eventBus } from './event-bus.js';
 import { getProcess } from './process-table.js';
-import { isCorrectionTask } from './correction-gate.js';
+import { evaluateCorrectionGate, isCorrectionTask, type CorrectionGateSnapshot } from './correction-gate.js';
 
 // =============================================================================
 // Types
@@ -379,6 +379,8 @@ export function schedulerPick(
     }
   }
 
+  const correctionSnapshot = evaluateCorrectionGate(memoryDir);
+  const activeCorrectionReasons = new Set(correctionSnapshot.reasons.map(reason => reason.type));
   const entries = queryMemoryIndexSync(memoryDir, {
     type: ['task'],
     status: ['pending', 'in_progress'],
@@ -389,6 +391,13 @@ export function schedulerPick(
   const phantomTitles = loadPhantomTaskTitles(memoryDir);
 
   const tasks: TaskSnapshot[] = entries.map(entryToSnapshot)
+    .filter(t => {
+      const entry = entries.find(item => item.id === t.id);
+      if (!entry || !isCorrectionTask(entry)) return true;
+      if (correctionTaskMatchesSnapshot(entry, correctionSnapshot, activeCorrectionReasons)) return true;
+      slog('SCHED', `dispatch-correction-stale: skipping task=${t.id.slice(0, 12)} ${t.summary.slice(0, 50)}`);
+      return false;
+    })
     .filter(t => {
       const proc = getProcess(t.id);
       return !proc || (proc.state !== 'completed' && proc.state !== 'abandoned');
@@ -408,7 +417,8 @@ export function schedulerPick(
       return true;
     });
   const decision = scheduler.decideNext(tasks, schedulerState, events);
-  const correctionTask = entries.find(isCorrectionTask);
+  const schedulableTaskIds = new Set(tasks.map(task => task.id));
+  const correctionTask = entries.find(entry => schedulableTaskIds.has(entry.id) && isCorrectionTask(entry));
   if (correctionTask && (!decision.taskId || decision.action === 'discovery' || decision.action === 'idle')) {
     const forced: SchedulingDecision = {
       taskId: correctionTask.id,
@@ -434,6 +444,26 @@ export function schedulerPick(
   recordSchedulerDecision(decision);
 
   return decision;
+}
+
+function correctionTaskMatchesSnapshot(
+  entry: MemoryIndexEntry,
+  snapshot: CorrectionGateSnapshot,
+  activeReasonTypes: Set<string>,
+): boolean {
+  if (!snapshot.needsCorrection) return false;
+  const payload = (entry.payload ?? {}) as Record<string, unknown>;
+  const payloadReason = typeof payload.correction_reason_type === 'string'
+    ? payload.correction_reason_type
+    : null;
+  const summaryReason = parseCorrectionReasonFromSummary(entry.summary ?? '');
+  const reason = payloadReason ?? summaryReason;
+  return reason ? activeReasonTypes.has(reason) : true;
+}
+
+function parseCorrectionReasonFromSummary(summary: string): string | null {
+  const match = summary.match(/correction gate: resolve ([a-z-]+)/i);
+  return match?.[1] ?? null;
 }
 
 function recordSchedulerDecision(decision: SchedulingDecision): void {

--- a/tests/scheduler-dispatch-suppression.test.ts
+++ b/tests/scheduler-dispatch-suppression.test.ts
@@ -265,6 +265,27 @@ describe('schedulerPick — suppressed tasks excluded from dispatch', () => {
     expect(decision.taskId).not.toBe(task.id);
   });
 
+  it('does not force a stale correction task when the correction gate is clean', async () => {
+    const correction = await appendMemoryIndexEntry(tmpDir, {
+      type: 'task',
+      status: 'pending',
+      summary: 'P0 correction gate: resolve low-responsiveness',
+      payload: { origin: 'scheduler', priority: 0, correction_reason_type: 'low-responsiveness' },
+    });
+    const normal = await appendMemoryIndexEntry(tmpDir, {
+      type: 'task',
+      status: 'pending',
+      summary: 'P1 normal work',
+      payload: { priority: 1 },
+    });
+    invalidateIndexCache();
+
+    const decision = schedulerPick(tmpDir, []);
+
+    expect(decision.taskId).toBe(normal.id);
+    expect(decision.taskId).not.toBe(correction.id);
+  });
+
   it('resets suppression on a human-directed scheduler event', async () => {
     const task = await appendMemoryIndexEntry(tmpDir, {
       type: 'task',


### PR DESCRIPTION
## Summary
- make scheduler correction dispatch consult the live correction gate snapshot
- skip stale correction tasks when their reason is no longer active
- ensure the forced correction-task path only uses tasks that survived phantom/suppression/stale-correction filtering

Closes #275.

## Verification
- pnpm exec vitest run tests/scheduler-dispatch-suppression.test.ts tests/correction-gate.test.ts
- pnpm typecheck
- pnpm build
