### PR TITLE
fix(scheduler): wire low-responsiveness predicate (#306 Layer 1.5)

### DIFF
--- a/src/predicate-freshness.ts
+++ b/src/predicate-freshness.ts
@@ -11,15 +11,20 @@
 //   - false → predicate is now clean, skip dispatch (caller logs skip)
 //   - null  → no live source-of-truth wired for this type yet (fail-open: dispatch)
 //
-// Layer 1 ships the two cheapest predicates as proof:
-//   - `dirty-runtime-workspace` (~50ms `git status --porcelain`)
-//   - `local-commit-not-pushed` (~50ms `git rev-list --count @{u}..HEAD`)
-// Remaining predicates (`low-responsiveness`, `memory-state-truth`,
-// `ship-truth`) are scaffolded but return `null` until their checks are
-// added in follow-up commits.
+// Layer 1 ships the three cheapest predicates as proof:
+//   - `dirty-runtime-workspace`  (~50ms `git status --porcelain`)
+//   - `local-commit-not-pushed`  (~50ms `git rev-list --count @{u}..HEAD`)
+//   - `low-responsiveness`       (memory-index re-query, recomputes avgStaleness)
+// Remaining predicates (`memory-state-truth`, `ship-truth`) are scaffolded
+// but return `null` until their checks are added in follow-up commits.
 
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
+import { queryMemoryIndexSync, type MemoryIndexEntry } from './memory-index.js';
+// NB: avoid importing from correction-gate.ts — it imports this module
+// (`reverifyPredicate`), so a back-import would form a cycle. The two filter
+// helpers below are duplicated from correction-gate.ts; if they drift, both
+// snapshot and live re-check should be updated together.
 
 const execFileAsync = promisify(execFile);
 
@@ -50,8 +55,9 @@ export async function reverifyPredicate(
       return checkDirtyRuntimeWorkspace(ctx);
     case 'local-commit-not-pushed':
       return checkLocalCommitNotPushed(ctx);
-    // Scaffolded — return null (fail-open) until each is wired in follow-ups.
     case 'low-responsiveness':
+      return checkLowResponsiveness(ctx);
+    // Scaffolded — return null (fail-open) until each is wired in follow-ups.
     case 'memory-state-truth':
     case 'ship-truth':
       return null;
@@ -99,4 +105,62 @@ async function checkLocalCommitNotPushed(ctx: FreshnessContext): Promise<boolean
     // Fail-open so the snapshot decision wins.
     return null;
   }
+}
+
+/**
+ * Source-of-truth: re-query memory-index for `pending|in_progress` non-goal,
+ * non-background, non-correction tasks and recompute avgStaleness from
+ * `payload.ticksSinceLastProgress` — exactly mirroring the snapshot math in
+ * `correction-gate.ts:evaluateCorrectionGate`.
+ *
+ * Stale (true) when responsiveness < 0.5 (matches snapshot threshold).
+ * Fresh (false) when responsiveness ≥ 0.5 — typically because a stale task
+ * was completed/progressed between snapshot and dispatch. Fail-open (null)
+ * when memory-index query throws.
+ */
+async function checkLowResponsiveness(ctx: FreshnessContext): Promise<boolean | null> {
+  try {
+    const allTasks = queryMemoryIndexSync(ctx.memoryDir, { type: ['task'] });
+    const activeTasks = allTasks.filter(t =>
+      ['pending', 'in_progress'].includes(t.status) &&
+      !((t.payload as Record<string, unknown>)?.goal_id) &&
+      !isBackgroundMaintenanceTask(t) &&
+      !isCorrectionTask(t),
+    );
+    if (activeTasks.length === 0) {
+      // Snapshot uses 0.8 baseline when no active tasks — definitely fresh.
+      return false;
+    }
+    const avgStaleness = activeTasks.reduce(
+      (sum, t) => sum + (((t.payload as Record<string, unknown>)?.ticksSinceLastProgress as number) ?? 0),
+      0,
+    ) / activeTasks.length;
+    const responsiveness = Math.max(0, 1 - avgStaleness / 10);
+    return responsiveness < 0.5;
+  } catch {
+    // Memory-index unavailable / corrupt — fail-open so snapshot wins.
+    return null;
+  }
+}
+
+/**
+ * Duplicated from `correction-gate.ts` to avoid an import cycle.
+ * Background maintenance tasks (e.g. KG discussion janitor, low-priority
+ * discussion-lifecycle items) don't count toward responsiveness math.
+ */
+function isBackgroundMaintenanceTask(task: MemoryIndexEntry): boolean {
+  const payload = (task.payload ?? {}) as Record<string, unknown>;
+  if (payload.origin === 'kg-discussion-janitor') return true;
+  const priority = Number(payload.priority);
+  return Number.isFinite(priority) && priority >= 2 && Boolean(task.tags?.includes('discussion-lifecycle'));
+}
+
+/**
+ * Duplicated from `correction-gate.ts` to avoid an import cycle.
+ * Correction tasks emitted by the gate itself must not feed back into
+ * responsiveness — that would lock the gate open whenever it is open.
+ */
+function isCorrectionTask(entry: Pick<MemoryIndexEntry, 'summary' | 'payload'>): boolean {
+  const payload = (entry.payload ?? {}) as Record<string, unknown>;
+  return (entry.summary ?? '').includes('correction gate') || payload.origin === 'correction-gate';
 }


### PR DESCRIPTION
## Why

Closes the third `reverifyPredicate` source-of-truth case for #306. After PR #311 shipped Layer 1 (`dirty-runtime-workspace` + `local-commit-not-pushed`), the scheduler still emits **phantom `low-responsiveness` P0s** because that predicate returns `null` (fail-open) — exactly what just happened in this very cycle (the cycle that produced this PR was itself dispatched on a stale `low-responsiveness` snapshot — verified live).

## What

Single-file change to `src/predicate-freshness.ts`. Adds `checkLowResponsiveness(ctx)`:

- Re-queries memory-index for active non-goal, non-background, non-correction tasks
- Recomputes `avgStaleness` and `responsiveness = max(0, 1 - avgStaleness/10)` exactly the way `evaluateCorrectionGate` does
- Returns `true` when `responsiveness < 0.5`, `false` when fresh, `null` (fail-open) on query error
- `isBackgroundMaintenanceTask` / `isCorrectionTask` filters duplicated inline (correction-gate.ts already imports from this module — direct back-import would form a cycle; NB comment marks the duplication)

## Cherry-pick provenance

This is `0346cf90` from `fix/issue-306-predicate-freshness` (the original PR #307 branch, which is too dirty to merge cleanly: 199-ahead/34-behind, ~180 unrelated files). Cherry-picked onto a fresh branch from `origin/main` so only the predicate-freshness change ships.

## Falsifier (post-merge, 24h)

`task-events.jsonl` should record `p0_emit_skipped` events with `predicate=low-responsiveness` when the scheduler snapshot lags behind live state. If we see zero skips AND continued phantom `low-responsiveness` P0s in the next 14 cycles, the predicate is mis-wired.

## Notes

- PR #307 should be closed as superseded once this lands (Layer 1 already shipped via #311; remaining `memory-state-truth` and `ship-truth` predicates can ship as separate small PRs).