### PR TITLE
fix(agent): lower PROMPT_HARD_CAP 45K→40K for silent_exit_void_40k (#304 phase 2)

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -1852,10 +1852,15 @@ export async function callClaude(
   }
 
   // Pre-check: if prompt is too large, proactively reduce context before first attempt
-  // Lowered from 80K → 60K → 45K: data shows prompts >50K → 100% EXIT143.
+  // Lowered from 80K → 60K → 45K → 40K. Prior data: >50K → 100% EXIT143 crash.
+  // Issue #304 (silent_exit_void_40k): n=11 silent timeouts on instance 03bbc29a
+  // clustered at promptChars 41,411–43,379 (median ~42K), bimodal duration
+  // 180–540s — 100% loop lane / 100% callClaude / content-agnostic, size-driven.
+  // Cap lowered to 40K so the existing focused→compact→minimal cascade fires
+  // *before* the silent-timeout band, matching #304's proactive pre-flight ask.
   // Profile-based contextBudget (omlx-gate.ts) is the primary control;
   // this cap is the hard safety net ensuring CLI stability.
-  const PROMPT_HARD_CAP = 45_000;
+  const PROMPT_HARD_CAP = 40_000;
   const PROMPT_TARGET = 30_000; // Target for minimal mode — ensure Claude can process within timeout
   // Calculate actual context budget from known non-context sizes
   const nonContextSize = systemPrompt.length + prompt.length + 20; // 20 for separators

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -298,7 +298,7 @@ export function getSkillsPrompt(hint?: string, cycleMode?: CycleMode): string {
 
   // Hard cap on total skills section. Skills are part of every prompt's non-context budget
   // (system prompt + skills + user prompt). When skills blow past this, the math
-  // breaks: PROMPT_HARD_CAP (45K) − non-context > 0 is required for any context at all.
+  // breaks: PROMPT_HARD_CAP (40K, #304) − non-context > 0 is required for any context at all.
   // Incident 2026-04-17 19:04: non-context=46333 chars → actualContextBudget=-1333 →
   // every cycle stalled because even context=0 couldn't fit under the hard cap.
   const SKILLS_SECTION_CAP = 12_000;
@@ -3848,7 +3848,7 @@ export class InstanceMemory {
     // cf8049e7 fix: enforce caller-supplied budget. Root cause of TIMEOUT:silent_exit
     // retry-inflation was that buildMinimalContext ignored contextBudget — 5 unbounded
     // sections (soul-minimal / inbox / bg-completed / next / working-memory) could
-    // regenerate a ~86k prompt on retry and silently bypass PROMPT_HARD_CAP=45k upstream.
+    // regenerate a ~86k prompt on retry and silently bypass PROMPT_HARD_CAP=40k upstream.
     // Hard-cap last resort: if still over budget, truncate with a tail marker so the
     // retry prompt is guaranteed to be strictly smaller than the attempt that just failed.
     if (typeof budget === 'number' && budget > 0 && joined.length > budget) {


### PR DESCRIPTION
Closes #304 (phase 2). Phase 1 (preflight observability at 35K) was already shipped; this is the proactive-action half.

## Root cause

`agent.ts:1839` already runs the proactive cascade `rebuildContext('focused') → compactContext → rebuildContext('minimal')` when `fullPrompt > PROMPT_HARD_CAP`. But `PROMPT_HARD_CAP` was set at **45K**, while the failing cluster sits at **41,411–43,379 chars** — so the silent-timeout band slipped through unprotected.

## Evidence (from issue #304 + classifier #233)

| Dimension | n=11 silent_exit_void_40k events |
|---|---|
| Lane | 100% loop |
| Context | 100% callClaude |
| Instance | 100% 03bbc29a |
| promptChars | tight 41,411–43,379 (median ~42K) |
| Duration | bimodal: 10× 180–200s, 1× 538s |

100% lane + tight size cluster ⇒ content-agnostic, size-driven. EXIT143 (the prior >50K crash) is a different failure mode.

## Change

- `src/agent.ts`: `PROMPT_HARD_CAP` 45_000 → 40_000 + comment with #304 evidence trail.
- `src/memory.ts`: two doc comments updated (`(45K)`/`=45k` → `(40K, #304)`/`=40k`) for consistency.

The mechanism is unchanged — only the trigger threshold moves down, so 40–45K prompts now run focused→compact→minimal *before* dispatching to the CLI, instead of waiting for the silent timeout.

## Verification

- `pnpm typecheck` — clean
- `npx vitest run tests/agent.test.ts tests/memory.test.ts tests/delegation-phantom-prompt.test.ts` — 55 passed

## Falsifier (24h post-deploy)

`mini-agent-memory/memory/state/error-patterns.json` key `TIMEOUT:silent_exit_void_40k::callClaude.count` MUST NOT increment ≥ pre-fix baseline (~5/day on instance 03bbc29a). If it climbs, hypothesis refuted; reopen with new evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)