### PR TITLE
feat(trendradar): Commit 1 — setup.sh for zh-CN lane venv

### DIFF
--- a/scripts/trendradar/setup.sh
+++ b/scripts/trendradar/setup.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# TrendRadar zh-CN lane — Commit 1 setup
+# Per memory/topics/trendradar-integration-spec-2026-05-08.md
+# Ship: clone sansan0/TrendRadar to ~/Workspace/trendradar-upstream, build isolated venv, editable install.
+# Smoke test: python -m trendradar --help exits 0.
+set -euo pipefail
+
+UPSTREAM_DIR="${TRENDRADAR_UPSTREAM:-$HOME/Workspace/trendradar-upstream}"
+PYTHON_BIN="${TRENDRADAR_PYTHON:-python3.13}"
+
+if [ ! -d "$UPSTREAM_DIR" ]; then
+  echo "[trendradar/setup] cloning sansan0/TrendRadar -> $UPSTREAM_DIR"
+  git clone --depth 1 https://github.com/sansan0/TrendRadar.git "$UPSTREAM_DIR"
+fi
+
+cd "$UPSTREAM_DIR"
+
+if [ ! -x .venv/bin/python ]; then
+  echo "[trendradar/setup] creating venv with $PYTHON_BIN"
+  "$PYTHON_BIN" -m venv .venv
+fi
+
+.venv/bin/pip install --quiet --upgrade pip
+.venv/bin/pip install --quiet -e .
+
+echo "[trendradar/setup] smoke test: python -m trendradar --help"
+.venv/bin/python -m trendradar --help > /dev/null
+
+echo "[trendradar/setup] OK — venv ready at $UPSTREAM_DIR/.venv"


### PR DESCRIPTION
## Summary
- Commit 1 of TrendRadar zh-CN lane integration (per `agent-middleware/memory/topics/trendradar-integration-spec-2026-05-08.md`)
- Adds `scripts/trendradar/setup.sh`: idempotent isolated venv builder for sansan0/TrendRadar at `$TRENDRADAR_UPSTREAM` (default `~/Workspace/trendradar-upstream`)
- Editable-installs upstream, runs `python -m trendradar --help` smoke test

## Why
Alex P2 question #40: "你說不重疊 那不能一起用嗎？" — yes, complement not overlap. TrendRadar = 11 zh-CN hot lists (微博/知乎/B站/百度/...) + RSS, structurally zero overlap with HN/Latent/arXiv/GH/X (all en/global tech). Adds a 6th lane to `build-ai-trend-preview.mjs` with weight 0.5.

## Verification
- [x] `bash scripts/trendradar/setup.sh` → exit 0, smoke test `python -m trendradar --help` exit 0 (verified 04:30Z)
- [x] Idempotent: re-running skips clone + venv create, only runs pip install + smoke
- [ ] Commit 2 (next): `scripts/trendradar-fetch.mjs` subprocess + better-sqlite3 adapter → `state/trendradar-trend/<DATE>.json`
- [ ] Commit 3 (next+1): wire 6th lane into `build-ai-trend-preview.mjs`

## Falsifier KEPT
Spec line 50: `~/Workspace/trendradar-upstream/.venv/bin/python -m trendradar --help` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)