### PR TITLE
fix(closure): ignore review handoffs for closed PRs

### DIFF
--- a/src/autonomy-closure-health.ts
+++ b/src/autonomy-closure-health.ts
@@ -6,7 +6,7 @@ import { evaluatePrReviewConsensus, parsePrReviewHandoffs, readPrReviewClaimsSyn
 import { evaluateRuntimeMemoryPlacement } from './memory-paths.js';
 import { eventBus } from './event-bus.js';
 import { readTestHealthSnapshot, summarizeTestHealth } from './test-health-autopilot.js';
-import { evaluatePrClosureGaps } from './pr-autopilot.js';
+import { evaluatePrClosureGaps, readOpenPrSnapshot } from './pr-autopilot.js';
 import { evaluateKgExternalMemoryTruth, evaluateMemoryStateTruth } from './external-memory-health.js';
 import { evaluateMiddlewareQuality } from './middleware-quality-health.js';
 import { readClassifiedMiddlewareTaskIds } from './middleware-failure-self-healing.js';
@@ -371,8 +371,15 @@ function prReviewConsensusStage(memoryDir: string): AutonomyClosureStageResult {
 
   const activeContent = readFileSync(activePath, 'utf-8');
   const openPrGaps = evaluatePrClosureGaps(memoryDir, activeContent);
-  const handoffs = parsePrReviewHandoffs(activeContent);
-  const claims = readPrReviewClaimsSync(memoryDir);
+  const handoffsRaw = parsePrReviewHandoffs(activeContent);
+  const openPrSnapshot = readOpenPrSnapshot(memoryDir);
+  const openPrNumbers = openPrSnapshot ? new Set(openPrSnapshot.prs.map(pr => pr.number)) : null;
+  const handoffs = openPrNumbers
+    ? handoffsRaw.filter(handoff => openPrNumbers.has(handoff.prNumber))
+    : handoffsRaw;
+  const claims = openPrNumbers
+    ? readPrReviewClaimsSync(memoryDir).filter(claim => openPrNumbers.has(claim.prNumber))
+    : readPrReviewClaimsSync(memoryDir);
   const consensuses = evaluatePrReviewConsensus(handoffs, claims);
   const missing = consensuses.filter(c => c.status === 'pending' && c.missingReviewers.length > 0);
   const changes = consensuses.filter(c => c.status === 'changes_requested' || c.status === 'disputed');

--- a/tests/autonomy-closure-health.test.ts
+++ b/tests/autonomy-closure-health.test.ts
@@ -8,6 +8,8 @@ import {
   evaluateAutonomyClosure,
 } from '../src/autonomy-closure-health.js';
 import { queryMemoryIndexSync } from '../src/memory-index.js';
+import { writeOpenPrSnapshot } from '../src/pr-autopilot.js';
+import { appendPrReviewClaim, createPrReviewClaim } from '../src/pr-review-runner.js';
 
 describe('autonomy closure health', () => {
   let tmpDir: string;
@@ -95,6 +97,37 @@ describe('autonomy closure health', () => {
     expect(snapshot.status).toBe('blocked');
     expect(snapshot.blockingStages).toContain('public-write-identity');
     expect(snapshot.stages.find(s => s.stage === 'public-write-identity')?.evidence[0]).toContain('expected=kuro-agent actual=miles990');
+  });
+
+  it('does not block PR review consensus on handoffs for PRs absent from the open PR snapshot', () => {
+    writeFileSync(path.join(tmpDir, 'state/task-events.jsonl'), '', 'utf-8');
+    writeFileSync(path.join(tmpDir, 'index/relations.jsonl'), '', 'utf-8');
+    mkdirSync(path.join(tmpDir, 'handoffs'), { recursive: true });
+    writeFileSync(path.join(tmpDir, 'handoffs/active.md'), [
+      '| source | owner | item | status | opened | closed |',
+      '| github | codex | PR #313 stale closed PR | changes-requested | 05-07 | - |',
+    ].join('\n') + '\n', 'utf-8');
+    appendPrReviewClaim(tmpDir, createPrReviewClaim({
+      prNumber: 313,
+      reviewer: 'codex',
+      framework: 'code-review',
+      verdict: 'request_changes',
+      risk: 'medium',
+      summary: 'Stale change request for a closed PR.',
+      evidence: ['handoff'],
+    }));
+    writeOpenPrSnapshot(tmpDir, [], new Date('2026-05-08T00:00:00.000Z'));
+
+    const snapshot = evaluateAutonomyClosure(tmpDir, {
+      repoRoot,
+      now: new Date('2026-05-08T00:01:00.000Z'),
+    });
+
+    expect(snapshot.blockingStages).not.toContain('pr-review-consensus');
+    expect(snapshot.stages.find(s => s.stage === 'pr-review-consensus')).toEqual(expect.objectContaining({
+      status: 'ok',
+      summary: 'no pending PR review handoffs and open PR snapshot is current',
+    }));
   });
 
   it('closes active autonomy closure task after blockers resolve', async () => {


### PR DESCRIPTION
## Summary
- filter PR review consensus inputs to the current open-prs snapshot when it exists
- keep historical handoff rows in memory without letting closed/merged PRs block autonomy closure
- add a regression test for stale changes-requested handoffs on PRs absent from the open snapshot

## Why
After #313 was closed and #314/#321 were merged, GitHub showed zero open PRs and `open-prs.json` had an empty snapshot, but autonomy closure still blocked on stale `handoffs/active.md` rows marked changes-requested. The closure stage was evaluating all historical handoffs instead of only currently open PRs.

## Verification
- `pnpm typecheck`
- `pnpm test tests/autonomy-closure-health.test.ts`
