### PR TITLE
fix(predicate-freshness): wire memory-state-truth + ship-truth (Layer 2, #323)

### DIFF
--- a/src/predicate-freshness.ts
+++ b/src/predicate-freshness.ts
@@ -1,4 +1,4 @@
-// Layer 1 of issue #306: re-verify P0 conditions before dispatch.
+// Layer 1 + Layer 2 of issue #306 / #323: re-verify P0 conditions before dispatch.
 //
 // The scheduler emits correction tasks based on a snapshot evaluation
 // (`evaluateCorrectionGate`) that can lag behind ground truth — git status
@@ -11,20 +11,23 @@
 //   - false → predicate is now clean, skip dispatch (caller logs skip)
 //   - null  → no live source-of-truth wired for this type yet (fail-open: dispatch)
 //
-// Layer 1 ships the three cheapest predicates as proof:
+// Layer 1 wired three cheap predicates:
 //   - `dirty-runtime-workspace`  (~50ms `git status --porcelain`)
 //   - `local-commit-not-pushed`  (~50ms `git rev-list --count @{u}..HEAD`)
 //   - `low-responsiveness`       (memory-index re-query, recomputes avgStaleness)
-// Remaining predicates (`memory-state-truth`, `ship-truth`) are scaffolded
-// but return `null` until their checks are added in follow-up commits.
+// Layer 2 (issue #323) adds the remaining two:
+//   - `memory-state-truth`       (live `evaluateMemoryStateTruth` — JSONL parse,
+//                                 HEARTBEAT phantom check, curated-memory git status)
+//   - `ship-truth`               (live `git rev-list --left-right --count @{u}...HEAD`
+//                                 → `behind > 0` is the snapshot-trigger condition)
 
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { queryMemoryIndexSync, type MemoryIndexEntry } from './memory-index.js';
-// NB: avoid importing from correction-gate.ts — it imports this module
-// (`reverifyPredicate`), so a back-import would form a cycle. The two filter
-// helpers below are duplicated from correction-gate.ts; if they drift, both
-// snapshot and live re-check should be updated together.
+import { evaluateMemoryStateTruth } from './external-memory-health.js';
+// NB: avoid importing from correction-gate.ts — historically it formed an
+// import cycle with this module. Re-implement the small slice we need
+// (ahead/behind via `git rev-list --left-right --count`) inline.
 
 const execFileAsync = promisify(execFile);
 
@@ -57,10 +60,10 @@ export async function reverifyPredicate(
       return checkLocalCommitNotPushed(ctx);
     case 'low-responsiveness':
       return checkLowResponsiveness(ctx);
-    // Scaffolded — return null (fail-open) until each is wired in follow-ups.
     case 'memory-state-truth':
+      return checkMemoryStateTruth(ctx);
     case 'ship-truth':
-      return null;
+      return checkShipTruth(ctx);
     default:
       return null;
   }
@@ -139,6 +142,55 @@ async function checkLowResponsiveness(ctx: FreshnessContext): Promise<boolean | 
     return responsiveness < 0.5;
   } catch {
     // Memory-index unavailable / corrupt — fail-open so snapshot wins.
+    return null;
+  }
+}
+
+/**
+ * Source-of-truth: `evaluateMemoryStateTruth` from external-memory-health.
+ * That helper is the single producer of the `memory-state-truth` autonomy
+ * stage status (see autonomy-closure-health.ts:516-525), so calling it
+ * gives us the exact same answer the snapshot would compute right now.
+ *
+ * Stale (true) when status is `blocked` or `warn` — i.e. malformed JSONL,
+ * HEARTBEAT phantom recurring-error tasks, or curated memory dirty.
+ * Fresh (false) when status is `ok`. Fail-open (null) when the helper
+ * itself throws.
+ */
+async function checkMemoryStateTruth(ctx: FreshnessContext): Promise<boolean | null> {
+  try {
+    const result = evaluateMemoryStateTruth(ctx.memoryDir, ctx.repoRoot);
+    return result.status !== 'ok';
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Source-of-truth: `git rev-list --left-right --count @{u}...HEAD` against
+ * the runtime checkout. The snapshot's ship-and-deploy stage marks the
+ * predicate stale when `state ∈ {behind, diverged}` (autonomy-closure-
+ * health.ts:442-451), both of which require `behind > 0`. So we just need
+ * the live behind count.
+ *
+ * Stale (true) when behind > 0. Fresh (false) when behind === 0.
+ * Fail-open (null) when no upstream is configured or git errors —
+ * matches the snapshot's `state: 'unknown'` path which doesn't block.
+ */
+async function checkShipTruth(ctx: FreshnessContext): Promise<boolean | null> {
+  try {
+    const { stdout } = await execFileAsync(
+      'git',
+      ['rev-list', '--left-right', '--count', '@{u}...HEAD'],
+      { cwd: ctx.repoRoot, timeout: 5000 },
+    );
+    // Output: "<behind>\t<ahead>"
+    const parts = stdout.trim().split(/\s+/);
+    const behind = Number.parseInt(parts[0] ?? '', 10);
+    if (!Number.isFinite(behind)) return null;
+    return behind > 0;
+  } catch {
+    // No upstream / detached HEAD / git error → fail-open.
     return null;
   }
 }

--- a/tests/predicate-freshness.test.ts
+++ b/tests/predicate-freshness.test.ts
@@ -10,10 +10,11 @@
  *   - `dirty-runtime-workspace` (git status --porcelain)
  *   - `local-commit-not-pushed` (git rev-list --count @{u}..HEAD)
  *
- * Remaining predicates (`low-responsiveness`, `memory-state-truth`, `ship-truth`)
- * are scaffolded — they MUST return null until their checks land in follow-up
- * commits, so the scheduler keeps the snapshot decision rather than silently
- * dropping a real correction.
+ * Layer 2 (issue #323) extends to:
+ *   - `memory-state-truth` (live `evaluateMemoryStateTruth`)
+ *   - `ship-truth`         (live `git rev-list --left-right --count @{u}...HEAD`)
+ *
+ * Unknown predicate types still return null (fail-open: snapshot wins).
  */
 
 import { execFileSync } from 'node:child_process';
@@ -112,14 +113,60 @@ describe('issue #306 — reverifyPredicate', () => {
       expect(result).toBe(false);
     });
 
-    it('memory-state-truth returns null', async () => {
+    it('memory-state-truth returns false when curated memory is clean (skip phantom dispatch)', async () => {
+      // memoryDir is a tmp git repo with one empty commit — no malformed JSONL,
+      // no HEARTBEAT.md, no curated-memory dirty paths → status:'ok' → false.
       const result = await reverifyPredicate('memory-state-truth', { repoRoot, memoryDir });
+      expect(result).toBe(false);
+    });
+
+    it('memory-state-truth returns true when a critical JSONL is malformed', async () => {
+      const stateDir = path.join(memoryDir, 'state');
+      execFileSync('mkdir', ['-p', stateDir], { stdio: 'pipe' });
+      writeFileSync(path.join(stateDir, 'task-events.jsonl'), '{not valid json\n', 'utf-8');
+      const result = await reverifyPredicate('memory-state-truth', { repoRoot, memoryDir });
+      expect(result).toBe(true);
+    });
+
+    it('ship-truth returns null (fail-open) when no upstream is configured', async () => {
+      const result = await reverifyPredicate('ship-truth', { repoRoot, memoryDir });
       expect(result).toBeNull();
     });
 
-    it('ship-truth returns null', async () => {
-      const result = await reverifyPredicate('ship-truth', { repoRoot, memoryDir });
-      expect(result).toBeNull();
+    it('ship-truth returns false when local HEAD is in sync with the upstream', async () => {
+      const bare = mkdtempSync(path.join(os.tmpdir(), 'predicate-ship-sync-'));
+      try {
+        execFileSync('git', ['init', '--bare', '-q', '-b', 'main', bare], { stdio: 'pipe' });
+        git('remote', 'add', 'origin', bare);
+        git('push', '-q', '-u', 'origin', 'main');
+        const result = await reverifyPredicate('ship-truth', { repoRoot, memoryDir });
+        expect(result).toBe(false);
+      } finally {
+        rmSync(bare, { recursive: true, force: true });
+      }
+    });
+
+    it('ship-truth returns true when upstream is ahead of local (behind > 0)', async () => {
+      const bare = mkdtempSync(path.join(os.tmpdir(), 'predicate-ship-behind-'));
+      const otherClone = mkdtempSync(path.join(os.tmpdir(), 'predicate-ship-other-'));
+      try {
+        execFileSync('git', ['init', '--bare', '-q', '-b', 'main', bare], { stdio: 'pipe' });
+        git('remote', 'add', 'origin', bare);
+        git('push', '-q', '-u', 'origin', 'main');
+        // Push a new commit from another clone so origin/main moves ahead.
+        execFileSync('git', ['clone', '-q', bare, otherClone], { stdio: 'pipe' });
+        execFileSync('git', ['-C', otherClone, 'config', 'user.email', 'other@example.com'], { stdio: 'pipe' });
+        execFileSync('git', ['-C', otherClone, 'config', 'user.name', 'Other'], { stdio: 'pipe' });
+        execFileSync('git', ['-C', otherClone, 'commit', '--allow-empty', '-q', '-m', 'remote-only'], { stdio: 'pipe' });
+        execFileSync('git', ['-C', otherClone, 'push', '-q', 'origin', 'main'], { stdio: 'pipe' });
+        // Refresh our remote-tracking ref so @{u} sees the new commit.
+        git('fetch', '-q', 'origin', 'main');
+        const result = await reverifyPredicate('ship-truth', { repoRoot, memoryDir });
+        expect(result).toBe(true);
+      } finally {
+        rmSync(bare, { recursive: true, force: true });
+        rmSync(otherClone, { recursive: true, force: true });
+      }
     });
 
     it('unknown predicate type returns null', async () => {


### PR DESCRIPTION
Closes #323

## Summary
Two predicate-freshness branches (`memory-state-truth`, `ship-truth`) that
previously returned `null` (fail-open) now perform live source-of-truth
re-checks. This closes the remaining stale-signal lag in the correction
gate — phantom P0 dispatches for these predicates are now skipped when
the underlying condition was resolved between snapshot and dispatch.

## What changed
- `src/predicate-freshness.ts`
  - `memory-state-truth` → calls `evaluateMemoryStateTruth(memoryDir, repoRoot)` from `external-memory-health.ts`. Stale = `status !== 'ok'` (blocked/warn). Fresh = `status === 'ok'`. Fail-open on throw.
  - `ship-truth` → runs `git rev-list --left-right --count @{u}...HEAD`, parses behind count. Stale = `behind > 0` (matches snapshot's `behind`/`diverged` trigger in `autonomy-closure-health.ts:442-451`). Fresh = `behind === 0`. Fail-open on no-upstream / git error.
- `tests/predicate-freshness.test.ts`
  - Removes 2 obsolete "returns null" tests, adds 4 new behavioural tests (clean memory → false, malformed JSONL → true, ship-truth no-upstream → null, ship-truth in-sync → false, ship-truth behind → true).

## Verification
- `npx vitest run tests/predicate-freshness.test.ts` → 13/13 pass
- `npx tsc --noEmit -p tsconfig.json` → clean

## Acceptance (from #323)
- ✅ `reverifyPredicate('memory-state-truth', ctx)` returns boolean (not null)
- ✅ `reverifyPredicate('ship-truth', ctx)` returns boolean (not null)
- ✅ Smoke test: stale snapshot + currently-resolved condition → returns `false`
- ⏳ Telemetry on stale-skip path — already emitted by the scheduler/banner caller (`scheduler.ts:469-503`, `loop.ts:2327-2345`); both call sites log via existing `stale-signal-skip`/`P0-BANNER` patterns once `reverifyPredicate` returns `false`. No new instrumentation needed in this module.

## Predicate scoreboard after merge
5/5 wired (was 3/5):
- ✅ dirty-runtime-workspace
- ✅ local-commit-not-pushed
- ✅ low-responsiveness
- ✅ memory-state-truth (this PR)
- ✅ ship-truth (this PR)