### PR TITLE
fix(github-trend): always run fallback enricher to backfill pending-llm-pass (#258)

### DIFF
--- a/scripts/launchd-wrappers/github-ai-trend.sh
+++ b/scripts/launchd-wrappers/github-ai-trend.sh
@@ -5,4 +5,10 @@ set -a
 . ./.env
 set +a
 /opt/homebrew/bin/node scripts/github-ai-trend.mjs
-/opt/homebrew/bin/node scripts/ai-trend-enrich-remote.mjs --source=github
+# Remote enrich (claude-cli). Allowed to partially or fully fail —
+# fallback below always runs to backfill any post still showing
+# 'pending-llm-pass' so the user-facing output is never the literal
+# placeholder string. Issue #258.
+/opt/homebrew/bin/node scripts/ai-trend-enrich-remote.mjs --source=github \
+  || echo "[wrapper] remote-enrich exited non-zero, continuing to fallback"
+/opt/homebrew/bin/node scripts/ai-trend-enrich-fallback.mjs --source=github


### PR DESCRIPTION
## Summary
- launchd wrapper now always runs `ai-trend-enrich-fallback.mjs --source=github` after `ai-trend-enrich-remote.mjs`, preventing 60/60 `pending-llm-pass` literals from reaching the user-visible trend page when remote enrichment fails.
- Remote-enrich failure is logged via `|| echo` instead of killing the script.
- Backfilled 2026-05-06 local artifact: 60→0 pending, 60 unique novelty strings, 10 unique so_what.

## Why
Issue #258: `enrichment.fail=60/60` on 5/6 + 5/1 → all posts rendered as the literal `pending-llm-pass` string because the safety net script was never invoked from the wrapper.

## Verification
- [x] Smoke: `node scripts/ai-trend-enrich-fallback.mjs --source=github` is idempotent on healthy 5/7 (changed=0)
- [x] Repair: same script on 5/6 changed=60, 0 pending afterward
- [ ] Falsifier (TTL=2 cycles): next 15:00 cron run state file has `grep pending-llm-pass count > 0` → fix incorrect

Refs #258, #272 (#052 follow-up).