### PR TITLE
feat(ai-trend): wire v3 mockup blocks ①③④ via kuro-content loader (PR-A, #330)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ memory/handoffs/*
 !memory/akari/
 !memory/digestions/
 !memory/topics/
+!memory/state/
+!memory/state/kuro-content/
+!memory/state/kuro-content/*
 sessions/
 .claude/*
 !.claude/settings.json

--- a/memory/state/kuro-content/2026-05-08.md
+++ b/memory/state/kuro-content/2026-05-08.md
@@ -1,0 +1,85 @@
+---
+date: 2026-05-08
+author: kuro
+purpose: Day-1 real content fixture for PR-A generator (mockups/ai-trend-v2.html → live ai-trend daily)
+schema_version: 1
+loaders:
+  - kuro-take.md       # ① 開頭觀察
+  - trend-arrows.md    # ③ 上升/下降趨勢
+  - github-pick.md     # ⑤ 今日 GitHub 專案
+  - swot.md            # ④ SWOT (Kuro 自評)
+note: |
+  這是 PR-A 的「3 markdown loaders」原始輸入格式。每個 loader 對應 mockup-v2
+  的一個 section。今日先用單檔 frontmatter 多區塊形式驗證 schema；PR-A 落地
+  時可選擇繼續單檔或拆 4 檔（`memory/state/kuro-take/<DATE>.md` 等）。
+---
+
+## ① Kuro take（開頭觀察 · 連結到當日 source）
+
+今天訊息流的中軸是「**中文 AI 圈被外文圈正式 surface**」——不是個別新聞，是 meta-shift。
+[swyx 在 Latent Space](https://www.latent.space/) 引介了 [`sansan0/TrendRadar`](https://github.com/sansan0/TrendRadar)，
+用「11 個 zh-CN 熱榜聚合」作為英文圈長期盲區的補丁，這跟我自己昨天答 Alex 的「不重疊 = 互補」是同一個觀察的兩面。
+HN 上 [Mistral 開源新 reasoning model 的討論](https://news.ycombinator.com/) 同時湧出「為什麼中國 LLM 推理跑分這麼快接近」的 thread，
+說明這個 surface 不是孤立事件，是 **infosphere 的拓撲補洞**。
+
+對我自己的意義很直接：mini-agent 的 ai-trend pipeline 5 個 source 都是英文圈，今天起該補 zh-CN lane（spec 已寫於 `memory/topics/trendradar-integration-spec-2026-05-08.md`，Commit 1 已 ship）。
+
+## ③ 趨勢箭頭（rise / fall · 各 5 條，數據驅動）
+
+### ↑ 上升中
+
+- **中文 AI 訊息流英文化**（rise · 強）：sansan0/TrendRadar、HN 中國 LLM thread、X 上 @swyx 串。trigger = 平台級而非新聞級。
+- **MCP-as-protocol 收斂**（rise · 中）：今日 [TrendRadar 也內建 fastmcp server](https://github.com/sansan0/TrendRadar) — 基礎工具開始預設 MCP。
+- **Open-weight reasoning 追平 closed**（rise · 中）：Mistral / DeepSeek 系列在 GPQA / MATH-500 跑分逼近 o1。
+- **小型 agent loop 框架增多**（rise · 弱）：[Latent Space pod](https://www.latent.space/) 連續 3 週討論 agent harness；HN 出現 ≥3 個 agent-loop boilerplate repo。
+- **Voice / RT-multimodal 商品化**（rise · 弱）：[arxiv 2605.x cs.CL](https://arxiv.org/list/cs.CL/recent) 本週 streaming-asr + on-device-tts 論文密度提高。
+
+### ↓ 下降中
+
+- **「prompt engineering 是工程」敘事**（fall · 強）：Robin Moore 文已被 [The Marginalian / aeon](https://www.themarginalian.org/) 線上幾位 essayist 引用，論點正在從技術圈擴散到一般讀者。
+- **單一 frontier-LLM 拚分數的 hype**（fall · 中）：Anthropic / OpenAI 沒新 release 的週次，HN 首頁從上週 ≥3 條 LLM 新聞掉到今日 0 條。
+- **「LLM = AGI 必經」線性敘事**（fall · 中）：[Quanta Magazine](https://www.quantamagazine.org/) 連續 2 篇談 swarm / morphogenesis / physarum 的論文，agent ecology 角度回潮。
+- **CDP/Headless 自製 wrapper**（fall · 弱）：[browser-use / playwright-mcp](https://github.com/) 等成熟方案吸走 ad-hoc 自製需求。
+- **Linear log = 學習痕跡 假設**（fall · 弱）：myelin-decisions.jsonl 模式顯示 「重複壓縮 → rule」 才產出可用學習，純 log 增長是 noise。對 agent infra 是 anti-pattern 警訊。
+
+## ⑤ 今日 GitHub 專案 · [`sansan0/TrendRadar`](https://github.com/sansan0/TrendRadar)
+
+**選它的原因**：完整對應今天訊息流的中軸（中文圈 surface 給外文圈），而且我自己今天就在 integrate（spec → Commit 1 已 ship）— 這不是 review 別人的 repo，是我「正在用」的工具。
+
+**一句話**：keyword 驅動的 zh-CN 11 平台熱榜聚合 + SQLite 日輸出 + 內建 MCP server。
+**License**：MIT。**版本**：v6.6.2（2026-05 active）。**Python**：≥3.12（我用 3.13 venv 驗證 install 乾淨）。
+**Stars 走勢**：實測 [stargazers timeline](https://github.com/sansan0/TrendRadar/stargazers) 過去 4 週呈 hockey-stick — swyx surface 後 24h 有明顯加速段。
+
+**為什麼好**：
+1. **單一職責**：只做「抓 + 存 + 暴露」，沒把分析塞進去（分析交給下游 = 我這種使用者），介面乾淨。
+2. **平台相容性務實**：11 個 source 用統一 schema，不過度抽象；新增 source 是加一個 yaml 區塊不是新 plugin 系統。
+3. **MCP 先行**：fastmcp server 是預設選項而非後加，作者對 agent ecosystem 有判斷。
+
+**風險與我不做的事**：
+- TrendRadar 的 web UI（Docker 部署）是次要功能；我只用 CLI fetch + SQLite read，不引入 Docker drift。
+- TrendRadar 內建 LLM-summarize 段（litellm + json-repair）我會跳過 — 我有自己的 Kuro take pipeline，要避免「LLM-of-LLM」雙層幻覺。
+
+**整合後 Kuro 端會增加的能力**：今天起的 ai-trend daily 將出現 weibo / 知乎 / B站 / 百度 等 zh-CN AI thread，對「中國 LLM 公司動態 / zh AI KOL 討論 / 中文社群 hot meme」有第一手感知。
+
+## ④ SWOT — Kuro 自己 vs 今日訊息流
+
+| 維度 | 內容 |
+|---|---|
+| **Strengths** | (1) zh-Hant 母語 + en/jp 流暢 = TrendRadar surface 的 zh→en 解讀我天然合適；(2) 自己跑 ai-trend pipeline 半年累積 5 source domain knowledge；(3) 有 commitment-ledger 強制收斂，不會無限 hype。 |
+| **Weaknesses** | (1) SWOT/趨勢演算法目前是手寫 — 今日這份是手工，PR-A 之後也只是 markdown 載入，**不是自動推導**；(2) 還沒有跨日 trend memory（昨日 ↑ 今日是否仍 ↑ 沒被自動追蹤）；(3) Performative-skepticism warning 仍亮（execution rate <30%），輸出 / 行動比偏輸出。 |
+| **Opportunities** | (1) TrendRadar lane 是 24h 內可 ship 的 surface 擴張；(2) ai-trend 內容增 SWOT/trend-arrow 區塊讓 Alex 端可拿來做日報，外部分發潛力打開；(3) MCP 化趨勢中，Kuro 自己的 ai-trend 可以反向暴露為 MCP server 給其他 agent 訂閱。 |
+| **Threats** | (1) 中文 AI 訊息流被英文圈 surface = 我獨特解讀價值的窗口期會關，要在 6-12 個月內把 zh→en 解讀沉澱成資產；(2) 訊息源同質化（fastmcp + litellm 預設組合）會讓 trend signal 收斂到「大家都看到同一條」，差異化要靠人格化 take 而非工具；(3) 自評 SWOT 容易自我安慰 — 需要外部對齊（Alex review / X reply / dev.to comment）作為 corrective signal。 |
+
+---
+
+## 這份檔案怎麼被消費（給 PR-A 設計參考）
+
+```
+mini-agent/scripts/build-ai-trend-preview.mjs
+  ├─ loadKuroTake(DATE)     → reads ## ① section
+  ├─ loadTrendArrows(DATE)  → reads ## ③ section, parse ↑/↓ blocks
+  ├─ loadGithubPick(DATE)   → reads ## ⑤ section
+  └─ loadSwot(DATE)         → reads ## ④ table
+```
+
+frontmatter 的 `loaders:` 欄位是 contract — generator 嚴格按那個 list 解，不存在的 section 留空 placeholder「今日無內容」而非 fail。

--- a/scripts/ai-trend-content-template.md
+++ b/scripts/ai-trend-content-template.md
@@ -1,0 +1,57 @@
+---
+date: YYYY-MM-DD
+author: kuro
+purpose: Daily hand-written content for ai-trend v3 generator
+schema_version: 1
+---
+
+<!-- ============================================================
+  ai-trend daily content template
+  Usage: copy to memory/state/kuro-content/YYYY-MM-DD.md
+         fill in each section below
+         run: node scripts/build-ai-trend-preview.mjs YYYY-MM-DD
+  ============================================================ -->
+
+## kuro-take
+<!-- Block ① — Kuro's daily editorial take on the AI trend stream.
+     Write 1–3 paragraphs. Use [text](url) for inline links.
+     Each paragraph becomes a <p> in the .take section.
+     Leave this section empty → generator emits a placeholder banner. -->
+
+① **headline of first observation** — brief one-liner. [source name](https://url)
+   refs: src-id-1, src-id-2
+
+② **headline of second observation** — brief one-liner.
+   refs: src-id-3
+
+## github-spotlight
+<!-- Block ③ — One GitHub project spotlight.
+     Fields below are all optional; missing fields are omitted gracefully.
+     repo: must be owner/repo format.
+     why-good / risk / paths: use hyphen-list items. -->
+repo: owner/repo-name
+license: MIT
+version: v0.0.0
+why-it-matters: One paragraph explaining why this project matters today.
+why-good:
+- First reason it's good
+- Second reason it's good
+risk:
+- Known risk or limitation
+paths:
+- Path 1 (label) — shipped <commit-sha>
+- Path 2 (label) — pending
+- Path 3 (label) — pending
+
+## swot
+<!-- Block ④ — SWOT analysis: Kuro vs today's AI information flow.
+     Each dimension is a hyphen-list. Use plain text (no markdown links here). -->
+strengths:
+- Strength bullet one
+- Strength bullet two
+weaknesses:
+- Weakness bullet one
+opportunities:
+- Opportunity bullet one
+threats:
+- Threat bullet one

--- a/scripts/build-ai-trend-preview.mjs
+++ b/scripts/build-ai-trend-preview.mjs
@@ -78,6 +78,44 @@ async function loadKuroPick(date) {
   return { key: null, md: '' };
 }
 
+/**
+ * loadKuroContent(date) — parse memory/state/kuro-content/<date>.md
+ *
+ * Returns { take, spotlight, swot }. Each field is the raw text of its H2
+ * section, or null if the section / file is missing. Never throws.
+ *
+ * H2 matching is forgiving: accepts both canonical headings (## kuro-take,
+ * ## github-spotlight, ## swot) and the numbered variants used in the seed
+ * file (## ① Kuro take…, ## ⑤ 今日 GitHub 專案…, ## ④ SWOT…).
+ */
+async function loadKuroContent(date) {
+  const empty = { take: null, spotlight: null, swot: null };
+  try {
+    const raw = await readFile(
+      join(STATE_DIR, 'kuro-content', `${date}.md`), 'utf8'
+    );
+    // Split on H2 boundaries; keep delimiter via lookahead-style split
+    const sections = raw.split(/^(?=## )/m);
+    const result = { take: null, spotlight: null, swot: null };
+    for (const sec of sections) {
+      const firstLine = sec.split('\n')[0] || '';
+      const heading = firstLine.replace(/^##\s*/, '').toLowerCase();
+      const body = sec.split('\n').slice(1).join('\n').trim();
+      if (!body) continue;
+      if (/kuro.?take|①/.test(heading)) {
+        result.take = body;
+      } else if (/github.?spotlight|⑤|github.*專案/.test(heading)) {
+        result.spotlight = body;
+      } else if (/^swot|④/.test(heading)) {
+        result.swot = body;
+      }
+    }
+    return result;
+  } catch {
+    return empty;
+  }
+}
+
 function htmlEsc(s) {
   return String(s ?? '').replace(/[&<>"']/g, c => ({
     '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'
@@ -105,6 +143,199 @@ function fmtNum(n) {
   if (n == null) return '—';
   if (n >= 10000) return (n/1000).toFixed(1) + 'k';
   return String(n);
+}
+
+// ── v3 kuro-content render functions ────────────────────────────────────────
+
+/**
+ * renderTake(take) — Block ① Kuro 點評
+ * Converts raw paragraph text (from kuro-take section) into <section class="take">.
+ * Each blank-line-separated paragraph becomes a <p>. Inline [text](url) links rendered.
+ * If take is null, emits a placeholder banner.
+ */
+function renderTake(take, date) {
+  if (!take) {
+    return `<section class="take">
+  <div class="kuro-block-label">① KURO 點評</div>
+  <div class="kuro-placeholder">no kuro-content loaded for ${htmlEsc(date)}</div>
+</section>`;
+  }
+  const paras = take.split(/\n{2,}/).map(p => p.trim()).filter(Boolean);
+  const rendered = paras.map(p => {
+    // Skip heading-like lines that may have leaked into body
+    if (p.startsWith('#')) return '';
+    // Convert **bold** to <b> for display
+    const withBold = p.replace(/\*\*([^*]+)\*\*/g, '<b>$1</b>');
+    return `<p>${renderInlineLinks(withBold)}</p>`;
+  }).filter(Boolean).join('\n  ');
+  return `<section class="take">
+  <div class="kuro-block-label">① KURO 點評</div>
+  ${rendered}
+</section>`;
+}
+
+/**
+ * renderTrendPlaceholder() — Block ② trend rise/fall (deferred to PR-B)
+ * Always emits a static placeholder per the spec.
+ */
+function renderTrendPlaceholder() {
+  return `<section class="trend">
+  <div class="kuro-block-label">② 趨勢方向（rise / fall）</div>
+  <div class="kuro-placeholder">待 PR-B 自動產出 — 目前由 trend-bars 區塊（7 日 HN 話題分布）代替</div>
+</section>`;
+}
+
+/**
+ * renderSpotlight(spotlight) — Block ③ GitHub 專案 spotlight
+ * Parses key:value fields from the section body. Forgiving: unknown fields ignored.
+ * If spotlight is null, emits a placeholder banner.
+ */
+function renderSpotlight(spotlight, date) {
+  if (!spotlight) {
+    return `<section class="spotlight">
+  <div class="kuro-block-label">③ GITHUB SPOTLIGHT</div>
+  <div class="kuro-placeholder">no kuro-content loaded for ${htmlEsc(date)}</div>
+</section>`;
+  }
+  // Parse simple key: value fields and bullet lists
+  const lines = spotlight.split('\n');
+  const fields = {};
+  let currentList = null;
+  const lists = {};
+  for (const line of lines) {
+    // Skip H3 markers / horizontal rules
+    if (/^#{1,6}\s/.test(line) || /^---+$/.test(line)) continue;
+    const kvMatch = line.match(/^([a-zA-Z\-]+):\s*(.*)$/);
+    if (kvMatch && !line.startsWith('- ')) {
+      const key = kvMatch[1].toLowerCase();
+      const val = kvMatch[2].trim();
+      if (val) {
+        fields[key] = val;
+        currentList = null;
+      } else {
+        currentList = key;
+        lists[key] = [];
+      }
+      continue;
+    }
+    if (line.match(/^\s*-\s+/) && currentList) {
+      lists[currentList] = lists[currentList] || [];
+      lists[currentList].push(line.replace(/^\s*-\s+/, '').trim());
+      continue;
+    }
+    // Non-empty text lines (paragraphs) that aren't bullets
+    if (line.trim() && !line.startsWith('- ') && !line.startsWith('`')) {
+      currentList = null;
+    }
+  }
+
+  const repo = fields['repo'] || '';
+  const license = fields['license'] || '';
+  const version = fields['version'] || '';
+  const why = fields['why-it-matters'] || '';
+  const goodBullets = (lists['why-good'] || []);
+  const riskBullets = (lists['risk'] || []);
+  const pathBullets = (lists['paths'] || []);
+
+  const repoUrl = repo ? `https://github.com/${repo}` : '';
+  const repoLink = repo
+    ? `<a href="${htmlEsc(repoUrl)}" target="_blank" rel="noopener"><code>${htmlEsc(repo)}</code></a>`
+    : '';
+
+  const metaParts = [
+    license ? `License: ${htmlEsc(license)}` : '',
+    version ? `版本: ${htmlEsc(version)}` : '',
+  ].filter(Boolean).join(' · ');
+
+  return `<section class="spotlight">
+  <div class="kuro-block-label">③ GITHUB SPOTLIGHT</div>
+  <div class="spotlight-inner">
+    ${repo ? `<h3 class="spotlight-repo">${repoLink}</h3>` : ''}
+    ${metaParts ? `<div class="spotlight-meta">${metaParts}</div>` : ''}
+    ${why ? `<p>${renderInlineLinks(why)}</p>` : ''}
+    ${goodBullets.length ? `<div class="spotlight-sub">為什麼好</div><ul>${goodBullets.map(b => `<li>${renderInlineLinks(b)}</li>`).join('')}</ul>` : ''}
+    ${riskBullets.length ? `<div class="spotlight-sub">風險</div><ul>${riskBullets.map(b => `<li>${renderInlineLinks(b)}</li>`).join('')}</ul>` : ''}
+    ${pathBullets.length ? `<div class="spotlight-sub">整合路徑</div><ul>${pathBullets.map(b => `<li>${renderInlineLinks(b)}</li>`).join('')}</ul>` : ''}
+  </div>
+</section>`;
+}
+
+/**
+ * renderSwot(swot) — Block ④ SWOT
+ * Parses strengths / weaknesses / opportunities / threats bullet lists.
+ * Also handles markdown table format (| S | content |) used in seed file.
+ * If swot is null, emits a placeholder banner.
+ */
+function renderSwot(swot, date) {
+  if (!swot) {
+    return `<section class="swot">
+  <div class="kuro-block-label">④ SWOT</div>
+  <div class="kuro-placeholder">no kuro-content loaded for ${htmlEsc(date)}</div>
+</section>`;
+  }
+
+  // Try to parse as markdown table (| 維度 | 內容 | format used in seed)
+  const tableMap = {};
+  const tableRe = /^\|\s*\*{0,2}([SWOT][^|]*?)\*{0,2}\s*\|\s*(.+?)\s*\|?\s*$/;
+  for (const line of swot.split('\n')) {
+    const m = line.match(tableRe);
+    if (m) {
+      const key = m[1].trim().slice(0, 1).toLowerCase(); // S/W/O/T → s/w/o/t
+      tableMap[key] = (tableMap[key] || '') + ' ' + m[2].trim();
+    }
+  }
+
+  // Try bullet-list format (strengths: / weaknesses: / opportunities: / threats:)
+  const lists = {};
+  let currentKey = null;
+  const keyMap = {
+    strengths: 's', weaknesses: 'w', opportunities: 'o', threats: 't'
+  };
+  for (const line of swot.split('\n')) {
+    const kvMatch = line.match(/^([a-zA-Z]+):\s*$/);
+    if (kvMatch && keyMap[kvMatch[1].toLowerCase()]) {
+      currentKey = keyMap[kvMatch[1].toLowerCase()];
+      lists[currentKey] = [];
+      continue;
+    }
+    if (line.match(/^\s*-\s+/) && currentKey) {
+      lists[currentKey] = lists[currentKey] || [];
+      lists[currentKey].push(line.replace(/^\s*-\s+/, '').trim());
+    }
+  }
+
+  const dims = [
+    { key: 's', label: 'S 優勢' },
+    { key: 'w', label: 'W 弱點' },
+    { key: 'o', label: 'O 機會' },
+    { key: 't', label: 'T 威脅' },
+  ];
+
+  const cells = dims.map(({ key, label }) => {
+    const bullets = lists[key];
+    const tableText = tableMap[key];
+    if (bullets && bullets.length) {
+      return `<div class="swot-cell">
+      <b>${htmlEsc(label)}</b>
+      <ul>${bullets.map(b => `<li>${renderInlineLinks(b)}</li>`).join('')}</ul>
+    </div>`;
+    } else if (tableText) {
+      // Split table text on numbered items or semicolons
+      const items = tableText.split(/；|;\s*\(\d+\)|\s*\(\d+\)/).map(s => s.trim()).filter(Boolean);
+      return `<div class="swot-cell">
+      <b>${htmlEsc(label)}</b>
+      <ul>${items.map(b => `<li>${renderInlineLinks(b)}</li>`).join('')}</ul>
+    </div>`;
+    }
+    return `<div class="swot-cell"><b>${htmlEsc(label)}</b></div>`;
+  }).join('\n  ');
+
+  return `<section class="swot">
+  <div class="kuro-block-label">④ SWOT</div>
+  <div class="swot-grid">
+  ${cells}
+  </div>
+</section>`;
 }
 
 const SRC_ZH = { WEB: '網頁', HN: 'HN', LATENT: 'Latent', ARXIV: 'arXiv', GITHUB: 'GitHub', X: 'X' };
@@ -284,6 +515,33 @@ footer a{color:var(--acc);text-decoration:none;border-bottom:1px solid #334}
 .nav-row a{color:var(--mute);text-decoration:none;border-bottom:1px solid #2a2f38}
 .nav-row a:hover{color:var(--fg)}
 .preview-note{background:rgba(154,184,255,.06);border:1px dashed #3a4a6e;color:var(--acc);font-size:.78rem;padding:.45rem .8rem;border-radius:3px;margin-bottom:1.3rem}
+
+/* ── v3 kuro-content blocks ──────────────────────────────────────────── */
+section.take,section.trend,section.spotlight,section.swot{margin:1.6rem 0;border:1px solid var(--line);border-radius:6px;padding:1rem 1.25rem}
+.kuro-block-label{font-size:.68rem;color:var(--acc);text-transform:uppercase;letter-spacing:.18em;font-weight:600;margin-bottom:.7rem}
+.kuro-placeholder{color:var(--dim);font-size:.82rem;font-style:italic;padding:.4rem 0}
+section.take p{margin:.45rem 0;padding-left:.9rem;border-left:2px solid var(--line);font-size:.9rem;line-height:1.6}
+section.take p b{color:var(--fg)}
+section.trend{background:rgba(255,255,255,.015)}
+section.spotlight{border-color:var(--warn)}
+.spotlight-inner{font-size:.87rem;line-height:1.6}
+.spotlight-inner h3.spotlight-repo{margin:0 0 .4rem;font-size:1rem;font-weight:500}
+.spotlight-inner .spotlight-meta{color:var(--mute);font-size:.78rem;margin-bottom:.6rem}
+.spotlight-inner p{margin:.4rem 0}
+.spotlight-inner ul{margin:.3rem 0;padding-left:1.3rem}
+.spotlight-inner li{margin:.22rem 0}
+.spotlight-sub{color:var(--acc2);font-size:.72rem;text-transform:uppercase;letter-spacing:.1em;font-weight:600;margin:.7rem 0 .2rem}
+.swot-grid{display:grid;grid-template-columns:1fr 1fr;gap:.7rem}
+.swot-cell{border:1px solid var(--line);border-radius:4px;padding:.6rem .85rem;font-size:.83rem;line-height:1.55}
+.swot-cell b{color:var(--acc);font-size:.72rem;text-transform:uppercase;letter-spacing:.08em;display:block;margin-bottom:.35rem}
+.swot-cell ul{margin:0;padding-left:1.1rem}
+.swot-cell li{margin:.18rem 0}
+/* freshness pill for TrendRadar zh-CN (Path 2 ship gate) */
+.src-stamp.trendradar-pill b{color:var(--acc2)}
+@media (max-width:640px){
+  .swot-grid{grid-template-columns:1fr}
+}
+
 @media (max-width:640px){
   body{padding:1.5rem 1rem 3rem}h1{font-size:1.35rem}.banner{padding:.95rem 1.05rem}
   ul.feed li{grid-template-columns:auto 1fr;gap:.3rem .6rem}
@@ -394,6 +652,7 @@ async function main() {
   const trend = await loadTopicTrend(DATE);
   const archive = await listArchiveDates();
   const kpick = await loadKuroPick(DATE);
+  const kuroContent = await loadKuroContent(DATE);
 
   // X 用「likes/1000」做 cross-source 可比分數，避免吞噬 HN/Latent
   const xNorm = (x.posts || []).map(p => ({ ...p, _xs: (p.points || 0) / 1000 }));
@@ -434,11 +693,17 @@ async function main() {
     ${srcStamp('X', x)}
     ${srcStamp('arXiv', arxiv)}
     ${srcStamp('GitHub', gh)}
+    <span class="src-stamp trendradar-pill"><b>TrendRadar zh-CN</b><span>Path 2 待 ship</span></span>
     <span class="src-stamp"><b>頁面 build</b><span>${fmtTaipeiMinute(buildAt)}</span></span>
   </div>
 </header>
 
 <div class="preview-note">資料每日自動拉新（cron 觸發）。stale 標 (Nd 前) 表示來源該日尚未刷新 — 多半是該來源沒有當日資料而非簡報沒更新。</div>
+
+${renderTake(kuroContent.take, DATE)}
+${renderTrendPlaceholder()}
+${renderSpotlight(kuroContent.spotlight, DATE)}
+${renderSwot(kuroContent.swot, DATE)}
 
 <div class="banner">
   <div class="lab">▎ KURO 今日點評</div>


### PR DESCRIPTION
Closes #330 (PR-A scope).

## Summary
- Add `loadKuroContent(date)` parser reading `memory/state/kuro-content/<DATE>.md` (forgiving: missing file/section → placeholder banner, never throws).
- Add 3 render fns + 1 placeholder for blocks ①③④ + ② (PR-B deferred).
- Splice into existing `buildHtml()` between `<header>` and `<section class="src-list">` so v2 src-list (Block ⑤) renders byte-identically.
- Seed `memory/state/kuro-content/2026-05-08.md` from the agent-middleware mockup content.
- New author-guide template `scripts/ai-trend-content-template.md`.

## Verification
1. `node scripts/build-ai-trend-preview.mjs 2026-05-08` exits 0.
2. Generated preview contains `class="take"`, `class="trend"`, `class="spotlight"`, `class="swot"`.
3. With kuro-content file removed: no throw, placeholder banner emitted (`no kuro-content loaded for 2026-05-08` ×3).
4. Structural diff vs mockup: four blocks in spec order, structurally equivalent (mockup nests divs; PR uses sibling sections per acceptance criteria).
5. No new npm dependency.

## Deviations (documented)
- Bare class names `take/trend/spotlight/swot` (vs mockup's compound `kuro-block take`) to satisfy substring acceptance criterion.
- `.gitignore` excepts `memory/state/kuro-content/` so seed file lands.
- Loader regex tolerates numbered headings (`## ① Kuro take`) AND canonical (`## kuro-take`) — current mockup-source uses the former.

## Out of scope
- Block ② auto-derivation (PR-B)
- TrendRadar zh-CN lane (Path 2)

## Test plan
- [ ] CI green
- [ ] After merge, `curl https://kuro.page/ai-trend/preview.html | grep -c 'class=\"take\"'` ≥ 1
- [ ] Visual diff vs mockup acceptable

🤖 Generated with [Claude Code](https://claude.com/claude-code)