### PR TITLE
fix(agent): circuit-breaker for transient_fast_band, not exp-backoff (#333)

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -12,7 +12,7 @@ import { getMemory } from './memory.js';
 import { getCurrentInstanceId, getInstanceDir } from './instance.js';
 import { getLogger } from './logging.js';
 import { slog, diagLog } from './utils.js';
-import { extractErrorSubtype } from './feedback-loops.js';
+import { extractErrorSubtype, shouldFastFailFastBand } from './feedback-loops.js';
 import { getSystemPrompt } from './dispatcher.js';
 import type { CycleMode } from './memory.js';
 import { eventBus, debounce } from './event-bus.js';
@@ -2021,8 +2021,24 @@ export async function callClaude(
 
       lastErrorMessage = `${classified.message}\n[Model Guidance: ${classified.modelGuidance}]`;
 
+      // Issue #333: circuit-breaker for transient_fast_band — fail-fast instead of
+      // sleeping 90s × 2^attempt on errors that came back in <10s. The "wait it out"
+      // assumption only fits slow-band; fast-band repeats are deterministic and the
+      // sleep is wasted budget. Caller decides next step (switch model / delegate).
+      const fastFailFastBand = shouldFastFailFastBand({
+        attempt,
+        attemptDurationMs: attemptDuration,
+        errorMsg: stderr || classified.message || '',
+      });
+      if (fastFailFastBand) {
+        slog(
+          'RETRY',
+          `circuit-breaker (#333): transient_fast_band on attempt ${attempt + 1}, dur=${attemptDuration}ms — failing fast, skipping exp-backoff sleep`,
+        );
+      }
+
       // 如果可重試且還有機會，等待後重試
-      if (classified.retryable && attempt < maxRetries) {
+      if (classified.retryable && attempt < maxRetries && !fastFailFastBand) {
         // OOM-likely errors (exit 143 = SIGTERM) need longer backoff to let system reclaim memory
         const isOomLikely = exitCode === 143 || (exitCode === null && classified.type === 'TIMEOUT');
         // 2026-05-06 (Issue #166): transient_no_diag/midband_no_diag dominated retries

--- a/src/feedback-loops.ts
+++ b/src/feedback-loops.ts
@@ -249,6 +249,33 @@ export function extractErrorCode(errorMsg: string): string {
 }
 
 /**
+ * Issue #333: Circuit-breaker gate for transient_fast_band errors.
+ *
+ * Fast-band = API errored back in <10s. Sleeping 90s and retrying gives upstream
+ * nothing to recover from (these are likely deterministic provider-side rejections —
+ * auth/rate-limit/payload — not transient capacity gaps). Exponential backoff (#166)
+ * targets slow-band only; fast-band needs fail-fast so caller can switch model /
+ * route to delegation / report blocker.
+ *
+ * Returns true ONLY for the first attempt — once we're past attempt 0 we've already
+ * paid the retry cost and want the existing path to run to completion.
+ *
+ * Threshold tunable via env: KURO_FAST_FAIL_THRESHOLD_MS (default 10_000).
+ */
+export function shouldFastFailFastBand(args: {
+  attempt: number;
+  attemptDurationMs: number;
+  errorMsg: string;
+  thresholdMs?: number;
+}): boolean {
+  const threshold =
+    args.thresholdMs ?? (Number(process.env.KURO_FAST_FAIL_THRESHOLD_MS) || 10_000);
+  if (args.attempt !== 0) return false;
+  if (args.attemptDurationMs >= threshold) return false;
+  return extractErrorSubtype(args.errorMsg) === 'transient_fast_band';
+}
+
+/**
  * 掃描今天的 error log，按 (code + subtype + context) 分群。
  * 同模式 >= 3 次 → 寫入 HEARTBEAT.md 作為 P1 task。
  * 已建過的模式不重複建。

--- a/tests/should-fast-fail-fast-band.test.ts
+++ b/tests/should-fast-fail-fast-band.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { shouldFastFailFastBand } from '../src/feedback-loops.js';
+
+// Issue #333: circuit-breaker gate for transient_fast_band errors.
+// Fast-band = API errored back in <10s; sleeping 90s+ between retries is wasted
+// budget because the upstream rejection is deterministic. Gate fails fast on
+// attempt 0 only, so existing exp-backoff still applies to slow-band/no_diag.
+describe('shouldFastFailFastBand — circuit-breaker gate (#333)', () => {
+  // Mirrors the message shape extractErrorSubtype keys off (處理訊息時發生錯誤 + dur=Xs).
+  const mkMsg = (durSec: number) =>
+    `[${durSec}s] 處理訊息時發生錯誤 attempt 1/3, prompt 26866 chars, dur=${durSec}s`;
+
+  const origEnv = process.env.KURO_FAST_FAIL_THRESHOLD_MS;
+  beforeEach(() => {
+    delete process.env.KURO_FAST_FAIL_THRESHOLD_MS;
+  });
+  afterEach(() => {
+    if (origEnv !== undefined) process.env.KURO_FAST_FAIL_THRESHOLD_MS = origEnv;
+    else delete process.env.KURO_FAST_FAIL_THRESHOLD_MS;
+  });
+
+  it('trips on first attempt fast-band error', () => {
+    expect(
+      shouldFastFailFastBand({
+        attempt: 0,
+        attemptDurationMs: 8_000,
+        errorMsg: mkMsg(8),
+      }),
+    ).toBe(true);
+  });
+
+  it('does NOT trip on retry attempts even if fast-band', () => {
+    // Once we're past attempt 0 the retry budget is already committed; let the
+    // existing path run so the sample frame shows up in error-patterns.
+    expect(
+      shouldFastFailFastBand({
+        attempt: 1,
+        attemptDurationMs: 8_000,
+        errorMsg: mkMsg(8),
+      }),
+    ).toBe(false);
+  });
+
+  it('does NOT trip when attempt duration crosses the 10s threshold', () => {
+    expect(
+      shouldFastFailFastBand({
+        attempt: 0,
+        attemptDurationMs: 12_000,
+        errorMsg: mkMsg(12),
+      }),
+    ).toBe(false);
+  });
+
+  it('does NOT trip on slow-band subtype', () => {
+    expect(
+      shouldFastFailFastBand({
+        attempt: 0,
+        attemptDurationMs: 8_000,
+        errorMsg: mkMsg(15), // slow-band by classifier
+      }),
+    ).toBe(false);
+  });
+
+  it('does NOT trip on unrelated subtypes (dns / sigterm)', () => {
+    expect(
+      shouldFastFailFastBand({
+        attempt: 0,
+        attemptDurationMs: 5_000,
+        errorMsg: 'getaddrinfo ENOTFOUND api.anthropic.com',
+      }),
+    ).toBe(false);
+    expect(
+      shouldFastFailFastBand({
+        attempt: 0,
+        attemptDurationMs: 5_000,
+        errorMsg: 'exit 143 sigterm reason=preempt',
+      }),
+    ).toBe(false);
+  });
+
+  it('respects KURO_FAST_FAIL_THRESHOLD_MS env override', () => {
+    process.env.KURO_FAST_FAIL_THRESHOLD_MS = '5000';
+    // 8s would trip default 10s threshold but is above 5s override.
+    expect(
+      shouldFastFailFastBand({
+        attempt: 0,
+        attemptDurationMs: 8_000,
+        errorMsg: mkMsg(8),
+      }),
+    ).toBe(false);
+    // 4s below override threshold trips.
+    expect(
+      shouldFastFailFastBand({
+        attempt: 0,
+        attemptDurationMs: 4_000,
+        errorMsg: mkMsg(4),
+      }),
+    ).toBe(true);
+  });
+
+  it('explicit thresholdMs argument wins over env', () => {
+    process.env.KURO_FAST_FAIL_THRESHOLD_MS = '5000';
+    expect(
+      shouldFastFailFastBand({
+        attempt: 0,
+        attemptDurationMs: 6_000,
+        errorMsg: mkMsg(6),
+        thresholdMs: 8_000,
+      }),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `shouldFastFailFastBand()` gate in `feedback-loops.ts` — trips on attempt 0 only when dur < `KURO_FAST_FAIL_THRESHOLD_MS` (default 10_000) AND subtype is `transient_fast_band`.
- Wire into `callClaude()` retry loop in `agent.ts` — when gate trips, skip the 90s × 2^attempt exp-backoff sleep (#166) and fall through to the "last attempt failed" branch. Caller (loop / cron / foreground) then decides next step.
- 7 unit tests covering attempt-0 only / threshold boundary / slow-band negative / unrelated subtypes / env override / explicit threshold-arg wins.

## Why exp-backoff (#166) doesn't fix this

Fast-band = API errors back in <10s, then we sleep 90s, retry, error again in <10s. Sample from live error-patterns: `8096ms this attempt, 148356ms total, attempt 2/3` — `totalTime - 2*attemptTime ≈ 132s` of pure sleep before the 2nd fast-fail. The "wait it out" assumption fits slow-band (10-59s, the original 1-19s pattern #166 targeted), not fast-band repeats which look deterministic (auth/rate-limit/payload).

## Verification

- [x] `tests/should-fast-fail-fast-band.test.ts` — 7 new
- [x] `tests/extract-error-subtype.test.ts` — 5 existing still green
- [x] `tsc --noEmit` clean
- [ ] Post-deploy falsifier (next 7 days): `count(transient_fast_band)` growth slope flatter than 7-day pre-deploy slope. If flat → gate didn't help, different root cause.

Closes #333.

🤖 Generated with [Claude Code](https://claude.com/claude-code)