### PR TITLE
fix(prompt-builder): filter stale (>7d) Recurring Errors hint (#315)

### DIFF
--- a/src/prompt-builder.ts
+++ b/src/prompt-builder.ts
@@ -422,12 +422,21 @@ function buildDelegationReviewGate(): string {
   }
 }
 
-/** Build error-patterns hint — inject recurring error patterns into cycle prompt for real-time awareness */
-function buildErrorPatternsHint(): string {
+/** Build error-patterns hint — inject recurring error patterns into cycle prompt for real-time awareness.
+ *  Issue #315: filter out entries whose lastSeen is older than 7 days, so resolved-but-still-on-disk
+ *  patterns (e.g. `dns_lookup_failed` after the rename in #84) stop wasting cycle attention.
+ *  Exported for unit testing — production callers should still go through buildAutonomousPrompt. */
+export function buildErrorPatternsHint(): string {
   try {
     const patterns = readState<Record<string, { count: number; taskCreated: boolean; lastSeen: string; resolved?: boolean }>>('error-patterns.json', {});
+    const STALE_MS = 7 * 24 * 60 * 60 * 1000;
+    const cutoff = Date.now() - STALE_MS;
     const actionable = Object.entries(patterns)
-      .filter(([, v]) => v.count >= 3 && !v.resolved)
+      .filter(([, v]) => {
+        if (v.count < 3 || v.resolved) return false;
+        const ts = Date.parse(v.lastSeen);
+        return Number.isFinite(ts) && ts >= cutoff;
+      })
       .sort(([, a], [, b]) => b.count - a.count)
       .slice(0, 5);
     if (actionable.length === 0) return '';

--- a/tests/prompt-builder-error-patterns-hint.test.ts
+++ b/tests/prompt-builder-error-patterns-hint.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Issue #315: buildErrorPatternsHint must filter entries whose lastSeen is
+// older than 7 days, so once-resolved-but-still-on-disk patterns stop wasting
+// cycle attention.
+
+type Pattern = {
+  count: number;
+  taskCreated: boolean;
+  lastSeen: string;
+  resolved?: boolean;
+};
+
+const state: { patterns: Record<string, Pattern> } = { patterns: {} };
+
+vi.mock('../src/feedback-loops.js', () => ({
+  readState: <T>(filename: string, fallback: T): T => {
+    if (filename === 'error-patterns.json') {
+      return state.patterns as unknown as T;
+    }
+    return fallback;
+  },
+  writeState: () => {},
+}));
+
+vi.mock('../src/utils.js', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return { ...actual, slog: () => {} };
+});
+
+import { buildErrorPatternsHint } from '../src/prompt-builder.js';
+
+const isoDaysAgo = (days: number) =>
+  new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+
+describe('buildErrorPatternsHint — issue #315 staleness filter', () => {
+  beforeEach(() => {
+    state.patterns = {};
+  });
+
+  it('omits entries with lastSeen older than 7 days', () => {
+    state.patterns = {
+      'TIMEOUT:dns_lookup_failed::callClaude': {
+        count: 23,
+        taskCreated: true,
+        lastSeen: isoDaysAgo(10), // stale
+      },
+      'TIMEOUT:silent_exit_void::callClaude': {
+        count: 17,
+        taskCreated: true,
+        lastSeen: isoDaysAgo(1), // fresh
+      },
+    };
+
+    const out = buildErrorPatternsHint();
+
+    expect(out).toContain('silent_exit_void');
+    expect(out).not.toContain('dns_lookup_failed');
+  });
+
+  it('keeps entries within the 7-day window', () => {
+    state.patterns = {
+      'recent:problem': {
+        count: 5,
+        taskCreated: false,
+        lastSeen: isoDaysAgo(6), // boundary-fresh
+      },
+    };
+    expect(buildErrorPatternsHint()).toContain('recent:problem');
+  });
+
+  it('returns empty string when every actionable pattern is stale', () => {
+    state.patterns = {
+      'old:problem': {
+        count: 99,
+        taskCreated: true,
+        lastSeen: isoDaysAgo(30),
+      },
+    };
+    expect(buildErrorPatternsHint()).toBe('');
+  });
+
+  it('still drops resolved entries even if fresh', () => {
+    state.patterns = {
+      'fresh:resolved': {
+        count: 10,
+        taskCreated: true,
+        lastSeen: isoDaysAgo(1),
+        resolved: true,
+      },
+    };
+    expect(buildErrorPatternsHint()).toBe('');
+  });
+
+  it('still drops entries with count < 3 even if fresh', () => {
+    state.patterns = {
+      'low:count': {
+        count: 2,
+        taskCreated: false,
+        lastSeen: isoDaysAgo(1),
+      },
+    };
+    expect(buildErrorPatternsHint()).toBe('');
+  });
+
+  it('treats malformed lastSeen as stale (defensive guard)', () => {
+    state.patterns = {
+      'bad:timestamp': {
+        count: 5,
+        taskCreated: false,
+        lastSeen: 'not-a-date',
+      },
+    };
+    expect(buildErrorPatternsHint()).toBe('');
+  });
+});


### PR DESCRIPTION
Closes #315.

## What
Add a 7-day `lastSeen` window to `buildErrorPatternsHint()` so resolved-but-still-on-disk error keys stop wasting cycle attention. Defensive `Number.isFinite(Date.parse(...))` guard means malformed timestamps fail closed (filtered, not thrown).

## Falsifier (per #315 spec)
- Next cycle's prompt **must drop** `TIMEOUT:dns_lookup_failed::callClaude` (lastSeen 2026-05-05 → 3d stale today, but the next dispatch the data ages further; key has been silent for the full window soon).
- Next cycle's prompt **must keep** `silent_exit_void`, `silent_exit_void_40k`, `transient_no_diag` (all lastSeen 2026-05-07 → fresh).

## Verification
- `pnpm typecheck` clean
- `pnpm vitest run tests/prompt-builder-error-patterns-hint.test.ts` — 6/6 passing:
  - stale entry omitted, fresh entry kept
  - boundary (6d ago) kept
  - all-stale → empty string
  - resolved-but-fresh → still dropped
  - count<3 → still dropped
  - malformed `lastSeen` → defensive drop (no throw)

## Net change
6 added lines + 1 modified in `src/prompt-builder.ts` (function exported for testability), plus 117-line test file. Single concern, ready to merge.

— Kuro autonomously, instance 03bbc29a, cycle 27