### PR TITLE
fix(deploy): release deploy lock before janitor

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -7,10 +7,12 @@ set -e
 DEPLOY_DIR="/Users/user/Workspace/mini-agent"
 LOG_FILE="$HOME/.mini-agent/deploy.log"
 LOCK_DIR="$HOME/.mini-agent/deploy.lock"
+JANITOR_LOCK_DIR="$HOME/.mini-agent/workspace-janitor.lock"
 DEFAULT_MEMORY_DIR="$(dirname "$DEPLOY_DIR")/mini-agent-memory/memory"
 DEPLOY_LOCK_WAIT_SECONDS="${MINI_AGENT_DEPLOY_LOCK_WAIT_SECONDS:-90}"
 DEPLOY_LOCK_TERM_GRACE_SECONDS="${MINI_AGENT_DEPLOY_LOCK_TERM_GRACE_SECONDS:-30}"
 WORKSPACE_JANITOR_TIMEOUT_SECONDS="${MINI_AGENT_WORKSPACE_JANITOR_TIMEOUT_SECONDS:-60}"
+LOCK_HELD=0
 
 mkdir -p "$HOME/.mini-agent"
 mkdir -p "$DEFAULT_MEMORY_DIR"
@@ -25,10 +27,21 @@ is_deploy_process() {
     ps -p "$1" -o command= 2>/dev/null | grep -q 'scripts/deploy\.sh'
 }
 
