### PR TITLE
feat(ai-trend): inline [text](url) links in KURO commentary

### DIFF
--- a/scripts/build-ai-trend-preview.mjs
+++ b/scripts/build-ai-trend-preview.mjs
@@ -83,6 +83,24 @@ function htmlEsc(s) {
     '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'
   }[c]));
 }
+function renderInlineLinks(s) {
+  // Parse [text](url) markdown links inline; htmlEsc everything else.
+  // Backward compatible: plain text renders identically to htmlEsc(s).
+  const str = String(s ?? '');
+  const parts = [];
+  let last = 0;
+  const re = /\[([^\]]+)\]\(([^)\s]+)\)/g;
+  let m;
+  while ((m = re.exec(str)) !== null) {
+    if (m.index > last) parts.push(htmlEsc(str.slice(last, m.index)));
+    const text = htmlEsc(m[1]);
+    const url = htmlEsc(m[2]);
+    parts.push(`<a href="${url}" target="_blank" rel="noopener">${text} ↗</a>`);
+    last = m.index + m[0].length;
+  }
+  if (last < str.length) parts.push(htmlEsc(str.slice(last)));
+  return parts.join('');
+}
 function fmtNum(n) {
   if (n == null) return '—';
   if (n >= 10000) return (n/1000).toFixed(1) + 'k';
@@ -164,7 +182,7 @@ const KURO_TAKE = {
     up: [
       'services-attached labs（labs 不再只賣 token，直接吃 enterprise 應用層）',
       'agent-native file system / sandbox（Tilde 130pt 上 HN 前頁）',
-      'AI Trend 聚合層 commodity 化（TrendRadar 56K star、newsnow 多平台 API 開源）',
+      'AI Trend 聚合層 commodity 化（[TrendRadar](https://github.com/sansan0/TrendRadar) 56K star、newsnow 多平台 API 開源）',
     ],
     down: [
       'pure model API 單點變現 narrative（labs 自己跨進服務層）',
@@ -434,19 +452,19 @@ async function main() {
   </div>
   <div class="outlook">
     <strong>未來走向 / 注意點</strong>
-    ${htmlEsc(KURO_TAKE.outlook)}
+    ${renderInlineLinks(KURO_TAKE.outlook)}
   </div>
   <div class="trends">
-    <div class="col up"><strong>↗ 上升趨勢</strong><ul>${KURO_TAKE.trends.up.map(x => `<li>${htmlEsc(x)}</li>`).join('')}</ul></div>
-    <div class="col down"><strong>↘ 下降趨勢</strong><ul>${KURO_TAKE.trends.down.map(x => `<li>${htmlEsc(x)}</li>`).join('')}</ul></div>
+    <div class="col up"><strong>↗ 上升趨勢</strong><ul>${KURO_TAKE.trends.up.map(x => `<li>${renderInlineLinks(x)}</li>`).join('')}</ul></div>
+    <div class="col down"><strong>↘ 下降趨勢</strong><ul>${KURO_TAKE.trends.down.map(x => `<li>${renderInlineLinks(x)}</li>`).join('')}</ul></div>
   </div>
   <div class="swot">
     <strong>SWOT — 今日敘事</strong>
     <dl>
-      <dt>S</dt><dd>${htmlEsc(KURO_TAKE.swot.s)}</dd>
-      <dt>W</dt><dd>${htmlEsc(KURO_TAKE.swot.w)}</dd>
-      <dt>O</dt><dd>${htmlEsc(KURO_TAKE.swot.o)}</dd>
-      <dt>T</dt><dd>${htmlEsc(KURO_TAKE.swot.t)}</dd>
+      <dt>S</dt><dd>${renderInlineLinks(KURO_TAKE.swot.s)}</dd>
+      <dt>W</dt><dd>${renderInlineLinks(KURO_TAKE.swot.w)}</dd>
+      <dt>O</dt><dd>${renderInlineLinks(KURO_TAKE.swot.o)}</dd>
+      <dt>T</dt><dd>${renderInlineLinks(KURO_TAKE.swot.t)}</dd>
     </dl>
   </div>
 </div>


### PR DESCRIPTION
## Summary

- Adds `renderInlineLinks()` helper parsing markdown `[text](url)` inside `KURO_TAKE` prose (outlook / trends.up / trends.down / swot.{s,w,o,t})
- Renders anchors with `target="_blank" rel="noopener"` + ↗ marker for external-nav consistency
- Plain text without `[..](..)` renders identical to `htmlEsc` — backward compatible (no data migration needed)
- Seeds one real link (`TrendRadar` repo in trends.up) so today's render demonstrates the feature end-to-end

## Why

Closes Alex's 2026-05-07 14:33 ask:
> 你的點評 關聯到的文章 要連結 還有未來走向 有什麼是下降趨勢 有什麼是上升趨勢 還有 swot 分析

`threads[].link` was already supported (existing render wraps title in `<a>`), but the remaining 6 prose slots had no link path. Inline markdown was chosen over schema change so future commentary can cite without restructuring data.

## Verification

- [x] Helper unit-tested in isolation (5 cases: plain / one-link / escape / brackets-without-paren / null) — all pass
- [x] `node scripts/build-ai-trend-preview.mjs` runs clean
- [x] Output HTML grep confirms `<a href="https://github.com/sansan0/TrendRadar" target="_blank" rel="noopener">TrendRadar ↗</a>` rendered in `<div class="trends">`
- [ ] Visual review on `kuro.page/ai-trend/` after merge + cron rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)