### PR TITLE
fix(loop): DEBUG_P0_BANNER instrumentation (closes #296)

### DIFF
--- a/src/loop.ts
+++ b/src/loop.ts
@@ -2296,6 +2296,9 @@ export class AgentLoop {
 
       // P0 reminder — applies to ALL triggers, not just non-telegram
       const p0Previews = getP0TaskPreviews(memDir);
+      if (process.env.DEBUG_P0_BANNER) {
+        console.log('[p0-banner-debug]', JSON.stringify({ ts: new Date().toISOString(), count: p0Previews.length, items: p0Previews.slice(0, 5) }));
+      }
       if (p0Previews.length > 0) {
         const p0Preview = p0Previews.slice(0, 3).map(i => `  「${i.slice(0, 100)}」`).join('\n');
         priorityPrefix += `\nP0 items pending:\n${p0Preview}\n\n`;


### PR DESCRIPTION
## Summary
- Adds 3-line debug log at `src/loop.ts:2298` (the P0 banner assembly site).
- Emits `[p0-banner-debug] {ts, count, items}` JSON when `DEBUG_P0_BANNER=1`.
- Zero behavior change when env unset.

## Why
Per #296 acceptance: 5+ consecutive cycles emit stale P0 banners that don't match `getP0TaskPreviews` live probe (post-#289 fix verified working). Without telemetry we keep re-diagnosing the same symptom — three options: (a) bucket-cache divergence, (b) snapshot-vs-reply race, (c) parallel injection path. One cycle with this enabled settles which.

## Verification
- [x] tsc --noEmit passes
- [ ] Enable `DEBUG_P0_BANNER=1` on next restart
- [ ] Capture one cycle where banner shows N P0s
- [ ] Compare debug log emission to live `getP0TaskPreviews` — same N → cache; different → parallel injection path

Closes #296

🤖 Generated with [Claude Code](https://claude.com/claude-code)