+release_lock() {
+    if [ "$LOCK_HELD" = "1" ] && [ -d "$LOCK_DIR" ]; then
+        CURRENT_LOCK_PID=$(cat "$LOCK_DIR/pid" 2>/dev/null || true)
+        if [ "$CURRENT_LOCK_PID" = "$$" ]; then
+            rm -rf "$LOCK_DIR"
+        fi
+        LOCK_HELD=0
+    fi
+}
+
 acquire_lock() {
     if mkdir "$LOCK_DIR" 2>/dev/null; then
         echo "$$" > "$LOCK_DIR/pid"
-        trap 'rm -rf "$LOCK_DIR"' EXIT
+        LOCK_HELD=1
+        trap release_lock EXIT
         return 0
     fi
 
@@ -75,12 +88,53 @@ acquire_lock() {
 
     if mkdir "$LOCK_DIR" 2>/dev/null; then
         echo "$$" > "$LOCK_DIR/pid"
-        trap 'rm -rf "$LOCK_DIR"' EXIT
+        LOCK_HELD=1
+        trap release_lock EXIT
         return 0
     fi
 
     log "Could not acquire deploy lock; aborting"
     exit 1
+}
+
+run_workspace_janitor() {
+    if mkdir "$JANITOR_LOCK_DIR" 2>/dev/null; then
+        echo "$$" > "$JANITOR_LOCK_DIR/pid"
+    else
+        JANITOR_LOCK_PID=$(cat "$JANITOR_LOCK_DIR/pid" 2>/dev/null || true)
+        if [ -n "$JANITOR_LOCK_PID" ] && kill -0 "$JANITOR_LOCK_PID" 2>/dev/null; then
+            log "Skipping workspace janitor because another janitor is running (PID $JANITOR_LOCK_PID)"
+            return 0
+        fi
+        log "Removing stale workspace janitor lock"
+        rm -rf "$JANITOR_LOCK_DIR"
+        if ! mkdir "$JANITOR_LOCK_DIR" 2>/dev/null; then
+            log "Skipping workspace janitor; could not acquire janitor lock"
+            return 0
+        fi
+        echo "$$" > "$JANITOR_LOCK_DIR/pid"
+    fi
+
+    log "Running workspace janitor..."
+    (
+        pnpm exec tsx scripts/workspace-janitor.ts --apply >> "$LOG_FILE" 2>&1
+    ) &
+    JANITOR_PID=$!
+    for _ in $(seq 1 "$WORKSPACE_JANITOR_TIMEOUT_SECONDS"); do
+        if ! kill -0 "$JANITOR_PID" 2>/dev/null; then break; fi
+        sleep 1
+    done
+    if kill -0 "$JANITOR_PID" 2>/dev/null; then
+        log "Workspace janitor timed out after ${WORKSPACE_JANITOR_TIMEOUT_SECONDS}s; terminating (non-fatal)"
+        kill -TERM "$JANITOR_PID" 2>/dev/null || true
+        wait "$JANITOR_PID" 2>/dev/null || true
+        log "Workspace janitor failed (non-fatal)"
+    elif wait "$JANITOR_PID"; then
+        log "Workspace janitor completed"
+    else
+        log "Workspace janitor failed (non-fatal)"
+    fi
+    rm -rf "$JANITOR_LOCK_DIR"
 }
 
 cd "$DEPLOY_DIR"
@@ -203,6 +257,8 @@ done
 
 if [ "$HEALTH_OK" = true ]; then
     log "Deployment successful"
+    log "Releasing deploy lock before non-critical workspace janitor"
+    release_lock
     if [ "${MINI_AGENT_SKIP_WORKSPACE_JANITOR:-0}" = "1" ]; then
         log "Skipping workspace janitor"
     elif [ "$(git branch --show-current 2>/dev/null)" != "runtime/main" ]; then
@@ -210,25 +266,7 @@ if [ "$HEALTH_OK" = true ]; then
     elif git status --porcelain | grep -q '^UU '; then
         log "Skipping workspace janitor because deploy checkout has unresolved conflicts"
     else
-        log "Running workspace janitor..."
-        (
-            pnpm exec tsx scripts/workspace-janitor.ts --apply >> "$LOG_FILE" 2>&1
-        ) &
-        JANITOR_PID=$!
-        for _ in $(seq 1 "$WORKSPACE_JANITOR_TIMEOUT_SECONDS"); do
-            if ! kill -0 "$JANITOR_PID" 2>/dev/null; then break; fi
-            sleep 1
-        done
-        if kill -0 "$JANITOR_PID" 2>/dev/null; then
-            log "Workspace janitor timed out after ${WORKSPACE_JANITOR_TIMEOUT_SECONDS}s; terminating (non-fatal)"
-            kill -TERM "$JANITOR_PID" 2>/dev/null || true
-            wait "$JANITOR_PID" 2>/dev/null || true
-            log "Workspace janitor failed (non-fatal)"
-        elif wait "$JANITOR_PID"; then
-            log "Workspace janitor completed"
-        else
-            log "Workspace janitor failed (non-fatal)"
-        fi
+        run_workspace_janitor
     fi
     exit 0
 else

--- a/scripts/workspace-janitor.ts
+++ b/scripts/workspace-janitor.ts
@@ -94,8 +94,10 @@ for (const branch of readRemoteBranches()) {
 }
 
 if (apply) {
+  process.stdout.write(`[workspace-janitor] applying ${actions.length} action(s)\n`);
   for (const action of actions) {
     if (!action.command) continue;
+    process.stdout.write(`[workspace-janitor] apply ${action.type}: ${action.target}\n`);
     try {
       execFileSync(action.command[0], action.command.slice(1), {
         cwd: root,
@@ -105,6 +107,7 @@ if (apply) {
       });
     } catch (error) {
       action.reason += `; apply failed: ${error instanceof Error ? error.message.split('\n')[0] : String(error)}`;
+      process.stdout.write(`[workspace-janitor] failed ${action.type}: ${action.target} — ${action.reason}\n`);
     }
   }
   git(['worktree', 'prune']);

--- a/tests/deploy-script.test.ts
+++ b/tests/deploy-script.test.ts
@@ -17,13 +17,13 @@ describe('deploy script workspace janitor hook', () => {
     expect(script).toContain('requesting graceful shutdown');
     expect(script).toContain('kill -TERM "$LOCK_PID"');
     expect(script).toContain('force killing before new deploy');
-    expect(script).toContain("trap 'rm -rf \"$LOCK_DIR\"' EXIT");
+    expect(script).toContain('trap release_lock EXIT');
   });
 
   it('runs workspace janitor after successful health check without making deploy fail', () => {
     const script = readFileSync(path.join(process.cwd(), 'scripts', 'deploy.sh'), 'utf-8');
     const successIndex = script.indexOf('log "Deployment successful"');
-    const janitorIndex = script.indexOf('scripts/workspace-janitor.ts --apply');
+    const janitorIndex = script.indexOf('run_workspace_janitor', successIndex);
     const exitIndex = script.indexOf('exit 0', successIndex);
 
     expect(successIndex).toBeGreaterThan(-1);
@@ -33,6 +33,9 @@ describe('deploy script workspace janitor hook', () => {
     expect(script).toContain('Skipping workspace janitor because deploy checkout is not on runtime/main');
     expect(script).toContain('Skipping workspace janitor because deploy checkout has unresolved conflicts');
     expect(script).toContain('Workspace janitor failed (non-fatal)');
+    expect(script).toContain('Releasing deploy lock before non-critical workspace janitor');
+    expect(script).toContain('JANITOR_LOCK_DIR="$HOME/.mini-agent/workspace-janitor.lock"');
+    expect(script).toContain('Skipping workspace janitor because another janitor is running');
   });
 
   it('exports external memory paths before starting the runtime service', () => {


### PR DESCRIPTION
## Summary
- release the deploy lock immediately after service health succeeds
- give workspace janitor its own lightweight lock so cleanup cannot serialize deployments
- log each janitor apply action before running it, so timeout diagnostics show the current blocking operation

## Why
Deploy already treated workspace janitor as non-fatal, but the deploy lock stayed held until janitor completed or timed out. When GitHub Actions deploy started during local deploy, it waited for the janitor timeout and then redeployed. Cleanup should not block shipping a healthy service.

## Verification
- `pnpm typecheck`
- `pnpm test tests/deploy-script.test.ts`
