### PR TITLE
fix(enrich): surface stderr/status when claude-cli enrichment fails

### DIFF
--- a/scripts/ai-trend-enrich-remote.mjs
+++ b/scripts/ai-trend-enrich-remote.mjs
@@ -109,7 +109,10 @@ async function enrich(post) {
       so_what:  parsed.so_what  || 'unspecified',
     };
   } catch (e) {
-    console.error(`[enrich] ${post.id} fail: ${e.message?.slice(0, 200)}`);
+    const stderr = (e.stderr?.toString?.() || '').trim();
+    const stdout = (e.stdout?.toString?.() || '').trim();
+    const detail = stderr || stdout || e.message || String(e);
+    console.error(`[enrich] ${post.id} fail status=${e.status ?? '?'} signal=${e.signal ?? '-'}: ${detail.slice(0, 600)}`);
     return null;
   }
 }


### PR DESCRIPTION
## Why

P0 #052 投訴根因 Layer 1 prerequisite. `memory/state/github-trend/2026-05-07.json` shows AI enrichment 60/60 fail today (`enrichment.ok=0, fail=60, model=haiku, via=claude-cli`). All 60 entries fall through to `ai-trend-enrich-fallback.mjs`, which hardcodes one `so_what` per category — that's why "GitHub trending 摘要都是同一句".

But `github-ai-trend-launchd.log` only shows `[enrich] github_X fail: Command failed: echo "..."` — the prompt is echoed back; real `claude-cli` stderr is lost because `e.message?.slice(0, 200)` from `child_process.execSync` truncates to the failed command line, not the captured stderr.

Without visible failure mode, we cannot decide between (a) shell-escape bug, (b) haiku timeout, (c) schema rejection, (d) auth/quota.

## What changed

`scripts/ai-trend-enrich-remote.mjs:111-115` — error log now reads `e.stderr` (preferred) or `e.stdout`, falls back to `e.message`, and includes `e.status` / `e.signal`. Cap raised 200→600 chars. Strictly-additive; no logic / control-flow / dependency change.

## Falsifier

Tomorrow's 15:00 cron run (or manual `node scripts/ai-trend-enrich-remote.mjs --source=github --force --date=2026-05-07`) produces an actionable error string identifying the real failure mode in `memory/logs/github-trend-launchd.log`.

If output is still uninformative → captured-fields hypothesis wrong; switch to wrapping `execSync` with explicit `{ shell: '/bin/bash' }` + capture-into-tmpfile pattern.

## Test plan

- [x] `node --check` passes
- [ ] Manual run on today's data file produces stderr-with-real-error
- [ ] Tomorrow's cron emits diagnosable failure mode → file Layer 2 issue

## Out of scope (Layer 2 / Layer 3, follow-up)

- Per-repo fallback `so_what` (description + topics → unique sentence)
- LLM/topics multi-label `detectCategory` (replace keyword bucket)

🤖 Generated with [Claude Code](https://claude.com/claude-code)