### PR TITLE
fix(loop): let high-priority work clear true noop backoff

### DIFF
--- a/src/loop.ts
+++ b/src/loop.ts
@@ -107,6 +107,13 @@ import { cleanupStaleLaneOutput } from './memory.js';
 import { trackNutrientSignals } from './nutrient.js';
 import { detectCitations } from './nutrient-router.js';
 import { recordCycleNutrient } from './cycle-nutrient.js';
+import {
+  canHardSkipRoutineTrigger,
+  effectiveTrueNoopStreak,
+  nextTrueNoopStreakAfterCycle,
+  shouldApplyNoopBackoff,
+  shouldBypassTriageForPendingWork,
+} from './noop-policy.js';
 import { metabolismScan, initMetabolism } from './metabolism.js';
 import { routeModel, getModelCliName, recordModelOutcome } from './model-router.js';
 import { buildCycleRoute, recordCycleRoute } from './route-tracker.js';
@@ -1221,6 +1228,10 @@ export class AgentLoop {
     if (health) {
       this.noopStreak = health.noopStreak;
       this.trueNoopStreak = health.trueNoopStreak ?? 0;
+      if (this.hasPendingWork() && this.trueNoopStreak > 0) {
+        slog('HEALTH', `Reset restored trueNoopStreak=${this.trueNoopStreak} because high-priority work is pending`);
+        this.trueNoopStreak = 0;
+      }
     }
 
     // Achievement system: retroactive unlock on first boot
@@ -1522,15 +1533,22 @@ export class AgentLoop {
       || reason.startsWith('direct-message');
     const isContinuation = reason.startsWith('continuation');
     const hasP0 = this.hasPendingWork();
-    // Noop spiral override: after 3+ consecutive TRUE empty cycles (zero tags),
-    // pending work is clearly not addressable right now — stop bypassing triage.
-    // Uses trueNoopStreak (not noopStreak) to avoid throttling productive-but-invisible cycles.
-    const effectiveP0 = hasP0 && this.trueNoopStreak < 3;
-    if (effectiveP0 && !isDM) {
+    const effectiveTrueNoop = effectiveTrueNoopStreak({
+      hasPendingHighPriority: hasP0,
+      trueNoopStreak: this.trueNoopStreak,
+    });
+    if (effectiveTrueNoop !== this.trueNoopStreak) {
+      slog('LOOP', `Clearing trueNoopStreak=${this.trueNoopStreak} because P0/P1 work is pending`);
+      this.trueNoopStreak = effectiveTrueNoop;
+    }
+    const effectiveP0 = shouldBypassTriageForPendingWork({
+      hasPendingHighPriority: hasP0,
+      trueNoopStreak: this.trueNoopStreak,
+      isDirectMessage: isDM,
+    });
+    if (effectiveP0) {
       slog('MUSHI', `✅ P0 pending work bypasses triage (hard rule)`);
       logTriageBypass('P0-pending', 'wake', 'pending work exists');
-    } else if (hasP0 && this.trueNoopStreak >= 3) {
-      slog('MUSHI', `⚠️ P0 pending but trueNoopStreak=${this.trueNoopStreak} — triage not bypassed`);
     }
     // Log alert/delegation bypasses independently — NOT gated by hasP0 or mushi-triage flag
     if (!isContinuation && reason) {
@@ -1552,7 +1570,10 @@ export class AgentLoop {
         && (triageSource === 'heartbeat' || triageSource === 'workspace')
         && perceptionStreams.version === this.lastPerceptionVersion
         && this.lastAction && /no action|穩態|無需行動|nothing to do/i.test(this.lastAction)
-        && (!this.hasPendingWork() || this.trueNoopStreak >= 3)
+        && canHardSkipRoutineTrigger({
+          hasPendingHighPriority: this.hasPendingWork(),
+          trueNoopStreak: this.trueNoopStreak,
+        })
       ) {
         // Hard skip: routine trigger + no perception change + last cycle was idle + no P0 work
         // Noop spiral override: if 3+ consecutive empty cycles, skip even with pending work
@@ -1701,18 +1722,21 @@ export class AgentLoop {
     // Pending work detection — cap interval when unprocessed items still exist
     // Different from concurrentInbox: checks state AT cycle end, not during Claude call
     // Priority: kuro:schedule > concurrent-inbox (30s) > pending-work (2min) > adjustInterval
-    // Noop spiral guard: if 3+ consecutive empty cycles, pending work is not actionable right now
+    // P0/P1 work owns the interval cap; stale/noop counters must not make it wait longer.
     if (!this.lastCycleHadSchedule && !this.concurrentInboxDetected
-        && this.currentInterval > 120_000 && this.trueNoopStreak < 3) {
+        && this.currentInterval > 120_000) {
       if (this.hasPendingWork()) {
         this.currentInterval = 120_000; // 2min cap
         slog('LOOP', `[pending-work] Capping interval to 2min — unprocessed items detected`);
       }
     }
 
-    // Noop spiral backoff: force minimum interval proportional to TRUE noop streak.
-    // Uses trueNoopStreak (zero tags) to avoid throttling productive-but-invisible cycles.
-    if (this.trueNoopStreak >= 3 && !this.lastCycleHadSchedule) {
+    // Noop spiral backoff only applies when no high-priority work is pending.
+    if (shouldApplyNoopBackoff({
+      hasPendingHighPriority: this.hasPendingWork(),
+      trueNoopStreak: this.trueNoopStreak,
+      lastCycleHadSchedule: this.lastCycleHadSchedule,
+    })) {
       const noopFloor = Math.min(this.trueNoopStreak * 120_000, 600_000);
       if (this.currentInterval < noopFloor) {
         this.currentInterval = noopFloor;
@@ -3264,11 +3288,16 @@ export class AgentLoop {
           this.noopStreak = Math.ceil(this.noopStreak / 2);
         }
       } else {
+        const hasPendingAfterCycle = this.hasPendingWork();
         this.noopStreak++;
         if (cycleTagsProcessed.length > 0) {
           this.trueNoopStreak = 0;
         } else {
-          this.trueNoopStreak++;
+          this.trueNoopStreak = nextTrueNoopStreakAfterCycle({
+            hasPendingHighPriority: hasPendingAfterCycle,
+            trueNoopStreak: this.trueNoopStreak,
+            hadAgentActivity: false,
+          });
         }
       }
 

--- a/src/noop-policy.ts
+++ b/src/noop-policy.ts
@@ -1,0 +1,29 @@
+export interface NoopPolicyInput {
+  hasPendingHighPriority: boolean;
+  trueNoopStreak: number;
+  lastCycleHadSchedule?: boolean;
+}
+
+export function effectiveTrueNoopStreak(input: NoopPolicyInput): number {
+  return input.hasPendingHighPriority ? 0 : Math.max(0, input.trueNoopStreak);
+}
+
+export function shouldBypassTriageForPendingWork(input: NoopPolicyInput & { isDirectMessage: boolean }): boolean {
+  return input.hasPendingHighPriority && !input.isDirectMessage;
+}
+
+export function canHardSkipRoutineTrigger(input: NoopPolicyInput): boolean {
+  return !input.hasPendingHighPriority;
+}
+
+export function shouldApplyNoopBackoff(input: NoopPolicyInput): boolean {
+  return !input.hasPendingHighPriority
+    && !input.lastCycleHadSchedule
+    && input.trueNoopStreak >= 3;
+}
+
+export function nextTrueNoopStreakAfterCycle(input: NoopPolicyInput & { hadAgentActivity: boolean }): number {
+  if (input.hasPendingHighPriority) return 0;
+  if (input.hadAgentActivity) return 0;
+  return Math.max(0, input.trueNoopStreak) + 1;
+}

--- a/tests/noop-policy.test.ts
+++ b/tests/noop-policy.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import {
+  canHardSkipRoutineTrigger,
+  effectiveTrueNoopStreak,
+  nextTrueNoopStreakAfterCycle,
+  shouldApplyNoopBackoff,
+  shouldBypassTriageForPendingWork,
+} from '../src/noop-policy.js';
+
+describe('noop policy', () => {
+  it('clears restored trueNoopStreak when high-priority work exists', () => {
+    expect(effectiveTrueNoopStreak({
+      hasPendingHighPriority: true,
+      trueNoopStreak: 20,
+    })).toBe(0);
+  });
+
+  it('always lets P0/P1 pending work bypass mushi triage unless the trigger is a direct message', () => {
+    expect(shouldBypassTriageForPendingWork({
+      hasPendingHighPriority: true,
+      trueNoopStreak: 20,
+      isDirectMessage: false,
+    })).toBe(true);
+    expect(shouldBypassTriageForPendingWork({
+      hasPendingHighPriority: true,
+      trueNoopStreak: 20,
+      isDirectMessage: true,
+    })).toBe(false);
+  });
+
+  it('does not hard-skip or back off routine triggers while high-priority work exists', () => {
+    expect(canHardSkipRoutineTrigger({
+      hasPendingHighPriority: true,
+      trueNoopStreak: 20,
+    })).toBe(false);
+    expect(shouldApplyNoopBackoff({
+      hasPendingHighPriority: true,
+      trueNoopStreak: 20,
+      lastCycleHadSchedule: false,
+    })).toBe(false);
+  });
+
+  it('still allows noop backoff when there is no high-priority work', () => {
+    expect(shouldApplyNoopBackoff({
+      hasPendingHighPriority: false,
+      trueNoopStreak: 3,
+      lastCycleHadSchedule: false,
+    })).toBe(true);
+  });
+
+  it('keeps trueNoopStreak at zero after empty cycles if high-priority work remains pending', () => {
+    expect(nextTrueNoopStreakAfterCycle({
+      hasPendingHighPriority: true,
+      trueNoopStreak: 20,
+      hadAgentActivity: false,
+    })).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- clear restored trueNoopStreak as soon as P0/P1 work is pending
- let pending P0/P1 work bypass Mushi triage and no-op hard-skip/backoff paths
- add a small noop-policy module with regression tests so advisory Mushi signals cannot suppress owned scheduler truth

## Why
Kuro restored trueNoopStreak=21 from a previous instance, then logged `P0 pending but trueNoopStreak=21 — triage not bypassed` and applied noop backoff. That let a stale idle streak delay real high-priority work.

Mushi should remain an advisory perception layer. mini-agent owns P0/P1 truth and must clear idle/backoff state when high-priority work exists.

## Verification
- `pnpm typecheck`
- `pnpm test tests/noop-policy.test.ts`
