### PR TITLE
fix(scheduler): filter held correction tasks before stack-rank (#316)

### DIFF
--- a/src/correction-holds.ts
+++ b/src/correction-holds.ts
@@ -142,3 +142,35 @@ export function findActiveHold(
 
   return null;
 }
+
+/**
+ * Issue #316: shared filter to drop correction tasks that have an active hold.
+ * Used by both `getP0TaskPreviews` (prompt header) and `Scheduler.stackRank`
+ * (dispatch path) so the two paths stay consistent. Without this, scheduler
+ * Rule 4 stack-ranks held correction tasks (priority 0 + +8000 score boost),
+ * causing same-task re-emission every cycle while the hold is active.
+ */
+export function filterHeldCorrectionTasks<
+  T extends { summary?: string; payload?: Record<string, unknown> | unknown }
+>(
+  tasks: T[],
+  memoryDir: string,
+  repoRoot: string,
+): T[] {
+  let holds: CorrectionHold[] | null = null;
+  return tasks.filter(t => {
+    const summary = (t as { summary?: string }).summary ?? '';
+    if (!summary.includes('correction gate')) return true;
+    if (holds === null) holds = loadCorrectionHolds(memoryDir);
+    if (holds.length === 0) return true;
+    const payload = ((t as { payload?: Record<string, unknown> }).payload ?? {}) as Record<string, unknown>;
+    const reasonFromPayload = typeof payload.correction_reason_type === 'string'
+      ? payload.correction_reason_type
+      : null;
+    const match = summary.match(/correction gate: resolve ([a-z-]+)/i);
+    const reason = reasonFromPayload ?? match?.[1] ?? null;
+    if (!reason) return true;
+    const hold = findActiveHold(holds, reason as CorrectionReasonType, {}, { repoRoot });
+    return !hold;
+  });
+}

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -6,7 +6,7 @@
  */
 
 import { existsSync, readFileSync, statSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 import { execSync } from 'node:child_process';
 import { queryMemoryIndexSync, updateMemoryIndexEntry, type MemoryIndexEntry } from './memory-index.js';
 import { slog } from './utils.js';
@@ -14,6 +14,7 @@ import { eventBus } from './event-bus.js';
 import { getProcess } from './process-table.js';
 import { evaluateCorrectionGate, isCorrectionTask, type CorrectionGateSnapshot } from './correction-gate.js';
 import { reverifyPredicate } from './predicate-freshness.js';
+import { filterHeldCorrectionTasks } from './correction-holds.js';
 
 // =============================================================================
 // Types
@@ -417,8 +418,21 @@ export function schedulerPick(
       }
       return true;
     });
-  const decision = scheduler.decideNext(tasks, schedulerState, events);
-  const schedulableTaskIds = new Set(tasks.map(task => task.id));
+  // Issue #316: drop correction tasks whose hold is still active. Mirrors the
+  // filter already applied in memory-index.getP0TaskPreviews so the dispatch
+  // path stays consistent with the prompt-header preview path. Without this,
+  // Rule 4 stackRank picks held correction tasks (priority 0 + +8000 boost),
+  // re-emitting the same P0 every cycle while the hold is active.
+  const repoRootForHolds = resolve(memoryDir, '..', '..');
+  const beforeHoldFilter = tasks.length;
+  const tasksAfterHolds = filterHeldCorrectionTasks(tasks, memoryDir, repoRootForHolds);
+  if (tasksAfterHolds.length !== beforeHoldFilter) {
+    slog('SCHED', `stack-rank-hold-filter: dropped ${beforeHoldFilter - tasksAfterHolds.length} held correction task(s)`);
+  }
+  const decision = scheduler.decideNext(tasksAfterHolds, schedulerState, events);
+  // Issue #316: schedulableTaskIds must reflect the post-hold-filter set, otherwise
+  // the force-correction branch below would reintroduce a held correction task.
+  const schedulableTaskIds = new Set(tasksAfterHolds.map(task => task.id));
   const correctionTask = entries.find(entry => schedulableTaskIds.has(entry.id) && isCorrectionTask(entry));
   if (correctionTask && (!decision.taskId || decision.action === 'discovery' || decision.action === 'idle')) {
     const forced: SchedulingDecision = {


### PR DESCRIPTION
## Why
Closes the dispatch-path twin of #289. Scheduler Rule 4 `stackRank` read `activeTasks` unfiltered, while `memory-index.getP0TaskPreviews` correctly filtered held correction tasks. Result: held correction tasks (priority 0 + +8000 score boost) re-emitted every cycle on the dispatch path even though the prompt-header preview path hid them.

Empirical signature (instance 03bbc29a): 8+ consecutive cycles re-handed `P0 correction gate: resolve low-responsiveness` despite active hold `hold-low-responsiveness-quota-2026-05-07` (until `2026-05-09T10:00Z`).

## What
- New shared helper `filterHeldCorrectionTasks()` in `correction-holds.ts`.
- `schedulerPick()` applies it before `scheduler.decideNext()`.
- Force-correction fallback uses the post-filter id set so a held task can't be reintroduced via the idle/discovery branch.
- Telemetry: `slog('SCHED', 'stack-rank-hold-filter: dropped N held correction task(s)')`.

`memory-index.getP0TaskPreviews` keeps its inline filter for now (no behavior change). Refactor to share the helper is a follow-up.

## Verification
- `npx tsc --noEmit` clean for `scheduler.ts` and `correction-holds.ts`.
- Falsifier (next 24h after merge): with `hold-low-responsiveness-quota-2026-05-07` active, scheduler should NOT emit `stack rank: P0 P0 correction gate: resolve low-responsiveness`. After `2026-05-09T10:00Z` hold expiry, the task resumes emitting.
- Watch for `SCHED stack-rank-hold-filter` log lines in `server.log`.

## Related
- #316 — this issue
- #289 — original mirror fix on prompt-preview path
- #306 / PR #314 — orthogonal stale-signal lag fix (banner path, awaiting review)

— kuro-agent (instance 03bbc29a)