### PR TITLE
feat(skills): add promotion autopilot loop

### DIFF
--- a/config/agent-capabilities.json
+++ b/config/agent-capabilities.json
@@ -233,6 +233,42 @@
       "writePolicy": "internal-service"
     },
     {
+      "service": "skill-promotion-autopilot",
+      "kind": "workflow",
+      "defaultExpected": "skill-promotion-autopilot",
+      "expectedEnv": [],
+      "credentialEnv": [],
+      "owner": "kuro",
+      "capabilities": ["capability-promotion", "skill-iteration", "autonomous-backtest", "workflow-to-code"],
+      "trigger": {
+        "modes": ["reflect", "act"],
+        "keywords": ["skill promotion", "promotion candidate", "能力升級", "自我更新", "自我迭代", "湧現能力"],
+        "signals": ["cross_skill_pattern", "repeated_success_path", "capability_promotion_candidate"],
+        "taskTypes": ["ops", "code", "plan"],
+        "minPriority": 1
+      },
+      "requires": ["constraint-texture-analysis", "verification-before-completion", "autonomy-closure-workflow"],
+      "combinesWith": ["task-decomposition", "kg-context-synthesis", "progress-reporting"],
+      "verifier": "promotion candidate becomes a scheduler-visible task, ships through PR/deploy, then passes next-3-use backtest or produces an iterate task",
+      "contextFabric": {
+        "sources": ["skill-usage", "capability-promotion-candidate", "task-events", "github-prs", "autonomy-closure"],
+        "writes": ["skill-promotion-autopilot", "promotion-backtest", "skill-usage"],
+        "learnsFrom": ["repeated-success-paths", "failed-promotions", "token-savings", "workflow-overhead"],
+        "sharesWith": ["kg", "constraint-texture-analysis", "task-decomposition", "autonomy-closure-workflow"],
+        "emergenceSignals": ["cross_skill_pattern", "repeated_success_path", "capability_promotion_candidate"]
+      },
+      "iteration": {
+        "ledger": "memory/state/skill-promotion-autopilot.jsonl",
+        "minUses": 3,
+        "failureThreshold": 0.34,
+        "reviewCadenceDays": 3,
+        "updatePolicy": "self-edit-skill"
+      },
+      "readPolicy": "internal-service",
+      "writePolicy": "internal-service",
+      "notes": "Turns repeated high-success skill patterns into durable skill/workflow/script/CLI/code changes, then backtests the promoted capability against future usage."
+    },
+    {
       "service": "constraint-texture-analysis",
       "kind": "workflow",
       "defaultExpected": "constraint-texture",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "memory:repo:setup": "tsx scripts/setup-memory-repo.ts --init",
     "memory:repo:check": "tsx scripts/setup-memory-repo.ts --check",
     "memory:kg:promote": "tsx scripts/kg-promote-memory.ts",
+    "skill-promotion:autopilot": "tsx scripts/skill-promotion-autopilot.ts",
     "check:autonomy-closure": "tsx scripts/autonomy-closure-health.ts",
     "check:test-health": "tsx scripts/test-health-autopilot.ts",
     "setup": "pnpm install && pnpm build && npm link",

--- a/scripts/skill-promotion-autopilot.ts
+++ b/scripts/skill-promotion-autopilot.ts
@@ -1,0 +1,22 @@
+import { getMemoryRootDir } from '../src/memory-paths.js';
+import {
+  maybeQueueSkillPromotion,
+  summarizeSkillPromotionAutopilot,
+  sweepSkillPromotionBacktests,
+} from '../src/skill-promotion-autopilot.js';
+
+const args = new Set(process.argv.slice(2));
+const memoryDir = getMemoryRootDir();
+
+if (args.has('--queue')) {
+  const result = await maybeQueueSkillPromotion(memoryDir, {
+    triggerReason: 'skill-promotion-cli',
+    dryRun: args.has('--dry-run'),
+  });
+  process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+} else if (args.has('--sweep')) {
+  const result = sweepSkillPromotionBacktests(memoryDir);
+  process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+} else {
+  process.stdout.write(JSON.stringify(summarizeSkillPromotionAutopilot(memoryDir), null, 2) + '\n');
+}

--- a/src/agent-skill-manager.ts
+++ b/src/agent-skill-manager.ts
@@ -228,6 +228,7 @@ export function inferSkillSelectionInput(input: SkillRuntimeSelectionInput): Ski
   addSignalIf(signals, /(test failure|vitest|tsc|typecheck|regression|failing test)/i, text, 'test_failure');
   addSignalIf(signals, /(closure|autonomy|blocked|degraded|閉環)/i, text, 'autonomy_closure_blocked');
   addSignalIf(signals, /(tension|tradeoff|stakeholder|conflict|competing requirement|張力|取捨|衝突)/i, text, 'requirement_tension');
+  addSignalIf(signals, /(skill promotion|promotion candidate|capability promotion|能力升級|自我更新|自我迭代|湧現能力)/i, text, 'capability_promotion_candidate');
   addSignalIf(signals, /(complete|done|merge|deploy|ship|完成|部署)/i, text, 'before_done');
 
   addSignalIf(contextSignals, /(same root cause|same_root_cause|root cause family)/i, text, 'same_root_cause_family');

--- a/src/api.ts
+++ b/src/api.ts
@@ -179,6 +179,7 @@ import type { WorkIntent } from './brain-types.js';
 import { listAgentCapabilities, loadAgentRelationshipRegistry } from './agent-owned-identity.js';
 import { evaluatePublicWriteIdentity } from './public-write-identity.js';
 import { selectAgentSkills, summarizeSkillHealth, suggestPatternPromotions } from './agent-skill-manager.js';
+import { summarizeSkillPromotionAutopilot } from './skill-promotion-autopilot.js';
 
 // =============================================================================
 // Server Log Helper (re-exported from utils to avoid circular deps)
@@ -948,7 +949,7 @@ export function createApi(port = 3001): express.Express {
   app.use(createRateLimiter());
 
   // Request logging middleware (skip noisy polling endpoints)
-  const SILENT_PATHS = new Set(['/health', '/status', '/api/dashboard/behaviors', '/api/dashboard/learning', '/api/dashboard/journal', '/api/dashboard/cognition', '/api/dashboard/capabilities', '/api/dashboard/agent-arsenal', '/api/dashboard/public-write-identity', '/api/dashboard/agent-skills/select', '/api/dashboard/agent-skills/promotions', '/api/dashboard/context', '/api/dashboard/inner-state', '/api/dashboard/work-closure', '/api/events', '/api/room/stream', '/api/memory/structured', '/api/memory/history', '/api/memory/files']);
+  const SILENT_PATHS = new Set(['/health', '/status', '/api/dashboard/behaviors', '/api/dashboard/learning', '/api/dashboard/journal', '/api/dashboard/cognition', '/api/dashboard/capabilities', '/api/dashboard/agent-arsenal', '/api/dashboard/public-write-identity', '/api/dashboard/agent-skills/select', '/api/dashboard/agent-skills/promotions', '/api/dashboard/agent-skills/autopilot', '/api/dashboard/context', '/api/dashboard/inner-state', '/api/dashboard/work-closure', '/api/events', '/api/room/stream', '/api/memory/structured', '/api/memory/history', '/api/memory/files']);
   app.use((req: Request, res: Response, next: NextFunction) => {
     if (SILENT_PATHS.has(req.path)) { next(); return; }
     const start = Date.now();
@@ -2614,6 +2615,10 @@ export function createApi(port = 3001): express.Express {
       ledger: 'memory/state/skill-usage.jsonl',
       policy: 'Repeated high-success patterns should be promoted into the lowest-overhead durable form: skill, workflow, script, CLI, code, or hybrid capability.',
     });
+  });
+
+  app.get('/api/dashboard/agent-skills/autopilot', (_req: Request, res: Response) => {
+    res.json(summarizeSkillPromotionAutopilot(getMemoryRootDir()));
   });
 
   // Forge slots — worktree allocation health for dashboard tile (W7 F-d)

--- a/src/index.ts
+++ b/src/index.ts
@@ -206,6 +206,19 @@ export type {
 export { maybeQueueSelfResearch } from './self-research-autopilot.js';
 export type { SelfResearchAutopilotOptions, SelfResearchAutopilotResult } from './self-research-autopilot.js';
 export {
+  maybeQueueSkillPromotion,
+  readSkillPromotionRecords,
+  summarizeSkillPromotionAutopilot,
+  sweepSkillPromotionBacktests,
+} from './skill-promotion-autopilot.js';
+export type {
+  SkillPromotionAutopilotOptions,
+  SkillPromotionAutopilotRecord,
+  SkillPromotionAutopilotResult,
+  SkillPromotionAutopilotSummary,
+  SkillPromotionBacktestResult,
+} from './skill-promotion-autopilot.js';
+export {
   closeResolvedCorrectionTasks,
   ensureCorrectionTask,
   evaluateCorrectionGate,

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -2388,6 +2388,20 @@ export class AgentLoop {
       } catch (e) { slog('WARN', `autonomy closure health failed: ${e}`); }
 
       try {
+        const { maybeQueueSkillPromotion, sweepSkillPromotionBacktests } = await import('./skill-promotion-autopilot.js');
+        const backtest = sweepSkillPromotionBacktests(memDir);
+        if (backtest.updated > 0) {
+          slog('SKILL-PROMOTION', `backtest updated=${backtest.updated} accepted=${backtest.accepted} iterate=${backtest.iterate}`);
+        }
+        const promotion = await maybeQueueSkillPromotion(memDir, {
+          triggerReason: currentTriggerReason,
+        });
+        if (promotion.queued) {
+          slog('SKILL-PROMOTION', `queued ${promotion.candidate?.recommendedKind} task=${promotion.task?.id.slice(0, 12)}`);
+        }
+      } catch (e) { slog('WARN', `skill promotion autopilot failed: ${e}`); }
+
+      try {
         const { maybeQueueSelfResearch } = await import('./self-research-autopilot.js');
         const selfResearch = await maybeQueueSelfResearch(memDir, {
           triggerReason: currentTriggerReason,

--- a/src/skill-promotion-autopilot.ts
+++ b/src/skill-promotion-autopilot.ts
@@ -1,0 +1,333 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { eventBus } from './event-bus.js';
+import { appendMemoryIndexEntry, queryMemoryIndexSync, type MemoryIndexEntry } from './memory-index.js';
+import {
+  readSkillUsage,
+  suggestPatternPromotions,
+  type PatternPromotionCandidate,
+  type SkillUsageEvent,
+} from './agent-skill-manager.js';
+
+const LEDGER_FILE = 'skill-promotion-autopilot.jsonl';
+const ACTIVE_TASK_STATUSES = ['pending', 'in_progress', 'needs-decomposition', 'blocked', 'hold'];
+const TERMINAL_TASK_STATUSES = ['completed', 'done'];
+
+export type SkillPromotionStatus = 'queued' | 'observing' | 'accepted' | 'iterate';
+
+export interface SkillPromotionObservationPolicy {
+  nextUses: number;
+  minSuccessRate: number;
+}
+
+export interface SkillPromotionAutopilotRecord {
+  type: 'skill_promotion_autopilot';
+  id: string;
+  pattern: string;
+  service: string;
+  recommendedKind: PatternPromotionCandidate['recommendedKind'];
+  status: SkillPromotionStatus;
+  queuedAt: string;
+  queuedTaskId?: string;
+  implementedAt?: string;
+  decidedAt?: string;
+  observedUses?: number;
+  observedSuccessRate?: number;
+  observationPolicy: SkillPromotionObservationPolicy;
+  rationale: string[];
+  verifier: string;
+  candidate: PatternPromotionCandidate['suggestedCapability'];
+  note?: string;
+}
+
+export interface SkillPromotionAutopilotOptions {
+  now?: Date;
+  triggerReason?: string | null;
+  maxActive?: number;
+  dryRun?: boolean;
+  observationPolicy?: Partial<SkillPromotionObservationPolicy>;
+}
+
+export interface SkillPromotionAutopilotResult {
+  queued: boolean;
+  reason: string;
+  candidate?: PatternPromotionCandidate;
+  task?: MemoryIndexEntry;
+  record?: SkillPromotionAutopilotRecord;
+}
+
+export interface SkillPromotionBacktestResult {
+  updated: number;
+  accepted: number;
+  iterate: number;
+  records: SkillPromotionAutopilotRecord[];
+}
+
+export interface SkillPromotionAutopilotSummary {
+  ledger: string;
+  candidates: PatternPromotionCandidate[];
+  records: SkillPromotionAutopilotRecord[];
+  active: SkillPromotionAutopilotRecord[];
+  observing: SkillPromotionAutopilotRecord[];
+  accepted: SkillPromotionAutopilotRecord[];
+  iterate: SkillPromotionAutopilotRecord[];
+  nextCandidate?: PatternPromotionCandidate;
+  policy: string;
+}
+
+export async function maybeQueueSkillPromotion(
+  memoryDir: string,
+  opts: SkillPromotionAutopilotOptions = {},
+): Promise<SkillPromotionAutopilotResult> {
+  if (!isPromotionTrigger(opts.triggerReason ?? '')) {
+    return { queued: false, reason: 'not-promotion-trigger' };
+  }
+
+  const maxActive = opts.maxActive ?? 1;
+  const activeTasks = activePromotionTasks(memoryDir);
+  if (activeTasks.length >= maxActive) {
+    return { queued: false, reason: 'active-promotion-task-exists' };
+  }
+
+  const latest = latestRecords(memoryDir);
+  const candidate = nextPromotionCandidate(memoryDir, latest);
+  if (!candidate) return { queued: false, reason: 'no-eligible-candidate' };
+
+  const record = createQueuedRecord(candidate, opts);
+  if (opts.dryRun) return { queued: true, reason: 'dry-run', candidate, record };
+
+  const task = await appendMemoryIndexEntry(memoryDir, {
+    type: 'task',
+    status: 'pending',
+    summary: promotionTaskTitle(candidate),
+    tags: ['skill-promotion', 'autopilot', candidate.recommendedKind],
+    refs: ['memory/state/skill-usage.jsonl', `pattern:${candidate.pattern}`],
+    payload: {
+      origin: 'skill-promotion-autopilot',
+      priority: 1,
+      pattern: candidate.pattern,
+      recommended_kind: candidate.recommendedKind,
+      suggested_capability: candidate.suggestedCapability,
+      required_skills: candidate.skills,
+      acceptance_criteria: promotionAcceptance(candidate, record.observationPolicy),
+      verify_command: 'pnpm typecheck && pnpm test && pnpm check:autonomy-closure -- --json',
+      effect_backtest: {
+        ledger: `memory/state/${LEDGER_FILE}`,
+        next_uses: record.observationPolicy.nextUses,
+        min_success_rate: record.observationPolicy.minSuccessRate,
+      },
+    },
+  });
+
+  const persisted = { ...record, queuedTaskId: task.id };
+  appendPromotionRecord(memoryDir, persisted);
+  eventBus.emit('action:task', {
+    event: 'skill-promotion-queued',
+    taskId: task.id,
+    pattern: candidate.pattern,
+    recommendedKind: candidate.recommendedKind,
+    service: candidate.suggestedCapability.service,
+  });
+
+  return { queued: true, reason: 'queued', candidate, task, record: persisted };
+}
+
+export function sweepSkillPromotionBacktests(
+  memoryDir: string,
+  opts: SkillPromotionAutopilotOptions = {},
+): SkillPromotionBacktestResult {
+  const now = (opts.now ?? new Date()).toISOString();
+  const records = latestRecords(memoryDir);
+  const usage = readSkillUsage(memoryDir);
+  let updated = 0;
+  let accepted = 0;
+  let iterate = 0;
+  const written: SkillPromotionAutopilotRecord[] = [];
+
+  for (const record of records.values()) {
+    if (record.status === 'queued') {
+      const task = record.queuedTaskId
+        ? queryMemoryIndexSync(memoryDir, { id: record.queuedTaskId, limit: 1 })[0]
+        : undefined;
+      if (!task || !TERMINAL_TASK_STATUSES.includes(String(task.status))) continue;
+      const next: SkillPromotionAutopilotRecord = {
+        ...record,
+        status: 'observing',
+        implementedAt: now,
+        note: 'implementation task completed; observing next skill-usage events',
+      };
+      appendPromotionRecord(memoryDir, next);
+      written.push(next);
+      updated++;
+      continue;
+    }
+
+    if (record.status !== 'observing' || !record.implementedAt) continue;
+    const observed = observedUsage(record, usage);
+    if (observed.uses < record.observationPolicy.nextUses) continue;
+
+    const status: SkillPromotionStatus = observed.successRate >= record.observationPolicy.minSuccessRate
+      ? 'accepted'
+      : 'iterate';
+    const next: SkillPromotionAutopilotRecord = {
+      ...record,
+      status,
+      decidedAt: now,
+      observedUses: observed.uses,
+      observedSuccessRate: observed.successRate,
+      note: status === 'accepted'
+        ? 'promotion backtest passed'
+        : 'promotion backtest failed; revise or disable promoted capability',
+    };
+    appendPromotionRecord(memoryDir, next);
+    written.push(next);
+    updated++;
+    if (status === 'accepted') accepted++;
+    if (status === 'iterate') iterate++;
+  }
+
+  return { updated, accepted, iterate, records: written };
+}
+
+export function summarizeSkillPromotionAutopilot(memoryDir: string): SkillPromotionAutopilotSummary {
+  const candidates = suggestPatternPromotions(memoryDir);
+  const records = [...latestRecords(memoryDir).values()]
+    .sort((a, b) => (b.decidedAt ?? b.implementedAt ?? b.queuedAt).localeCompare(a.decidedAt ?? a.implementedAt ?? a.queuedAt));
+  const active = records.filter(record => record.status === 'queued');
+  const observing = records.filter(record => record.status === 'observing');
+  const accepted = records.filter(record => record.status === 'accepted');
+  const iterate = records.filter(record => record.status === 'iterate');
+  return {
+    ledger: `memory/state/${LEDGER_FILE}`,
+    candidates,
+    records,
+    active,
+    observing,
+    accepted,
+    iterate,
+    nextCandidate: nextPromotionCandidate(memoryDir, latestRecords(memoryDir)),
+    policy: 'Queue at most one skill-promotion task; after implementation, observe the next 3 matching skill-usage events and accept only if successRate >= 0.67.',
+  };
+}
+
+export function readSkillPromotionRecords(memoryDir: string): SkillPromotionAutopilotRecord[] {
+  const filePath = promotionLedgerPath(memoryDir);
+  if (!fs.existsSync(filePath)) return [];
+  const records: SkillPromotionAutopilotRecord[] = [];
+  for (const line of fs.readFileSync(filePath, 'utf-8').split('\n')) {
+    if (!line.trim()) continue;
+    try {
+      const parsed = JSON.parse(line) as SkillPromotionAutopilotRecord;
+      if (parsed.type === 'skill_promotion_autopilot' && parsed.id && parsed.pattern && parsed.status) {
+        records.push(parsed);
+      }
+    } catch {
+      // Ignore malformed telemetry. The autopilot remains best-effort.
+    }
+  }
+  return records;
+}
+
+function nextPromotionCandidate(
+  memoryDir: string,
+  latest: Map<string, SkillPromotionAutopilotRecord>,
+): PatternPromotionCandidate | undefined {
+  return suggestPatternPromotions(memoryDir).find(candidate => {
+    const id = promotionId(candidate);
+    const record = latest.get(id);
+    if (!record) return true;
+    return record.status === 'iterate';
+  });
+}
+
+function activePromotionTasks(memoryDir: string): MemoryIndexEntry[] {
+  return queryMemoryIndexSync(memoryDir, { type: ['task'], status: ACTIVE_TASK_STATUSES })
+    .filter(task => {
+      const payload = (task.payload ?? {}) as Record<string, unknown>;
+      return payload.origin === 'skill-promotion-autopilot'
+        || (task.summary ?? '').includes('skill promotion:');
+    });
+}
+
+function createQueuedRecord(
+  candidate: PatternPromotionCandidate,
+  opts: SkillPromotionAutopilotOptions,
+): SkillPromotionAutopilotRecord {
+  const policy = {
+    nextUses: opts.observationPolicy?.nextUses ?? 3,
+    minSuccessRate: opts.observationPolicy?.minSuccessRate ?? 0.67,
+  };
+  return {
+    type: 'skill_promotion_autopilot',
+    id: promotionId(candidate),
+    pattern: candidate.pattern,
+    service: candidate.suggestedCapability.service,
+    recommendedKind: candidate.recommendedKind,
+    status: 'queued',
+    queuedAt: (opts.now ?? new Date()).toISOString(),
+    observationPolicy: policy,
+    rationale: candidate.rationale,
+    verifier: candidate.suggestedCapability.verifier,
+    candidate: candidate.suggestedCapability,
+  };
+}
+
+function appendPromotionRecord(memoryDir: string, record: SkillPromotionAutopilotRecord): void {
+  const filePath = promotionLedgerPath(memoryDir);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.appendFileSync(filePath, JSON.stringify(record) + '\n', 'utf-8');
+}
+
+function latestRecords(memoryDir: string): Map<string, SkillPromotionAutopilotRecord> {
+  const latest = new Map<string, SkillPromotionAutopilotRecord>();
+  for (const record of readSkillPromotionRecords(memoryDir)) latest.set(record.id, record);
+  return latest;
+}
+
+function observedUsage(record: SkillPromotionAutopilotRecord, usage: SkillUsageEvent[]): { uses: number; successRate: number } {
+  const since = Date.parse(record.implementedAt ?? '');
+  const observed = usage.filter(event => {
+    if (Number.isFinite(since) && Date.parse(event.ts ?? '') < since) return false;
+    return normalizePattern(event.pattern ?? '') === normalizePattern(record.pattern)
+      || event.skill === record.service
+      || event.combinedWith?.includes(record.service);
+  });
+  const success = observed.filter(event => event.outcome === 'success').length;
+  return {
+    uses: observed.length,
+    successRate: observed.length > 0 ? success / observed.length : 0,
+  };
+}
+
+function promotionTaskTitle(candidate: PatternPromotionCandidate): string {
+  return `P1 skill promotion: turn ${candidate.pattern.slice(0, 90)} into ${candidate.recommendedKind}`;
+}
+
+function promotionAcceptance(candidate: PatternPromotionCandidate, policy: SkillPromotionObservationPolicy): string {
+  return [
+    `Implement ${candidate.suggestedCapability.service} as ${candidate.recommendedKind} using the lowest-overhead durable form.`,
+    `Required loop: code/script/workflow change -> PR -> review consensus -> merge -> deploy -> record skill usage.`,
+    `Backtest: next ${policy.nextUses} matching skill-usage events must keep successRate >= ${policy.minSuccessRate}.`,
+    `Verifier: ${candidate.suggestedCapability.verifier}`,
+  ].join(' ');
+}
+
+function promotionId(candidate: PatternPromotionCandidate): string {
+  return `skill-promotion:${candidate.suggestedCapability.service}`;
+}
+
+function promotionLedgerPath(memoryDir: string): string {
+  return path.join(memoryDir, 'state', LEDGER_FILE);
+}
+
+function isPromotionTrigger(trigger: string): boolean {
+  return trigger === ''
+    || trigger.includes('heartbeat')
+    || trigger.startsWith('workspace')
+    || trigger.includes('skill-promotion')
+    || trigger.includes('self-improvement');
+}
+
+function normalizePattern(pattern: string): string {
+  return pattern.toLowerCase().replace(/\s+/g, ' ').trim();
+}

--- a/tests/skill-promotion-autopilot.test.ts
+++ b/tests/skill-promotion-autopilot.test.ts
@@ -1,0 +1,98 @@
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { recordSkillUsage } from '../src/agent-skill-manager.js';
+import { queryMemoryIndexSync, updateMemoryIndexEntry } from '../src/memory-index.js';
+import {
+  maybeQueueSkillPromotion,
+  readSkillPromotionRecords,
+  summarizeSkillPromotionAutopilot,
+  sweepSkillPromotionBacktests,
+} from '../src/skill-promotion-autopilot.js';
+
+function memoryDir(): string {
+  return mkdtempSync(join(tmpdir(), 'mini-agent-skill-promotion-'));
+}
+
+function seedPromotionUsage(dir: string, pattern = 'always-on autonomy health gate for phantom task suppression'): void {
+  for (let i = 0; i < 3; i += 1) {
+    recordSkillUsage(dir, {
+      skill: 'constraint-texture-analysis',
+      outcome: 'success',
+      pattern,
+      combinedWith: ['kg-context-synthesis', 'task-decomposition'],
+      note: 'runtime gate should close loop automatically',
+      ts: `2026-05-07T00:0${i}:00.000Z`,
+    });
+  }
+}
+
+describe('skill promotion autopilot', () => {
+  it('queues the top promotion candidate as a scheduler-visible task', async () => {
+    const dir = memoryDir();
+    seedPromotionUsage(dir);
+
+    const result = await maybeQueueSkillPromotion(dir, {
+      triggerReason: 'heartbeat',
+      now: new Date('2026-05-07T01:00:00.000Z'),
+    });
+
+    expect(result.queued).toBe(true);
+    expect(result.task?.summary).toContain('P1 skill promotion:');
+    expect(result.task?.payload).toEqual(expect.objectContaining({
+      origin: 'skill-promotion-autopilot',
+      recommended_kind: 'code',
+      effect_backtest: expect.objectContaining({ next_uses: 3 }),
+    }));
+    expect(queryMemoryIndexSync(dir, { type: ['task'], status: ['pending'] })).toHaveLength(1);
+    expect(readSkillPromotionRecords(dir)[0]).toEqual(expect.objectContaining({
+      status: 'queued',
+      queuedTaskId: result.task?.id,
+    }));
+  });
+
+  it('does not queue a second candidate while a promotion task is active', async () => {
+    const dir = memoryDir();
+    seedPromotionUsage(dir);
+
+    await maybeQueueSkillPromotion(dir, { triggerReason: 'heartbeat' });
+    const second = await maybeQueueSkillPromotion(dir, { triggerReason: 'heartbeat' });
+
+    expect(second).toEqual(expect.objectContaining({
+      queued: false,
+      reason: 'active-promotion-task-exists',
+    }));
+  });
+
+  it('moves completed promotion tasks into observing and accepts after successful backtest uses', async () => {
+    const dir = memoryDir();
+    const pattern = 'always-on autonomy health gate for phantom task suppression';
+    seedPromotionUsage(dir, pattern);
+    const queued = await maybeQueueSkillPromotion(dir, {
+      triggerReason: 'heartbeat',
+      now: new Date('2026-05-07T01:00:00.000Z'),
+    });
+    await updateMemoryIndexEntry(dir, queued.task!.id, { status: 'completed' });
+
+    const observing = sweepSkillPromotionBacktests(dir, { now: new Date('2026-05-07T02:00:00.000Z') });
+    expect(observing.updated).toBe(1);
+    expect(observing.records[0].status).toBe('observing');
+
+    for (let i = 0; i < 3; i += 1) {
+      recordSkillUsage(dir, {
+        skill: 'constraint-texture-analysis',
+        outcome: 'success',
+        pattern,
+        ts: `2026-05-07T03:0${i}:00.000Z`,
+      });
+    }
+
+    const accepted = sweepSkillPromotionBacktests(dir, { now: new Date('2026-05-07T04:00:00.000Z') });
+    expect(accepted.accepted).toBe(1);
+    expect(summarizeSkillPromotionAutopilot(dir).accepted[0]).toEqual(expect.objectContaining({
+      observedUses: 3,
+      observedSuccessRate: 1,
+    }));
+  });
+});


### PR DESCRIPTION
## Summary
- add skill-promotion-autopilot to turn repeated high-success skill patterns into scheduler-visible implementation tasks
- add next-3-use backtest ledger so promoted skill/workflow/script/code changes are accepted or sent back to iteration by evidence
- expose /api/dashboard/agent-skills/autopilot and add a CLI script for queue/status/sweep
- register the autopilot as a managed workflow capability and run it before generic self-research

## Verification
- [x] pnpm typecheck
- [x] pnpm exec vitest run tests/skill-promotion-autopilot.test.ts tests/agent-skill-manager.test.ts
- [x] MINI_AGENT_MEMORY_DIR=/Users/user/Workspace/mini-agent-memory/memory pnpm exec tsx scripts/skill-promotion-autopilot.ts --queue --dry-run selected a live code promotion candidate