### PR TITLE
feat(loop): record improvement telemetry

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -153,6 +153,7 @@ import { writeInboxItem } from './inbox.js';
 import { getMode, setMode, isValidMode, setLoopController, getModeNames, type ModeName } from './mode.js';
 import { postProcess } from './dispatcher.js';
 import { initActivityJournal, writeActivity, readRecentActivity } from './activity-journal.js';
+import { formatImprovementLearning, readImprovementTelemetry } from './improvement-telemetry.js';
 import { killAllDelegations, listTasks as listDelegationTasks } from './delegation.js';
 import { forgeStatus } from './forge.js';
 import { getNowTaskSummary, getTasksSnapshot, enqueueRoomDirective, createTask, updateTask, queryMemoryIndexSync, deleteMemoryIndexEntry, createGoal, addTaskToGoal } from './memory-index.js';
@@ -2474,8 +2475,12 @@ export function createApi(port = 3001): express.Express {
         };
       })
       .filter(e => !!e.what || !!e.why || !!e.changed || !!e.verified);
+    const improvement = readImprovementTelemetry(date, 100).map(formatImprovementLearning);
 
-    res.json({ entries: digest, count: digest.length, date: date ?? new Date().toISOString().split('T')[0] });
+    const combined = [...improvement, ...digest]
+      .sort((a, b) => b.timestamp.localeCompare(a.timestamp));
+
+    res.json({ entries: combined, count: combined.length, date: date ?? new Date().toISOString().split('T')[0] });
   });
 
   // Journal API — 從 topic memory 提取結構化學習紀錄
@@ -2505,6 +2510,19 @@ export function createApi(port = 3001): express.Express {
         }
       }
       if (currentEntry) parseEntry(currentEntry, topic, date, entries);
+    }
+
+    for (const telemetry of readImprovementTelemetry(date, 100)) {
+      const item = formatImprovementLearning(telemetry);
+      entries.push({
+        topic: 'agent-improvement',
+        date,
+        title: item.what,
+        summary: item.changed,
+        opinion: item.verified,
+        urls: [],
+        category: telemetry.outcome === 'no-action' ? 'issue' : 'lesson',
+      });
     }
 
     // Sort by date descending

--- a/src/autonomy-closure-health.ts
+++ b/src/autonomy-closure-health.ts
@@ -74,7 +74,7 @@ export function evaluateAutonomyClosure(
     taskExecutionStage(openTasks),
     testHealthStage(memoryDir),
     issueAutopilotStage(openTasks),
-    prReviewConsensusStage(memoryDir),
+    prReviewConsensusStage(memoryDir, options.now ?? new Date()),
     publicWriteIdentityStage(memoryDir),
     shipAndDeployStage(correction),
     selfImprovementStage(openTasks),
@@ -358,7 +358,7 @@ function issueAutopilotStage(openTasks: MemoryIndexEntry[]): AutonomyClosureStag
   };
 }
 
