### PR TITLE
fix(correction): ignore correction tasks in responsiveness gate

### DIFF
--- a/src/correction-gate.ts
+++ b/src/correction-gate.ts
@@ -71,7 +71,8 @@ export function evaluateCorrectionGate(memoryDir: string, repoRoot = process.cwd
   const activeTasks = allTasks.filter(t =>
     ['pending', 'in_progress'].includes(t.status) &&
     !(t.payload as Record<string, unknown>)?.goal_id &&
-    !isBackgroundMaintenanceTask(t)
+    !isBackgroundMaintenanceTask(t) &&
+    !isCorrectionTask(t)
   );
   const avgStaleness = activeTasks.length === 0 ? 0 :
     activeTasks.reduce((sum, t) => sum + ((t.payload as Record<string, unknown>)?.ticksSinceLastProgress as number ?? 0), 0) / activeTasks.length;

--- a/tests/correction-gate.test.ts
+++ b/tests/correction-gate.test.ts
@@ -88,6 +88,26 @@ describe('correction gate', () => {
     expect(snapshot.suppressedActions).not.toContain('self-research');
   });
 
+  it('does not let stale correction tasks create a self-referential responsiveness loop', async () => {
+    await appendMemoryIndexEntry(tmpDir, {
+      type: 'task',
+      status: 'pending',
+      summary: 'P0 correction gate: resolve low-responsiveness',
+      payload: {
+        origin: 'scheduler',
+        priority: 0,
+        correction_reason_type: 'low-responsiveness',
+        ticksSinceLastProgress: 99,
+      },
+    });
+    invalidateIndexCache();
+
+    const snapshot = evaluateCorrectionGate(tmpDir, tmpDir);
+
+    expect(snapshot.needsCorrection).toBe(false);
+    expect(snapshot.reasons.map(r => r.type)).not.toContain('low-responsiveness');
+  });
+
   it('parses git ahead state as pending-push ship truth', () => {
     const parsed = parseGitStatusPorcelainV2([
       '# branch.oid abc123',


### PR DESCRIPTION
## Summary
- exclude correction tasks from general responsiveness scoring so correction gate cannot block on its own stale task
- keep gate-clean closure responsible for completing resolved correction tasks
- add regression coverage for stale correction self-loop

## Verification
- pnpm test tests/correction-gate.test.ts
- pnpm typecheck
