### PR TITLE
fix(github): close superseded forge PRs

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -40,6 +40,7 @@ import {
 import {
   appendStaleDraftPrHandoffs,
   extractClosingIssueRefs,
+  extractSupersededIssueRefs,
   findUntrackedPrs,
   shouldAutoCloseSupersededPr,
   writeOpenPrSnapshot,
@@ -475,7 +476,9 @@ async function autoCloseSupersededPRs(): Promise<void> {
   let closedCount = 0;
   for (const pr of prs) {
     const normalized = toOpenPrSummary(pr);
-    const refs = extractClosingIssueRefs(`${pr.title}\n${pr.body ?? ''}`);
+    const text = `${pr.title}\n${pr.body ?? ''}`;
+    const closingRefs = extractClosingIssueRefs(text);
+    const refs = closingRefs.length > 0 ? closingRefs : extractSupersededIssueRefs(text);
     if (refs.length === 0) continue;
 
     const issues: IssueStateSummary[] = [];
@@ -490,7 +493,9 @@ async function autoCloseSupersededPRs(): Promise<void> {
       }
     }
     if (issueLookupFailed) continue;
-    if (!shouldAutoCloseSupersededPr(normalized, refs, issues)) continue;
+    if (!shouldAutoCloseSupersededPr(normalized, refs, issues, {
+      requireBlockedMergeable: closingRefs.length === 0,
+    })) continue;
 
     const reason = `This PR declares ${refs.map(ref => `#${ref}`).join(', ')} as closing scope, and that issue is already closed. Closing to keep the autonomous PR queue truthful; reopen or create a fresh PR if this still has unique scope.`;
     try {

--- a/src/pr-autopilot.ts
+++ b/src/pr-autopilot.ts
@@ -34,6 +34,7 @@ export interface IssueStateSummary {
 }
 
 const CLOSING_REF_RE = /(?:^|[\s(])(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)\b/gi;
+const FORGE_ISSUE_REF_RE = /\b(?:github\s+)?issue\s+#?(\d+)\b/gi;
 
 export function getOpenPrSnapshotPath(memoryDir: string): string {
   return path.join(memoryDir, 'state', OPEN_PRS_SNAPSHOT_FILE);
@@ -172,15 +173,24 @@ export function extractClosingIssueRefs(text: string): number[] {
   return [...refs].sort((a, b) => a - b);
 }
 
+export function extractSupersededIssueRefs(text: string): number[] {
+  const refs = new Set(extractClosingIssueRefs(text));
+  let match: RegExpExecArray | null;
+  while ((match = FORGE_ISSUE_REF_RE.exec(text)) !== null) refs.add(Number(match[1]));
+  return [...refs].sort((a, b) => a - b);
+}
+
 export function shouldAutoCloseSupersededPr(
-  pr: Pick<OpenPrSnapshotEntry, 'createdAt' | 'isDraft' | 'labels'>,
+  pr: Pick<OpenPrSnapshotEntry, 'createdAt' | 'isDraft' | 'labels' | 'mergeable'>,
   closingRefs: number[],
   issues: IssueStateSummary[],
+  options: { requireBlockedMergeable?: boolean } = {},
 ): boolean {
   if (pr.isDraft) return false;
   const labels = new Set((pr.labels ?? []).map(label => label.toLowerCase()));
   if (labels.has('hold')) return false;
   if (closingRefs.length === 0 || issues.length !== closingRefs.length) return false;
+  if (options.requireBlockedMergeable && !isBlockedMergeable(pr.mergeable)) return false;
 
   const prCreatedAt = Date.parse(pr.createdAt ?? '');
   if (!Number.isFinite(prCreatedAt)) return false;

--- a/tests/pr-autopilot.test.ts
+++ b/tests/pr-autopilot.test.ts
@@ -6,6 +6,7 @@ import {
   appendStaleDraftPrHandoffs,
   evaluatePrClosureGaps,
   extractClosingIssueRefs,
+  extractSupersededIssueRefs,
   findApprovedBlockedPrs,
   findUntrackedPrs,
   parseTrackedPrNumbers,
@@ -97,6 +98,10 @@ describe('PR autopilot closure', () => {
     expect(extractClosingIssueRefs('Refs #196\nCloses #200\nfixes #201\nrelated #202')).toEqual([200, 201]);
   });
 
+  it('extracts forge task issue refs for conflict superseded closure', () => {
+    expect(extractSupersededIssueRefs('[forge] ## Task: P2 GitHub issue #323: predicate-freshness')).toEqual([323]);
+  });
+
   it('auto-closes only low-risk superseded PRs', () => {
     expect(shouldAutoCloseSupersededPr(
       pr({ number: 217, title: 'feat: old fix', createdAt: '2026-05-07T02:24:00.000Z' }),
@@ -108,6 +113,22 @@ describe('PR autopilot closure', () => {
       pr({ number: 218, title: 'feat: active fix', createdAt: '2026-05-07T02:24:00.000Z' }),
       [200],
       [{ number: 200, state: 'OPEN', closedAt: null }],
+    )).toBe(false);
+  });
+
+  it('requires a blocked mergeable state for inferred issue refs', () => {
+    const issue = { number: 323, state: 'CLOSED', closedAt: '2026-05-08T00:41:36.000Z' };
+    expect(shouldAutoCloseSupersededPr(
+      pr({ number: 328, title: '[forge] issue #323', createdAt: '2026-05-08T00:39:30.000Z', mergeable: 'CONFLICTING' }),
+      [323],
+      [issue],
+      { requireBlockedMergeable: true },
+    )).toBe(true);
+    expect(shouldAutoCloseSupersededPr(
+      pr({ number: 329, title: '[forge] issue #323', createdAt: '2026-05-08T00:39:30.000Z', mergeable: 'MERGEABLE' }),
+      [323],
+      [issue],
+      { requireBlockedMergeable: true },
     )).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- detect forge PR titles that reference GitHub issue #N as supersedable issue refs
- auto-close only when the referenced issue is closed and the inferred-ref PR is already conflicting
- add regression coverage for PR #328 / issue #323 shape

## Verification
- pnpm vitest run tests/pr-autopilot.test.ts
- pnpm typecheck
- pnpm build

Note: final verification was run in the runtime checkout before moving the patch into this isolated worktree; this worktree has no node_modules, so its local typecheck reports missing dependency types.