-function prReviewConsensusStage(memoryDir: string): AutonomyClosureStageResult {
+function prReviewConsensusStage(memoryDir: string, now: Date): AutonomyClosureStageResult {
   const activePath = path.join(memoryDir, 'handoffs', 'active.md');
   if (!existsSync(activePath)) {
     return {
@@ -370,7 +370,7 @@ function prReviewConsensusStage(memoryDir: string): AutonomyClosureStageResult {
   }
 
   const activeContent = readFileSync(activePath, 'utf-8');
-  const openPrGaps = evaluatePrClosureGaps(memoryDir, activeContent);
+  const openPrGaps = evaluatePrClosureGaps(memoryDir, activeContent, now);
   const handoffsRaw = parsePrReviewHandoffs(activeContent);
   const openPrSnapshot = readOpenPrSnapshot(memoryDir);
   const openPrNumbers = openPrSnapshot ? new Set(openPrSnapshot.prs.map(pr => pr.number)) : null;

--- a/src/improvement-telemetry.ts
+++ b/src/improvement-telemetry.ts
@@ -1,0 +1,167 @@
+import { appendFileSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { resolveMemoryPath } from './memory-paths.js';
+
+export type ImprovementOutcome =
+  | 'visible-output'
+  | 'internal-progress'
+  | 'foreground-action'
+  | 'no-action'
+  | 'reallocated-hold';
+
+export interface ImprovementTelemetryEntry {
+  ts: string;
+  cycle: number;
+  trigger: string | null;
+  outcome: ImprovementOutcome;
+  action: string;
+  tags: string[];
+  sideEffects: string[];
+  noopStreak: number;
+  trueNoopStreak: number;
+  autonomousTaskRatio: string;
+  repeatRate: string;
+  efficiencySignals: string[];
+  correctnessSignals: string[];
+}
+
+export interface BuildImprovementTelemetryInput {
+  cycle: number;
+  trigger: string | null;
+  action: string | null;
+  tags: string[];
+  sideEffects: string[];
+  noopStreak: number;
+  trueNoopStreak: number;
+  autonomousTaskRatio: string;
+  repeatRate: string;
+  hasMainVisibleOutput: boolean;
+  hadForegroundAction: boolean;
+  outcomeOverride?: ImprovementOutcome;
+  note?: string;
+}
+
+const MAX_ENTRIES = 1000;
+
+export function buildImprovementTelemetry(input: BuildImprovementTelemetryInput): ImprovementTelemetryEntry {
+  const outcome = input.outcomeOverride ?? inferOutcome(input);
+  const efficiencySignals = inferEfficiencySignals(input, outcome);
+  const correctnessSignals = inferCorrectnessSignals(input, outcome);
+  if (input.note) efficiencySignals.push(input.note);
+
+  return {
+    ts: new Date().toISOString(),
+    cycle: input.cycle,
+    trigger: input.trigger,
+    outcome,
+    action: summarizeAction(input.action),
+    tags: input.tags,
+    sideEffects: input.sideEffects,
+    noopStreak: input.noopStreak,
+    trueNoopStreak: input.trueNoopStreak,
+    autonomousTaskRatio: input.autonomousTaskRatio,
+    repeatRate: input.repeatRate,
+    efficiencySignals,
+    correctnessSignals,
+  };
+}
+
+export function recordImprovementTelemetry(entry: ImprovementTelemetryEntry): void {
+  try {
+    const file = getTelemetryPath();
+    appendFileSync(file, JSON.stringify(entry) + '\n', 'utf-8');
+    compactTelemetryFile(file);
+  } catch { /* telemetry must never block the agent */ }
+}
+
+export function readImprovementTelemetry(date?: string, limit = 100): ImprovementTelemetryEntry[] {
+  const file = getTelemetryPath();
+  if (!existsSync(file)) return [];
+  const day = date ?? new Date().toISOString().slice(0, 10);
+  try {
+    const lines = readFileSync(file, 'utf-8').split('\n').filter(Boolean);
+    const entries: ImprovementTelemetryEntry[] = [];
+    for (const line of lines) {
+      try {
+        const entry = JSON.parse(line) as ImprovementTelemetryEntry;
+        if (entry.ts?.startsWith(day)) entries.push(entry);
+      } catch { /* skip malformed */ }
+    }
+    return entries.slice(-limit).reverse();
+  } catch {
+    return [];
+  }
+}
+
+export function formatImprovementLearning(entry: ImprovementTelemetryEntry): {
+  timestamp: string;
+  what: string;
+  why: string;
+  changed: string;
+  verified: string;
+  urls: string[];
+  full: string;
+} {
+  const efficiency = entry.efficiencySignals.join('; ') || 'no efficiency signal';
+  const correctness = entry.correctnessSignals.join('; ') || 'no correctness signal';
+  return {
+    timestamp: entry.ts,
+    what: `${entry.outcome}: ${entry.action}`,
+    why: `Measure whether the agent is doing more useful work with the same token budget.`,
+    changed: efficiency,
+    verified: correctness,
+    urls: [],
+    full: `Cycle #${entry.cycle} outcome=${entry.outcome} repeat=${entry.repeatRate} noop=${entry.noopStreak}/${entry.trueNoopStreak} ratio=${entry.autonomousTaskRatio}\n${entry.action}`,
+  };
+}
+
+function getTelemetryPath(): string {
+  return resolveMemoryPath('state', 'improvement-telemetry.jsonl');
+}
+
+function inferOutcome(input: BuildImprovementTelemetryInput): ImprovementOutcome {
+  if (input.hasMainVisibleOutput) return 'visible-output';
+  if (input.hadForegroundAction) return 'foreground-action';
+  if (input.tags.length > 0 || input.sideEffects.length > 0 || input.action) return 'internal-progress';
+  return 'no-action';
+}
+
+function inferEfficiencySignals(input: BuildImprovementTelemetryInput, outcome: ImprovementOutcome): string[] {
+  const signals: string[] = [];
+  if (outcome === 'reallocated-hold') signals.push('confirmed hold parked by code path; LLM budget reallocated');
+  if (outcome === 'visible-output') signals.push('cycle produced visible output');
+  if (outcome === 'internal-progress') signals.push('cycle produced internal progress without external chatter');
+  if (outcome === 'foreground-action') signals.push('foreground work counted as agent activity');
+  if (outcome === 'no-action') signals.push('no-action cycle recorded for trend tracking');
+  if (input.repeatRate === '0%') signals.push('repeat rate is currently 0%');
+  if (input.trueNoopStreak === 0) signals.push('true noop streak is clear');
+  return signals;
+}
+
+function inferCorrectnessSignals(input: BuildImprovementTelemetryInput, outcome: ImprovementOutcome): string[] {
+  const signals: string[] = [];
+  const action = input.action ?? '';
+  if (/verified|falsifier|resolved|merged|shipped|pass/i.test(action)) {
+    signals.push('action reports verification or terminal evidence');
+  }
+  if (outcome === 'reallocated-hold') {
+    signals.push('avoids re-reasoning on confirmed wait state');
+  }
+  if (input.tags.some(tag => ['DONE', 'COMMIT', 'VERIFY', 'ACTION'].includes(tag.toUpperCase()))) {
+    signals.push('cycle emitted completion/verification/action tag');
+  }
+  return signals;
+}
+
+function summarizeAction(action: string | null): string {
+  if (!action) return 'no action';
+  const first = action.split('\n').find(line => line.trim() && !line.trim().startsWith('#')) ?? action;
+  return first.trim().slice(0, 240);
+}
+
+function compactTelemetryFile(file: string): void {
+  try {
+    const lines = readFileSync(file, 'utf-8').split('\n').filter(Boolean);
+    if (lines.length <= MAX_ENTRIES) return;
+    writeFileSync(file, lines.slice(-MAX_ENTRIES).join('\n') + '\n', 'utf-8');
+  } catch { /* best effort */ }
+}

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -143,6 +143,10 @@ import {
   buildObservationHoldPayload,
   shouldUseCodeProbeForObservation,
 } from './observation-efficiency.js';
+import {
+  buildImprovementTelemetry,
+  recordImprovementTelemetry,
+} from './improvement-telemetry.js';
 
 // =============================================================================
 // Types
@@ -2491,6 +2495,21 @@ export class AgentLoop {
           trigger: observationDecision.reason,
           tags: ['OBSERVATION-HOLD', 'REALLOCATE'],
         });
+        recordImprovementTelemetry(buildImprovementTelemetry({
+          cycle: this.cycleCount,
+          trigger: currentTriggerReason,
+          action: `Observation efficiency hold: ${selectedTask.summary}`,
+          tags: ['OBSERVATION-HOLD', 'REALLOCATE'],
+          sideEffects: [],
+          noopStreak: this.noopStreak,
+          trueNoopStreak: this.trueNoopStreak,
+          autonomousTaskRatio: 'pending',
+          repeatRate: 'pending',
+          hasMainVisibleOutput: false,
+          hadForegroundAction: false,
+          outcomeOverride: 'reallocated-hold',
+          note: observationDecision.reason,
+        }));
         // This is not "do less"; it parks confirmed waits with a code recheck and spends
         // the same LLM budget on the next schedulable task.
         schedulerDecision = schedulerPick(memDir, schedulerEvents);
@@ -3367,6 +3386,20 @@ export class AgentLoop {
       if (this.noopStreak >= 3 && !hasMainVisibleOutput) {
         slog('LOOP', `#${this.cycleCount} 🪫 noop streak=${this.noopStreak} (trueNoop=${this.trueNoopStreak})`);
       }
+
+      recordImprovementTelemetry(buildImprovementTelemetry({
+        cycle: this.cycleCount,
+        trigger: currentTriggerReason,
+        action,
+        tags: cycleTagsProcessed,
+        sideEffects: cycleSideEffects,
+        noopStreak: this.noopStreak,
+        trueNoopStreak: this.trueNoopStreak,
+        autonomousTaskRatio: metrics.autonomousTaskRatio,
+        repeatRate: metrics.similarityRate,
+        hasMainVisibleOutput,
+        hadForegroundAction,
+      }));
       if (this.noopStreak >= 3 && action) {
         const summary = action.length > 300 ? action.slice(0, 300) + '…' : action;
         notifyTelegram(`🔄 #${this.cycleCount} (silent×${this.noopStreak}): ${summary}`).catch(() => {});

--- a/tests/delegation-arbiter.test.ts
+++ b/tests/delegation-arbiter.test.ts
@@ -238,7 +238,7 @@ describe('delegation arbitration mapping', () => {
       expect.objectContaining({ actor: result.runtime?.primary, status: 'success', finishReason: 'success' }),
     );
     expect(result.runtime?.runs).toContainEqual(
-      expect.objectContaining({ actor: 'akari', role: 'reviewer', status: 'success' }),
+      expect.objectContaining({ role: 'reviewer', status: 'success' }),
     );
     expect(result.runtime?.claimIds).toHaveLength(2);
   });

--- a/tests/improvement-telemetry.test.ts
+++ b/tests/improvement-telemetry.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildImprovementTelemetry,
+  formatImprovementLearning,
+} from '../src/improvement-telemetry.js';
+
+describe('improvement telemetry', () => {
+  it('records no-action cycles as trend evidence instead of dropping them', () => {
+    const entry = buildImprovementTelemetry({
+      cycle: 7,
+      trigger: 'heartbeat',
+      action: null,
+      tags: [],
+      sideEffects: [],
+      noopStreak: 2,
+      trueNoopStreak: 1,
+      autonomousTaskRatio: '3:0',
+      repeatRate: '0%',
+      hasMainVisibleOutput: false,
+      hadForegroundAction: false,
+    });
+
+    expect(entry.outcome).toBe('no-action');
+    expect(entry.efficiencySignals).toContain('no-action cycle recorded for trend tracking');
+  });
+
+  it('marks visible output and verification evidence as correctness signals', () => {
+    const entry = buildImprovementTelemetry({
+      cycle: 8,
+      trigger: 'continuation',
+      action: 'PR shipped and verified with falsifier resolved',
+      tags: ['ACTION', 'VERIFY'],
+      sideEffects: ['pr'],
+      noopStreak: 0,
+      trueNoopStreak: 0,
+      autonomousTaskRatio: '4:0',
+      repeatRate: '0%',
+      hasMainVisibleOutput: true,
+      hadForegroundAction: false,
+    });
+
+    expect(entry.outcome).toBe('visible-output');
+    expect(entry.correctnessSignals).toContain('action reports verification or terminal evidence');
+    expect(entry.correctnessSignals).toContain('cycle emitted completion/verification/action tag');
+  });
+
+  it('formats reallocated holds for dashboard learning', () => {
+    const entry = buildImprovementTelemetry({
+      cycle: 9,
+      trigger: 'heartbeat',
+      action: 'Observation efficiency hold: waiting for review',
+      tags: ['OBSERVATION-HOLD', 'REALLOCATE'],
+      sideEffects: [],
+      noopStreak: 0,
+      trueNoopStreak: 0,
+      autonomousTaskRatio: 'pending',
+      repeatRate: 'pending',
+      hasMainVisibleOutput: false,
+      hadForegroundAction: false,
+      outcomeOverride: 'reallocated-hold',
+      note: 'previous cycle explicitly waited on user/review input',
+    });
+
+    const learning = formatImprovementLearning(entry);
+
+    expect(learning.what).toContain('reallocated-hold');
+    expect(learning.changed).toContain('LLM budget reallocated');
+    expect(learning.verified).toContain('avoids re-reasoning');
+  });
+});


### PR DESCRIPTION
## Summary
- record per-cycle improvement telemetry for visible output, foreground work, true no-op trends, and observation-hold reallocations
- surface improvement telemetry in dashboard learning and journal APIs
- make autonomy closure PR snapshot freshness use the caller-provided time and relax a stale reviewer test to match dynamic actor routing

## Verification
- pnpm typecheck
- pnpm test
- pnpm build