### PR TITLE
fix(correction): ignore bounded maintenance lane responsiveness

### DIFF
--- a/src/correction-gate.ts
+++ b/src/correction-gate.ts
@@ -70,7 +70,8 @@ export function evaluateCorrectionGate(memoryDir: string, repoRoot = process.cwd
 
   const activeTasks = allTasks.filter(t =>
     ['pending', 'in_progress'].includes(t.status) &&
-    !(t.payload as Record<string, unknown>)?.goal_id
+    !(t.payload as Record<string, unknown>)?.goal_id &&
+    !isBackgroundMaintenanceTask(t)
   );
   const avgStaleness = activeTasks.length === 0 ? 0 :
     activeTasks.reduce((sum, t) => sum + ((t.payload as Record<string, unknown>)?.ticksSinceLastProgress as number ?? 0), 0) / activeTasks.length;
@@ -199,6 +200,13 @@ export function evaluateCorrectionGate(memoryDir: string, repoRoot = process.cwd
     shipTruth,
     acknowledgedHolds,
   };
+}
+
+function isBackgroundMaintenanceTask(task: MemoryIndexEntry): boolean {
+  const payload = (task.payload ?? {}) as Record<string, unknown>;
+  if (payload.origin === 'kg-discussion-janitor') return true;
+  const priority = Number(payload.priority);
+  return Number.isFinite(priority) && priority >= 2 && Boolean(task.tags?.includes('discussion-lifecycle'));
 }
 
 export async function ensureCorrectionTask(memoryDir: string, snapshot = evaluateCorrectionGate(memoryDir)): Promise<MemoryIndexEntry | null> {

--- a/tests/correction-gate.test.ts
+++ b/tests/correction-gate.test.ts
@@ -68,6 +68,26 @@ describe('correction gate', () => {
     expect(correctionTasks).toHaveLength(1);
   });
 
+  it('does not suppress exploration for bounded background maintenance tasks', async () => {
+    await appendMemoryIndexEntry(tmpDir, {
+      type: 'task',
+      status: 'pending',
+      summary: 'KG discussion old topic: close or refresh stale context',
+      tags: ['kg', 'discussion-lifecycle', 'stale-discussion'],
+      payload: {
+        origin: 'kg-discussion-janitor',
+        priority: 2,
+        ticksSinceLastProgress: 50,
+      },
+    });
+    invalidateIndexCache();
+
+    const snapshot = evaluateCorrectionGate(tmpDir, tmpDir);
+
+    expect(snapshot.reasons.map(r => r.type)).not.toContain('low-responsiveness');
+    expect(snapshot.suppressedActions).not.toContain('self-research');
+  });
+
   it('parses git ahead state as pending-push ship truth', () => {
     const parsed = parseGitStatusPorcelainV2([
       '# branch.oid abc123',


### PR DESCRIPTION
## Summary
- exclude bounded background maintenance tasks from correction-gate responsiveness scoring
- prevents KG discussion lifecycle cleanup from suppressing self-research/open-cycle discovery
- add regression coverage for bounded maintenance tasks with high staleness

## Verification
- [x] pnpm typecheck
- [x] pnpm exec vitest run tests/correction-gate.test.ts tests/kg-discussion-janitor.test.ts