### PR TITLE
fix(deploy): let waiters follow released locks

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -53,6 +53,15 @@ acquire_lock() {
         else
             log "Another deploy is already running (PID $LOCK_PID); waiting up to ${DEPLOY_LOCK_WAIT_SECONDS}s"
             for _ in $(seq 1 "$DEPLOY_LOCK_WAIT_SECONDS"); do
+                if [ ! -d "$LOCK_DIR" ]; then
+                    log "Deploy lock was released; taking over lock"
+                    break
+                fi
+                CURRENT_LOCK_PID=$(cat "$LOCK_DIR/pid" 2>/dev/null || true)
+                if [ -n "$CURRENT_LOCK_PID" ] && [ "$CURRENT_LOCK_PID" != "$LOCK_PID" ]; then
+                    log "Deploy lock owner changed from $LOCK_PID to $CURRENT_LOCK_PID; continuing wait"
+                    LOCK_PID="$CURRENT_LOCK_PID"
+                fi
                 if ! kill -0 "$LOCK_PID" 2>/dev/null; then
                     log "Previous deploy PID $LOCK_PID exited; taking over lock"
                     rm -rf "$LOCK_DIR"
@@ -117,7 +126,7 @@ run_workspace_janitor() {
 
     log "Running workspace janitor..."
     (
-        pnpm exec tsx scripts/workspace-janitor.ts --apply >> "$LOG_FILE" 2>&1
+        pnpm exec tsx scripts/workspace-janitor.ts --apply --local-only >> "$LOG_FILE" 2>&1
     ) &
     JANITOR_PID=$!
     for _ in $(seq 1 "$WORKSPACE_JANITOR_TIMEOUT_SECONDS"); do

--- a/scripts/workspace-janitor.ts
+++ b/scripts/workspace-janitor.ts
@@ -20,6 +20,7 @@ const apply = process.argv.includes('--apply');
 const json = process.argv.includes('--json');
 const repo = readArg('--repo') ?? process.env.MINI_AGENT_GITHUB_REPO ?? 'miles990/mini-agent';
 const base = readArg('--base') ?? process.env.MINI_AGENT_BASE_BRANCH ?? 'main';
+const localOnly = process.argv.includes('--local-only');
 const root = git(['rev-parse', '--show-toplevel']) || process.cwd();
 const currentBranch = git(['rev-parse', '--abbrev-ref', 'HEAD']) || 'unknown';
 const mergedPrBranches = new Set(readMergedPrBranches(repo));
@@ -81,15 +82,17 @@ for (const branch of readLocalBranches()) {
   }
 }
 
-for (const branch of readRemoteBranches()) {
-  if (openPrBranches.has(branch)) continue;
-  if (mergedPrBranches.has(branch)) {
-    actions.push({
-      type: 'delete-remote-branch',
-      target: branch,
-      reason: 'PR already merged and no open PR uses this head',
-      command: ['git', 'push', 'origin', '--delete', branch],
-    });
+if (!localOnly) {
+  for (const branch of readRemoteBranches()) {
+    if (openPrBranches.has(branch)) continue;
+    if (mergedPrBranches.has(branch)) {
+      actions.push({
+        type: 'delete-remote-branch',
+        target: branch,
+        reason: 'PR already merged and no open PR uses this head',
+        command: ['git', 'push', 'origin', '--delete', branch],
+      });
+    }
   }
 }
 
@@ -114,9 +117,9 @@ if (apply) {
 }
 
 if (json) {
-  process.stdout.write(JSON.stringify({ apply, root, currentBranch, actions }, null, 2) + '\n');
+  process.stdout.write(JSON.stringify({ apply, localOnly, root, currentBranch, actions }, null, 2) + '\n');
 } else {
-  process.stdout.write(`[workspace-janitor] mode=${apply ? 'apply' : 'dry-run'} actions=${actions.length}\n`);
+  process.stdout.write(`[workspace-janitor] mode=${apply ? 'apply' : 'dry-run'} localOnly=${localOnly} actions=${actions.length}\n`);
   for (const action of actions) {
     process.stdout.write(`- ${action.type}: ${action.target} — ${action.reason}\n`);
   }

--- a/tests/deploy-script.test.ts
+++ b/tests/deploy-script.test.ts
@@ -14,6 +14,7 @@ describe('deploy script workspace janitor hook', () => {
     expect(acquireIndex).toBeLessThan(startIndex);
     expect(script).toContain('Another deploy is already running');
     expect(script).toContain('waiting up to ${DEPLOY_LOCK_WAIT_SECONDS}s');
+    expect(script).toContain('Deploy lock was released; taking over lock');
     expect(script).toContain('requesting graceful shutdown');
     expect(script).toContain('kill -TERM "$LOCK_PID"');
     expect(script).toContain('force killing before new deploy');
@@ -36,6 +37,7 @@ describe('deploy script workspace janitor hook', () => {
     expect(script).toContain('Releasing deploy lock before non-critical workspace janitor');
     expect(script).toContain('JANITOR_LOCK_DIR="$HOME/.mini-agent/workspace-janitor.lock"');
     expect(script).toContain('Skipping workspace janitor because another janitor is running');
+    expect(script).toContain('scripts/workspace-janitor.ts --apply --local-only');
   });
 
   it('exports external memory paths before starting the runtime service', () => {


### PR DESCRIPTION
## Summary
- make waiting deploys notice when the lock directory has been released even if the previous deploy process is still running non-critical janitor work
- run post-deploy workspace janitor in `--local-only` mode so deploy cleanup does not attempt remote branch deletion
- keep remote branch cleanup out of the shipping path; it belongs to separate governance/maintenance work with explicit GitHub identity

## Why
The previous fix released the deploy lock before janitor, but a deploy that had already started waiting still watched the old PID. It would continue waiting until janitor timeout. Also, deploy janitor attempted many remote branch deletes, which failed and consumed the timeout budget.

## Verification
- `pnpm typecheck`
- `pnpm test tests/deploy-script.test.ts`
