### PR TITLE
fix(scheduler): hide held correction tasks from p0 preview

### DIFF
--- a/src/memory-index.ts
+++ b/src/memory-index.ts
@@ -22,6 +22,8 @@ import { slog, diagLog, tokenizeForMatch } from './utils.js';
 import { eventBus } from './event-bus.js';
 import { writeMemoryTriple } from './kg-memory.js';
 import type { ParsedTags } from './types.js';
+import { loadCorrectionHolds, findActiveHold } from './correction-holds.js';
+import type { CorrectionReasonType } from './correction-gate.js';
 
 // =============================================================================
 // Types
@@ -1706,12 +1708,33 @@ export function getP0TaskPreviews(memoryDir: string): string[] {
   // task-events.jsonl. Phantom tasks (visible only via relations.jsonl) are
   // skipped so they don't re-inject into the heartbeat prompt each cycle.
   const taskEventIds = new Set(getCachedBucket(memoryDir, 'task-events').keys());
+  // Issue #289: mirror scheduler's correction-task hold filter so the prompt
+  // header preview stays consistent with what scheduler will actually
+  // dispatch. Without this, held correction tasks (e.g. low-responsiveness
+  // during quota outage) re-emit P0 labels every cycle even though scheduler
+  // suppresses dispatch.
+  const holds = loadCorrectionHolds(memoryDir);
+  const repoRoot = path.resolve(memoryDir, '..', '..');
   return queryMemoryIndexSync(memoryDir, {
     type: ['task', 'goal'],
     status: ['pending', 'in_progress'],
   })
     .filter(t => t.type !== 'task' || taskEventIds.has(t.id))
     .filter(t => getTaskPriority(t) === 0)
+    .filter(t => {
+      const summary = t.summary ?? '';
+      const isCorrection = summary.includes('correction gate');
+      if (!isCorrection) return true;
+      const payload = (t.payload ?? {}) as Record<string, unknown>;
+      const reasonFromPayload = typeof payload.correction_reason_type === 'string'
+        ? payload.correction_reason_type
+        : null;
+      const match = summary.match(/correction gate: resolve ([a-z-]+)/i);
+      const reason = reasonFromPayload ?? match?.[1] ?? null;
+      if (!reason) return true;
+      const hold = findActiveHold(holds, reason as CorrectionReasonType, {}, { repoRoot });
+      return !hold;
+    })
     .map(t => `P0: ${t.summary ?? t.id}`);
 }
 

--- a/tests/scheduler-phantom-guard.test.ts
+++ b/tests/scheduler-phantom-guard.test.ts
@@ -24,6 +24,7 @@ import {
   invalidateIndexCache,
   queryMemoryIndexSync,
 } from '../src/memory-index.js';
+import { appendCorrectionHold } from '../src/correction-holds.js';
 
 let tmpDir: string;
 
@@ -211,5 +212,28 @@ describe('issue #257 — phantom task guard in getP0TaskPreviews', () => {
     expect(previews.some(p => p.includes('Real P0 incident response'))).toBe(true);
     expect(previews.some(p => p.includes(phantomId))).toBe(false);
     expect(previews.some(p => p.includes('max-turns failure'))).toBe(false);
+  });
+
+  it('held correction-gate P0 task is excluded from preview list', async () => {
+    await appendMemoryIndexEntry(tmpDir, {
+      type: 'task',
+      status: 'pending',
+      summary: 'P0 correction gate: resolve low-responsiveness',
+      payload: {
+        priority: 0,
+        correction_reason_type: 'low-responsiveness',
+      },
+    });
+    appendCorrectionHold(tmpDir, {
+      id: 'hold-low-responsive-maintenance',
+      correction_reason_type: 'low-responsiveness',
+      reason: 'bounded maintenance lane is allowed to age without suppressing prompt header',
+      unblock_when: { kind: 'timeout', until: '2999-01-01T00:00:00.000Z' },
+      created_at: new Date().toISOString(),
+    });
+    invalidateIndexCache();
+
+    const previews = getP0TaskPreviews(tmpDir);
+    expect(previews.some(p => p.includes('low-responsiveness'))).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- make prompt-header P0 previews respect active correction holds
- prevents held correction-gate tasks from re-emitting P0 labels every cycle while scheduler dispatch is already suppressed
- add regression coverage for held correction-gate P0 preview filtering

## Verification
- [x] pnpm typecheck
- [x] pnpm exec vitest run tests/scheduler-phantom-guard.test.ts tests/correction-gate.test.ts