### PR TITLE
feat(loop): preflight.drain telemetry for silent_exit_void_40k (#304 phase 1, rebuilt from main)

### DIFF
--- a/src/loop.ts
+++ b/src/loop.ts
@@ -2624,6 +2624,14 @@ export class AgentLoop {
         ? buildIdlePrompt()
         : prompt + (selectedSkillPrompt ? `\n\n${selectedSkillPrompt}` : '');
 
+      // Pre-flight observability (issue #304 phase 1) — silent_exit_void_40k risk surface.
+      // Measure ≥35K prompt rate before deciding rebuild/drain strategy in phase 2.
+      const PREFLIGHT_SIZE_THRESHOLD = 35_000;
+      if (effectivePrompt.length >= PREFLIGHT_SIZE_THRESHOLD) {
+        slog('LOOP', `[preflight.drain] prompt size ${effectivePrompt.length} >= ${PREFLIGHT_SIZE_THRESHOLD} (silent_exit_void_40k risk)`);
+        eventBus.emit('action:loop', { event: 'preflight.drain', promptSize: effectivePrompt.length, threshold: PREFLIGHT_SIZE_THRESHOLD, cycleMode, trigger: currentTriggerReason ?? null });
+      }
+
       // Intelligent model routing: decide Opus vs Sonnet based on cycle characteristics
       const modelRoute = routeModel({
         triggerReason: currentTriggerReason,


### PR DESCRIPTION
## Summary
- 8-line observability hook at `src/loop.ts:2627` (between `effectivePrompt` finalize and `callClaude` dispatch).
- Emits `action:loop` event with `event=preflight.drain` when `effectivePrompt.length >= 35_000`.
- Logs `[LOOP] [preflight.drain] prompt size N >= 35000 (silent_exit_void_40k risk)`.
- **Zero behavior change** — pure measurement. Prompts still flow to `callClaude` unchanged.

## Why this PR (vs #305)
PR #305 was closed by the autonomous governance bot because it targeted `runtime/main` instead of `main`. This PR is the same 8-line patch rebuilt from current `main` (HEAD = `eafec4df`) to satisfy the governance constraint. Diff is byte-identical to commit `998785dd` reviewed in #305.

## Why the patch
Issue #304 hypothesizes that prompts ≥40K chars trigger silent_exit_void in `callClaude` (11 occurrences in `error-patterns.json`, all on instance 03bbc29a, tight size cluster 41,411–43,379 chars / median ~42K, content-agnostic). Before designing rebuild/drain logic in phase 2, we need data on:
- How often prompts cross 35K under normal operation
- Whether silent_exit_void_40k events correlate temporally with oversized cycles
- Which `cycleMode` / `trigger` combinations produce them

## Threshold rationale
35K (not 40K) gives 5K headroom — early-warning signal before the failure zone. Matches the existing classifier threshold at `src/feedback-loops.ts:217`.

## Falsifier
After this PR is live and a real cycle has prompt ≥35K:
- `mini-agent-memory/memory/state/work-journal.jsonl` should contain entry with `event=preflight.drain`
- `[LOOP] [preflight.drain]` line in process stdout

If neither appears within 24h of cycles with prompt ≥35K, this patch is broken.

## Phase 2 scope (NOT in this PR)
Once we have a week of telemetry, design the actual reduction logic:
- Re-run `memory.buildContext({mode: 'minimal'})` on threshold breach
- Preserve `priorityPrefix` / `schedulerTaskPrefix` (cycle directives)
- Drop heavy context tail
- New PR, gated on phase 1 data

## Test plan
- [ ] After merge + deploy, observe at least one `event=preflight.drain` in work-journal.jsonl OR confirm no cycles in 24h crossed 35K (then either threshold needs tuning or risk is overstated)
- [ ] Confirm zero regressions in cycle duration / output (no new code path on hot loop except `if` + `slog` + `emit`)

Linked: https://github.com/miles990/mini-agent/issues/304
Replaces: https://github.com/miles990/mini-agent/pull/305 (closed for wrong target branch)

Verification before opening:
- [x] Branch created from `origin/main` (HEAD eafec4df, post #309)
- [x] Diff matches phase-1 commit `998785dd` byte-for-byte
- [x] Insertion site (loop.ts:2625-2627) intact on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Verification
- `pnpm tsc --noEmit` — passes (typecheck clean on phase-1 commit 998785dd)
- `pnpm test` — existing suite passes; this patch is pure observability (`if` + `slog` + `emit`), no new code paths on hot loop
- Symbol scope verified at insertion point `src/loop.ts:2627`: `slog` (imported l.19), `eventBus.emit('action:loop', ...)` (callsites 677/1038/1354/1812/2180), `currentTriggerReason` (l.2185), `cycleMode` (l.2595), `effectivePrompt` (l.2623)
- No duplicate `preflight` / `35_000` telemetry elsewhere; threshold matches `src/feedback-loops.ts:217` classifier
- Falsifier wired: `event=preflight.drain` should appear in `work-journal.jsonl` within 24h of any cycle with prompt ≥35K; absence = patch broken