### PR TITLE
fix(observability): tolerate structured task events

### DIFF
--- a/src/observability.ts
+++ b/src/observability.ts
@@ -181,8 +181,28 @@ function handleMemoryEvent(e: AgentEvent): void {
 
 function handleTaskEvent(e: AgentEvent): void {
   const logger = getLogger();
-  slog('LOOP', `📋 Auto-created task: ${(e.data.content as string).slice(0, 80)}`);
-  logger.logBehavior('agent', 'task.create', (e.data.content as string).slice(0, 200));
+  const content = taskEventContent(e.data);
+  slog('LOOP', `📋 Auto-created task: ${content.slice(0, 80)}`);
+  logger.logBehavior('agent', 'task.create', content.slice(0, 200));
+}
+
+export function taskEventContent(data: AgentEvent['data']): string {
+  if (typeof data.content === 'string' && data.content.trim()) return data.content;
+  const entry = data.entry as { summary?: unknown; id?: unknown } | undefined;
+  if (typeof entry?.summary === 'string' && entry.summary.trim()) return entry.summary;
+  if (typeof data.event === 'string' && data.event.trim()) {
+    const id = typeof data.taskId === 'string'
+      ? data.taskId
+      : typeof data.goalId === 'string'
+        ? data.goalId
+        : typeof entry?.id === 'string'
+          ? entry.id
+          : '';
+    return id ? `${data.event}:${id}` : data.event;
+  }
+  if (typeof data.taskId === 'string') return data.taskId;
+  if (typeof data.goalId === 'string') return data.goalId;
+  return 'task event';
 }
 
 // =============================================================================

--- a/tests/observability-task-event.test.ts
+++ b/tests/observability-task-event.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { taskEventContent } from '../src/observability.js';
+
+describe('observability task event content', () => {
+  it('uses content when present', () => {
+    expect(taskEventContent({ content: 'write regression test' })).toBe('write regression test');
+  });
+
+  it('formats structured task lifecycle events without content', () => {
+    expect(taskEventContent({
+      event: 'autonomy-closure-repair-queued',
+      taskId: 'idx-123',
+    })).toBe('autonomy-closure-repair-queued:idx-123');
+  });
+
+  it('falls back to entry summary or a safe placeholder', () => {
+    expect(taskEventContent({ entry: { summary: 'queued from memory index' } })).toBe('queued from memory index');
+    expect(taskEventContent({})).toBe('task event');
+  });
+});


### PR DESCRIPTION
## Summary
- make action:task observability robust when events carry event/taskId instead of content
- prevent structured task lifecycle telemetry from crashing the runtime
- add regression coverage for content, event/taskId, entry summary, and empty fallback cases

## Verification
- pnpm test tests/observability-task-event.test.ts
- pnpm typecheck
