### PR TITLE
fix(scheduler): re-verify P0 predicates before dispatch (#306, Layer 1)

### DIFF
--- a/src/predicate-freshness.ts
+++ b/src/predicate-freshness.ts
@@ -1,0 +1,102 @@
+// Layer 1 of issue #306: re-verify P0 conditions before dispatch.
+//
+// The scheduler emits correction tasks based on a snapshot evaluation
+// (`evaluateCorrectionGate`) that can lag behind ground truth — git status
+// races, autonomy-closure score updates, etc. This module performs a cheap
+// live re-check against the source-of-truth for each predicate type so
+// stale snapshots do not produce phantom P0 tasks.
+//
+// Contract: `reverifyPredicate(type, ctx)` returns:
+//   - true  → predicate still stale, dispatch the correction task
+//   - false → predicate is now clean, skip dispatch (caller logs skip)
+//   - null  → no live source-of-truth wired for this type yet (fail-open: dispatch)
+//
+// Layer 1 ships the two cheapest predicates as proof:
+//   - `dirty-runtime-workspace` (~50ms `git status --porcelain`)
+//   - `local-commit-not-pushed` (~50ms `git rev-list --count @{u}..HEAD`)
+// Remaining predicates (`low-responsiveness`, `memory-state-truth`,
+// `ship-truth`) are scaffolded but return `null` until their checks are
+// added in follow-up commits.
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+export interface FreshnessContext {
+  repoRoot: string;
+  memoryDir: string;
+}
+
+export type PredicateType =
+  | 'dirty-runtime-workspace'
+  | 'local-commit-not-pushed'
+  | 'low-responsiveness'
+  | 'memory-state-truth'
+  | 'ship-truth'
+  | string;
+
+/**
+ * Live re-evaluate whether a correction predicate is still stale.
+ * Returns false to skip a phantom dispatch, true to proceed, null when
+ * no live check is wired (fail-open).
+ */
+export async function reverifyPredicate(
+  type: PredicateType,
+  ctx: FreshnessContext,
+): Promise<boolean | null> {
+  switch (type) {
+    case 'dirty-runtime-workspace':
+      return checkDirtyRuntimeWorkspace(ctx);
+    case 'local-commit-not-pushed':
+      return checkLocalCommitNotPushed(ctx);
+    // Scaffolded — return null (fail-open) until each is wired in follow-ups.
+    case 'low-responsiveness':
+    case 'memory-state-truth':
+    case 'ship-truth':
+      return null;
+    default:
+      return null;
+  }
+}
+
+/**
+ * Source-of-truth: `git status --porcelain` against the runtime checkout.
+ * Stale (true) when there is uncommitted work; fresh (false) when clean.
+ */
+async function checkDirtyRuntimeWorkspace(ctx: FreshnessContext): Promise<boolean | null> {
+  try {
+    const { stdout } = await execFileAsync('git', ['status', '--porcelain'], {
+      cwd: ctx.repoRoot,
+      timeout: 5000,
+    });
+    return stdout.trim().length > 0;
+  } catch {
+    // Fail-open: if git status itself fails, let the snapshot win.
+    return null;
+  }
+}
+
+/**
+ * Source-of-truth: `git rev-list --count @{u}..HEAD` against the runtime
+ * checkout. Stale (true) when local commits exist that the upstream does
+ * not have; fresh (false) when zero commits are ahead. Fail-open (null)
+ * when no upstream is configured or the command errors — phantom-skip
+ * must never silently drop a real correction.
+ */
+async function checkLocalCommitNotPushed(ctx: FreshnessContext): Promise<boolean | null> {
+  try {
+    const { stdout } = await execFileAsync(
+      'git',
+      ['rev-list', '--count', '@{u}..HEAD'],
+      { cwd: ctx.repoRoot, timeout: 5000 },
+    );
+    const ahead = Number.parseInt(stdout.trim(), 10);
+    if (!Number.isFinite(ahead)) return null;
+    return ahead > 0;
+  } catch {
+    // Common cause: no upstream configured (detached HEAD, fresh branch).
+    // Fail-open so the snapshot decision wins.
+    return null;
+  }
+}

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -13,6 +13,7 @@ import { slog } from './utils.js';
 import { eventBus } from './event-bus.js';
 import { getProcess } from './process-table.js';
 import { evaluateCorrectionGate, isCorrectionTask, type CorrectionGateSnapshot } from './correction-gate.js';
+import { reverifyPredicate } from './predicate-freshness.js';
 
 // =============================================================================
 // Types
@@ -444,6 +445,76 @@ export function schedulerPick(
   recordSchedulerDecision(decision);
 
   return decision;
+}
+
+/**
+ * Async variant of schedulerPick that adds a live predicate re-verify step
+ * (Layer 1 of issue #306 — stale-signal lag fix).
+ *
+ * After schedulerPick selects a correction task, this function checks whether
+ * the underlying predicate is still stale via reverifyPredicate(). If the
+ * predicate is now clean (returns false), the dispatch is skipped and an idle
+ * decision is returned instead, preventing phantom P0 cycles.
+ *
+ * Fail-open: when reverifyPredicate returns null (no live check wired), the
+ * snapshot decision is preserved — phantom-skip must never silently drop a
+ * real correction.
+ */
+export async function schedulerPickAsync(
+  memoryDir: string,
+  repoRoot: string,
+  events: IncomingEvent[] = [],
+): Promise<SchedulingDecision> {
+  const decision = schedulerPick(memoryDir, events);
+
+  // Only correction tasks need predicate re-verification.
+  if (!decision.taskId) return decision;
+
+  const entries = queryMemoryIndexSync(memoryDir, { type: ['task'], status: ['pending', 'in_progress'] });
+  const entry = entries.find(e => e.id === decision.taskId);
+  if (!entry || !isCorrectionTask(entry)) return decision;
+
+  // Extract the predicate type from payload or summary.
+  const payload = (entry.payload ?? {}) as Record<string, unknown>;
+  const predicateType: string =
+    (typeof payload.correction_reason_type === 'string' ? payload.correction_reason_type : null)
+    ?? parseCorrectionReasonFromSummaryExported(entry.summary ?? '')
+    ?? '';
+
+  if (!predicateType) return decision; // Unknown type — fail-open.
+
+  const ctx = { repoRoot, memoryDir };
+  let stillStale: boolean | null;
+  try {
+    stillStale = await reverifyPredicate(predicateType, ctx);
+  } catch {
+    stillStale = null; // Fail-open on unexpected error.
+  }
+
+  if (stillStale === false) {
+    // Predicate is now clean — skip dispatch to avoid phantom P0 cycle.
+    slog(
+      'SCHED',
+      `stale-signal-skip: predicate=${predicateType} task=${decision.taskId.slice(0, 12)} resolved since snapshot`,
+    );
+    eventBus.emit('action:scheduler', {
+      event: 'stale-signal-skip',
+      predicateType,
+      taskId: decision.taskId,
+      ts: new Date().toISOString(),
+    });
+    const idle: SchedulingDecision = { taskId: null, reason: `stale-signal-skip: ${predicateType}`, action: 'idle', suspended: null };
+    resetCurrentTask();
+    recordSchedulerDecision(idle);
+    return idle;
+  }
+
+  // stillStale === true or null → proceed with the original decision.
+  return decision;
+}
+
+function parseCorrectionReasonFromSummaryExported(summary: string): string | null {
+  return parseCorrectionReasonFromSummary(summary);
 }
 
 function correctionTaskMatchesSnapshot(

--- a/tests/predicate-freshness.test.ts
+++ b/tests/predicate-freshness.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Predicate freshness re-verification — GitHub issue #306 (Layer 1)
+ *
+ * Verifies that `reverifyPredicate` returns:
+ *   - true  when the underlying predicate is still stale (dispatch should proceed)
+ *   - false when the predicate is now clean (dispatch should be skipped)
+ *   - null  when no live source-of-truth is wired (fail-open: snapshot wins)
+ *
+ * The two cheap predicates wired in Layer 1 are:
+ *   - `dirty-runtime-workspace` (git status --porcelain)
+ *   - `local-commit-not-pushed` (git rev-list --count @{u}..HEAD)
+ *
+ * Remaining predicates (`low-responsiveness`, `memory-state-truth`, `ship-truth`)
+ * are scaffolded — they MUST return null until their checks land in follow-up
+ * commits, so the scheduler keeps the snapshot decision rather than silently
+ * dropping a real correction.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { reverifyPredicate } from '../src/predicate-freshness.js';
+
+let repoRoot: string;
+let memoryDir: string;
+
+function git(...args: string[]): void {
+  execFileSync('git', args, { cwd: repoRoot, stdio: 'pipe' });
+}
+
+beforeEach(() => {
+  repoRoot = mkdtempSync(path.join(os.tmpdir(), 'predicate-freshness-'));
+  memoryDir = repoRoot;
+  // Initialise a minimal git repo with one commit so HEAD resolves.
+  git('init', '-q', '-b', 'main');
+  git('config', 'user.email', 'test@example.com');
+  git('config', 'user.name', 'Test');
+  git('commit', '--allow-empty', '-q', '-m', 'init');
+});
+
+afterEach(() => {
+  rmSync(repoRoot, { recursive: true, force: true });
+});
+
+describe('issue #306 — reverifyPredicate', () => {
+  describe('dirty-runtime-workspace', () => {
+    it('returns false when working tree is clean (skip phantom dispatch)', async () => {
+      const result = await reverifyPredicate('dirty-runtime-workspace', { repoRoot, memoryDir });
+      expect(result).toBe(false);
+    });
+
+    it('returns true when working tree has uncommitted changes', async () => {
+      writeFileSync(path.join(repoRoot, 'dirty.txt'), 'unstaged content', 'utf-8');
+      const result = await reverifyPredicate('dirty-runtime-workspace', { repoRoot, memoryDir });
+      expect(result).toBe(true);
+    });
+
+    it('returns null (fail-open) when path is not a git repo', async () => {
+      const nonRepo = mkdtempSync(path.join(os.tmpdir(), 'predicate-not-a-repo-'));
+      try {
+        const result = await reverifyPredicate('dirty-runtime-workspace', { repoRoot: nonRepo, memoryDir: nonRepo });
+        expect(result).toBeNull();
+      } finally {
+        rmSync(nonRepo, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe('local-commit-not-pushed', () => {
+    it('returns null (fail-open) when no upstream is configured', async () => {
+      // Fresh repo with no remote/upstream → @{u} resolution fails → null.
+      const result = await reverifyPredicate('local-commit-not-pushed', { repoRoot, memoryDir });
+      expect(result).toBeNull();
+    });
+
+    it('returns false when local HEAD is in sync with the upstream', async () => {
+      // Set up a bare upstream and push so @{u} = HEAD (0 ahead).
+      const bare = mkdtempSync(path.join(os.tmpdir(), 'predicate-upstream-'));
+      try {
+        execFileSync('git', ['init', '--bare', '-q', '-b', 'main', bare], { stdio: 'pipe' });
+        git('remote', 'add', 'origin', bare);
+        git('push', '-q', '-u', 'origin', 'main');
+        const result = await reverifyPredicate('local-commit-not-pushed', { repoRoot, memoryDir });
+        expect(result).toBe(false);
+      } finally {
+        rmSync(bare, { recursive: true, force: true });
+      }
+    });
+
+    it('returns true when local has commits the upstream lacks', async () => {
+      const bare = mkdtempSync(path.join(os.tmpdir(), 'predicate-upstream-ahead-'));
+      try {
+        execFileSync('git', ['init', '--bare', '-q', '-b', 'main', bare], { stdio: 'pipe' });
+        git('remote', 'add', 'origin', bare);
+        git('push', '-q', '-u', 'origin', 'main');
+        // Now create a local-only commit so HEAD is ahead of @{u}.
+        git('commit', '--allow-empty', '-q', '-m', 'local-only');
+        const result = await reverifyPredicate('local-commit-not-pushed', { repoRoot, memoryDir });
+        expect(result).toBe(true);
+      } finally {
+        rmSync(bare, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe('scaffolded predicates (fail-open until wired)', () => {
+    it('low-responsiveness returns null', async () => {
+      const result = await reverifyPredicate('low-responsiveness', { repoRoot, memoryDir });
+      expect(result).toBeNull();
+    });
+
+    it('memory-state-truth returns null', async () => {
+      const result = await reverifyPredicate('memory-state-truth', { repoRoot, memoryDir });
+      expect(result).toBeNull();
+    });
+
+    it('ship-truth returns null', async () => {
+      const result = await reverifyPredicate('ship-truth', { repoRoot, memoryDir });
+      expect(result).toBeNull();
+    });
+
+    it('unknown predicate type returns null', async () => {
+      const result = await reverifyPredicate('something-undeclared', { repoRoot, memoryDir });
+      expect(result).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes Layer 1 of #306 (stale-signal lag). Scheduler was emitting P0 correction tasks from stale KG digest snapshots, producing 3 phantom dispatches per 24h after the underlying condition was already resolved.

This PR adds a cheap pre-dispatch freshness re-check at the emit site so phantoms never enter the scheduler queue.

- `src/predicate-freshness.ts` — `reverifyPredicate(type, ctx)` returning `true` (still stale → dispatch), `false` (now clean → skip), or `null` (no live source-of-truth wired → fail-open). Two cheap predicates wired:
  - `dirty-runtime-workspace` → `git status --porcelain`
  - `local-commit-not-pushed` → `git rev-list --count @{u}..HEAD`
  - `low-responsiveness`, `memory-state-truth`, `ship-truth` scaffolded as `null` until follow-up commits wire their source-of-truth endpoints. Fail-open is deliberate: phantom-skip must never silently drop a real correction.
- `src/scheduler.ts` — new `schedulerPickAsync` wraps `schedulerPick` with the freshness gate. When the predicate is now clean, the decision is converted to idle, the scheduler-bound task is reset, and a `stale-signal-skip` event is emitted via `eventBus` + `slog`. Sync callers see no behaviour change; migration to the async variant is intentionally a separate step.
- `tests/predicate-freshness.test.ts` — 10 tests covering both live predicates (clean / dirty / no-upstream / ahead), all scaffolded null paths, and unknown-type fail-open.

Falsifier (per issue body): once `schedulerPickAsync` is wired in the OODA loop, `task-events.jsonl | grep stale-signal-skip` over a 24h window should be ≥ the current 3 phantom-rate; same-cycle dispatched-then-cleaned should drop to ≤1.

Layer 2 (digest TTL / source-of-truth split for the scheduler read path) is deferred to a follow-up issue once Layer 1 is observed in production.

## Verification

- [x] `pnpm typecheck` clean
- [x] `npx vitest run tests/predicate-freshness.test.ts` → 10/10 pass
- [x] Targeted scheduler/correction suites pass (`scheduler-phantom-guard`, `scheduler-completion-fallback`, `correction-gate`, `correction-holds`, `scheduler-hold-unblock`, `scheduler-dispatch-suppression` → 63/63)
- [x] `pnpm test` → 800 pass, 4 pre-existing failures unrelated to this change (`review-backlog`, `runtime-workspace-autocorrect`) — both reproduce on the base branch without these edits (env fixture deps, not regressions from #306)
- [ ] Wire `schedulerPickAsync` into the OODA loop (separate PR — intentionally out of scope here so the patch is a pure addition)
- [ ] Observe `stale-signal-skip` events in `task-events.jsonl` over a 24h window once wired

Refs: #306