### PR TITLE
fix(github): suppress expected reviewRequests scope fallback noise

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -50,6 +50,7 @@ import { assertKuroGithubIdentity, expectedKuroGithubLogin, kuroGithubCliEnv } f
 import { recordPublicWriteProvenance } from './public-write-identity.js';
 
 const execFileAsync = promisify(execFile);
+let loggedReviewRequestsDegrade = false;
 
 async function gh(args: string[], timeout = 15000): Promise<{ stdout: string; stderr: string }> {
   assertKuroGithubIdentity();
@@ -432,10 +433,30 @@ async function listOpenPrsForLifecycle(): Promise<ReviewablePR[]> {
     const { stdout } = await gh(['pr', 'list', '--state', 'open', '--json', `${baseFields},reviewRequests`, '--limit', '50']);
     return JSON.parse(stdout);
   } catch (err) {
-    slog('github', `open PR listing degraded without reviewRequests: ${String(err)}`);
+    if (shouldLogPrReviewRequestsDegrade(err)) {
+      slog('github', `open PR listing degraded without reviewRequests: ${String(err)}`);
+    }
     const { stdout } = await gh(['pr', 'list', '--state', 'open', '--json', baseFields, '--limit', '50']);
     return JSON.parse(stdout);
   }
+}
+
+export function isGithubReviewRequestsScopeError(err: unknown): boolean {
+  const text = String(err);
+  return text.includes('GraphQL:')
+    && text.includes('required scopes')
+    && text.includes('read:org')
+    && text.includes('reviewRequests');
+}
+
+function shouldLogPrReviewRequestsDegrade(err: unknown): boolean {
+  if (isGithubReviewRequestsScopeError(err)) {
+    if (process.env.MINI_AGENT_LOG_GITHUB_SCOPE_DEGRADES !== '1') return false;
+    if (loggedReviewRequestsDegrade) return false;
+    loggedReviewRequestsDegrade = true;
+    return true;
+  }
+  return true;
 }
 
 interface SupersedablePR extends ReviewablePR {

--- a/tests/github-reviewrequests-scope.test.ts
+++ b/tests/github-reviewrequests-scope.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { isGithubReviewRequestsScopeError } from '../src/github.js';
+
+describe('GitHub reviewRequests scope degradation', () => {
+  it('recognizes gh reviewRequests read:org scope failures as expected fallback cases', () => {
+    const err = new Error([
+      'Command failed: gh pr list --state open --json number,title,reviewRequests --limit 50',
+      "GraphQL: Your token has not been granted the required scopes to execute this query. The 'login' field requires one of the following scopes: ['read:org'], but your token has only been granted the: ['repo'] scopes.",
+    ].join('\n'));
+
+    expect(isGithubReviewRequestsScopeError(err)).toBe(true);
+  });
+
+  it('does not hide unrelated GitHub errors', () => {
+    expect(isGithubReviewRequestsScopeError(new Error('HTTP 500 from GitHub'))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- detect GitHub reviewRequests/read:org GraphQL scope failures as expected fallback cases
- keep fallback PR listing without reviewRequests, but suppress repeated degraded error logs by default
- preserve degraded logging for unrelated GitHub failures and optionally log scope fallback with MINI_AGENT_LOG_GITHUB_SCOPE_DEGRADES=1

## Verification
- pnpm test tests/github-reviewrequests-scope.test.ts
- pnpm typecheck
