### PR TITLE
fix(skills): close promotion autopilot stale loop

### DIFF
--- a/scripts/skill-promotion-autopilot.ts
+++ b/scripts/skill-promotion-autopilot.ts
@@ -15,7 +15,7 @@ if (args.has('--queue')) {
   });
   process.stdout.write(JSON.stringify(result, null, 2) + '\n');
 } else if (args.has('--sweep')) {
-  const result = sweepSkillPromotionBacktests(memoryDir);
+  const result = await sweepSkillPromotionBacktests(memoryDir);
   process.stdout.write(JSON.stringify(result, null, 2) + '\n');
 } else {
   process.stdout.write(JSON.stringify(summarizeSkillPromotionAutopilot(memoryDir), null, 2) + '\n');

--- a/src/agent-skill-manager.ts
+++ b/src/agent-skill-manager.ts
@@ -358,6 +358,7 @@ export function suggestPatternPromotions(
     const savedTokensEstimate = sum(list.map(event => event.savedTokensEstimate));
     const savedMinutesEstimate = sum(list.map(event => event.savedMinutesEstimate));
     if (uses < 3 || successRate < 0.67) continue;
+    if (!hasPromotionImpact(savedTokensEstimate, savedMinutesEstimate)) continue;
 
     const skills = unique(list.flatMap(event => [event.skill, ...(event.combinedWith ?? [])]));
     const recommendedKind = choosePromotionKind(pattern, list, savedTokensEstimate, savedMinutesEstimate);
@@ -445,6 +446,10 @@ function promotionRationale(
     ...(savedMinutesEstimate > 0 ? [`estimated time savings=${Math.round(savedMinutesEstimate)}m`] : []),
     `recommended as ${kind} because that is the lowest-overhead durable form for this pattern`,
   ];
+}
+
+function hasPromotionImpact(savedTokensEstimate: number, savedMinutesEstimate: number): boolean {
+  return savedTokensEstimate > 0 || savedMinutesEstimate > 0;
 }
 
 function normalizePattern(pattern: string): string {

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -2389,9 +2389,9 @@ export class AgentLoop {
 
       try {
         const { maybeQueueSkillPromotion, sweepSkillPromotionBacktests } = await import('./skill-promotion-autopilot.js');
-        const backtest = sweepSkillPromotionBacktests(memDir);
+        const backtest = await sweepSkillPromotionBacktests(memDir);
         if (backtest.updated > 0) {
-          slog('SKILL-PROMOTION', `backtest updated=${backtest.updated} accepted=${backtest.accepted} iterate=${backtest.iterate}`);
+          slog('SKILL-PROMOTION', `backtest updated=${backtest.updated} accepted=${backtest.accepted} iterate=${backtest.iterate} dismissed=${backtest.dismissed}`);
         }
         const promotion = await maybeQueueSkillPromotion(memDir, {
           triggerReason: currentTriggerReason,

--- a/src/skill-promotion-autopilot.ts
+++ b/src/skill-promotion-autopilot.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { eventBus } from './event-bus.js';
-import { appendMemoryIndexEntry, queryMemoryIndexSync, type MemoryIndexEntry } from './memory-index.js';
+import { appendMemoryIndexEntry, queryMemoryIndexSync, updateMemoryIndexEntry, type MemoryIndexEntry } from './memory-index.js';
 import {
   readSkillUsage,
   suggestPatternPromotions,
@@ -11,9 +11,9 @@ import {
 
 const LEDGER_FILE = 'skill-promotion-autopilot.jsonl';
 const ACTIVE_TASK_STATUSES = ['pending', 'in_progress', 'needs-decomposition', 'blocked', 'hold'];
-const TERMINAL_TASK_STATUSES = ['completed', 'done'];
+const TERMINAL_TASK_STATUSES = ['completed', 'done', 'abandoned', 'dropped', 'deleted'];
 
-export type SkillPromotionStatus = 'queued' | 'observing' | 'accepted' | 'iterate';
+export type SkillPromotionStatus = 'queued' | 'observing' | 'accepted' | 'iterate' | 'dismissed';
 
 export interface SkillPromotionObservationPolicy {
   nextUses: number;
@@ -60,6 +60,7 @@ export interface SkillPromotionBacktestResult {
   updated: number;
   accepted: number;
   iterate: number;
+  dismissed: number;
   records: SkillPromotionAutopilotRecord[];
 }
 
@@ -71,6 +72,7 @@ export interface SkillPromotionAutopilotSummary {
   observing: SkillPromotionAutopilotRecord[];
   accepted: SkillPromotionAutopilotRecord[];
   iterate: SkillPromotionAutopilotRecord[];
+  dismissed: SkillPromotionAutopilotRecord[];
   nextCandidate?: PatternPromotionCandidate;
   policy: string;
 }
@@ -132,24 +134,65 @@ export async function maybeQueueSkillPromotion(
   return { queued: true, reason: 'queued', candidate, task, record: persisted };
 }
 
-export function sweepSkillPromotionBacktests(
+export async function sweepSkillPromotionBacktests(
   memoryDir: string,
   opts: SkillPromotionAutopilotOptions = {},
-): SkillPromotionBacktestResult {
+): Promise<SkillPromotionBacktestResult> {
   const now = (opts.now ?? new Date()).toISOString();
   const records = latestRecords(memoryDir);
   const usage = readSkillUsage(memoryDir);
   let updated = 0;
   let accepted = 0;
   let iterate = 0;
+  let dismissed = 0;
   const written: SkillPromotionAutopilotRecord[] = [];
+  const eligiblePromotionIds = new Set(suggestPatternPromotions(memoryDir).map(promotionId));
 
   for (const record of records.values()) {
     if (record.status === 'queued') {
       const task = record.queuedTaskId
         ? queryMemoryIndexSync(memoryDir, { id: record.queuedTaskId, limit: 1 })[0]
         : undefined;
+      if (!eligiblePromotionIds.has(record.id)) {
+        if (task && ACTIVE_TASK_STATUSES.includes(String(task.status))) {
+          const payload = (task.payload ?? {}) as Record<string, unknown>;
+          await updateMemoryIndexEntry(memoryDir, task.id, {
+            status: 'abandoned',
+            payload: {
+              ...payload,
+              autoAbandoned: true,
+              abandoned_reason: 'skill-promotion-insufficient-impact-evidence',
+              abandoned_at: now,
+              ticksSinceLastProgress: 0,
+            },
+          });
+        }
+        const next: SkillPromotionAutopilotRecord = {
+          ...record,
+          status: 'dismissed',
+          decidedAt: now,
+          note: 'promotion dismissed because the pattern no longer has measurable token/time impact evidence',
+        };
+        appendPromotionRecord(memoryDir, next);
+        written.push(next);
+        updated++;
+        dismissed++;
+        continue;
+      }
       if (!task || !TERMINAL_TASK_STATUSES.includes(String(task.status))) continue;
+      if (!['completed', 'done'].includes(String(task.status))) {
+        const next: SkillPromotionAutopilotRecord = {
+          ...record,
+          status: 'iterate',
+          decidedAt: now,
+          note: `implementation task ended as ${task.status}; revise promotion before retrying`,
+        };
+        appendPromotionRecord(memoryDir, next);
+        written.push(next);
+        updated++;
+        iterate++;
+        continue;
+      }
       const next: SkillPromotionAutopilotRecord = {
         ...record,
         status: 'observing',
@@ -186,7 +229,7 @@ export function sweepSkillPromotionBacktests(
     if (status === 'iterate') iterate++;
   }
 
-  return { updated, accepted, iterate, records: written };
+  return { updated, accepted, iterate, dismissed, records: written };
 }
 
 export function summarizeSkillPromotionAutopilot(memoryDir: string): SkillPromotionAutopilotSummary {
@@ -197,6 +240,7 @@ export function summarizeSkillPromotionAutopilot(memoryDir: string): SkillPromot
   const observing = records.filter(record => record.status === 'observing');
   const accepted = records.filter(record => record.status === 'accepted');
   const iterate = records.filter(record => record.status === 'iterate');
+  const dismissed = records.filter(record => record.status === 'dismissed');
   return {
     ledger: `memory/state/${LEDGER_FILE}`,
     candidates,
@@ -205,8 +249,9 @@ export function summarizeSkillPromotionAutopilot(memoryDir: string): SkillPromot
     observing,
     accepted,
     iterate,
+    dismissed,
     nextCandidate: nextPromotionCandidate(memoryDir, latestRecords(memoryDir)),
-    policy: 'Queue at most one skill-promotion task; after implementation, observe the next 3 matching skill-usage events and accept only if successRate >= 0.67.',
+    policy: 'Queue at most one skill-promotion task with measurable token/time impact evidence; dismiss queued promotions that lose eligibility; after implementation, observe the next 3 matching skill-usage events and accept only if successRate >= 0.67.',
   };
 }
 
@@ -306,6 +351,7 @@ function promotionTaskTitle(candidate: PatternPromotionCandidate): string {
 function promotionAcceptance(candidate: PatternPromotionCandidate, policy: SkillPromotionObservationPolicy): string {
   return [
     `Implement ${candidate.suggestedCapability.service} as ${candidate.recommendedKind} using the lowest-overhead durable form.`,
+    `Impact evidence: savedTokens=${Math.round(candidate.savedTokensEstimate)}, savedMinutes=${Math.round(candidate.savedMinutesEstimate)}.`,
     `Required loop: code/script/workflow change -> PR -> review consensus -> merge -> deploy -> record skill usage.`,
     `Backtest: next ${policy.nextUses} matching skill-usage events must keep successRate >= ${policy.minSuccessRate}.`,
     `Verifier: ${candidate.suggestedCapability.verifier}`,

--- a/tests/skill-promotion-autopilot.test.ts
+++ b/tests/skill-promotion-autopilot.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
@@ -21,6 +21,7 @@ function seedPromotionUsage(dir: string, pattern = 'always-on autonomy health ga
       skill: 'constraint-texture-analysis',
       outcome: 'success',
       pattern,
+      savedTokensEstimate: 2_000,
       combinedWith: ['kg-context-synthesis', 'task-decomposition'],
       note: 'runtime gate should close loop automatically',
       ts: `2026-05-07T00:0${i}:00.000Z`,
@@ -75,7 +76,7 @@ describe('skill promotion autopilot', () => {
     });
     await updateMemoryIndexEntry(dir, queued.task!.id, { status: 'completed' });
 
-    const observing = sweepSkillPromotionBacktests(dir, { now: new Date('2026-05-07T02:00:00.000Z') });
+    const observing = await sweepSkillPromotionBacktests(dir, { now: new Date('2026-05-07T02:00:00.000Z') });
     expect(observing.updated).toBe(1);
     expect(observing.records[0].status).toBe('observing');
 
@@ -88,11 +89,59 @@ describe('skill promotion autopilot', () => {
       });
     }
 
-    const accepted = sweepSkillPromotionBacktests(dir, { now: new Date('2026-05-07T04:00:00.000Z') });
+    const accepted = await sweepSkillPromotionBacktests(dir, { now: new Date('2026-05-07T04:00:00.000Z') });
     expect(accepted.accepted).toBe(1);
     expect(summarizeSkillPromotionAutopilot(dir).accepted[0]).toEqual(expect.objectContaining({
       observedUses: 3,
       observedSuccessRate: 1,
     }));
   });
+
+  it('does not queue repeated patterns without measurable impact evidence', async () => {
+    const dir = memoryDir();
+    for (let i = 0; i < 3; i += 1) {
+      recordSkillUsage(dir, {
+        skill: 'constraint-texture-analysis',
+        outcome: 'success',
+        pattern: 'p0 low responsiveness scheduler task stack ranked from this',
+        combinedWith: ['kg-context-synthesis', 'task-decomposition'],
+        ts: `2026-05-07T00:1${i}:00.000Z`,
+      });
+    }
+
+    const result = await maybeQueueSkillPromotion(dir, { triggerReason: 'heartbeat' });
+
+    expect(result).toEqual(expect.objectContaining({
+      queued: false,
+      reason: 'no-eligible-candidate',
+    }));
+    expect(queryMemoryIndexSync(dir, { type: ['task'], status: ['pending'] })).toHaveLength(0);
+  });
+
+  it('dismisses queued promotions that lose measurable impact eligibility', async () => {
+    const dir = memoryDir();
+    const queuedTaskId = (await maybeQueueSkillPromotionWithImpact(dir)).taskId;
+    const queued = queryMemoryIndexSync(dir, { id: queuedTaskId })[0];
+    expect(queued.status).toBe('pending');
+
+    const ledgerDir = join(dir, 'state');
+    mkdirSync(ledgerDir, { recursive: true });
+    writeFileSync(join(ledgerDir, 'skill-usage.jsonl'), '', 'utf-8');
+
+    const dismissed = await sweepSkillPromotionBacktests(dir, { now: new Date('2026-05-07T02:00:00.000Z') });
+    const task = queryMemoryIndexSync(dir, { id: queued.id })[0];
+
+    expect(dismissed.dismissed).toBe(1);
+    expect(dismissed.records[0]).toEqual(expect.objectContaining({ status: 'dismissed' }));
+    expect(task.status).toBe('abandoned');
+    expect(task.payload).toEqual(expect.objectContaining({
+      abandoned_reason: 'skill-promotion-insufficient-impact-evidence',
+    }));
+  });
 });
+
+async function maybeQueueSkillPromotionWithImpact(dir: string): Promise<{ taskId: string }> {
+  seedPromotionUsage(dir);
+  const result = await maybeQueueSkillPromotion(dir, { triggerReason: 'heartbeat' });
+  return { taskId: result.task!.id };
+}


### PR DESCRIPTION
## Summary
- require measurable token/time impact before skill promotion creates scheduler work
- make queued promotions self-dismiss and abandon their task if they lose eligibility
- keep the autopilot sweep async so task retirement is completed before correction-gate scoring

## Verification
- pnpm typecheck
- pnpm test tests/skill-promotion-autopilot.test.ts tests/agent-skill-manager.test.ts
