### PR TITLE
fix(closure): deduplicate held correction tasks

### DIFF
--- a/src/autonomous-work-closure.ts
+++ b/src/autonomous-work-closure.ts
@@ -140,7 +140,7 @@ async function completeTerminalExpressionTasks(memoryDir: string, now: Date): Pr
 }
 
 async function deduplicateActiveTasks(memoryDir: string, now: Date): Promise<number> {
-  const tasks = queryMemoryIndexSync(memoryDir, { type: ['task', 'goal'], status: ['pending', 'in_progress'] })
+  const tasks = queryMemoryIndexSync(memoryDir, { type: ['task', 'goal'], status: ['pending', 'in_progress', 'hold', 'blocked', 'needs-decomposition'] })
     .filter(task => !TERMINAL_STATUSES.has(task.status));
   const groups = new Map<string, MemoryIndexEntry[]>();
   for (const task of tasks) {
@@ -151,7 +151,10 @@ async function deduplicateActiveTasks(memoryDir: string, now: Date): Promise<num
   let deduped = 0;
   for (const group of groups.values()) {
     if (group.length < 2) continue;
-    const sorted = [...group].sort((a, b) => b.ts.localeCompare(a.ts));
+    const sorted = [...group].sort((a, b) => {
+      const rankDelta = taskDedupKeepRank(b) - taskDedupKeepRank(a);
+      return rankDelta !== 0 ? rankDelta : b.ts.localeCompare(a.ts);
+    });
     const keep = sorted[0];
     for (const duplicate of sorted.slice(1)) {
       const updated = await updateMemoryIndexEntry(memoryDir, duplicate.id, {
@@ -167,6 +170,13 @@ async function deduplicateActiveTasks(memoryDir: string, now: Date): Promise<num
     }
   }
   return deduped;
+}
+
+function taskDedupKeepRank(task: MemoryIndexEntry): number {
+  if (task.status === 'in_progress') return 4;
+  if (task.status === 'pending') return 3;
+  if (task.status === 'hold') return 2;
+  return 1;
 }
 
 async function releaseExpiredHolds(memoryDir: string, now: Date): Promise<number> {

--- a/src/correction-gate.ts
+++ b/src/correction-gate.ts
@@ -214,7 +214,7 @@ export async function ensureCorrectionTask(memoryDir: string, snapshot = evaluat
   if (!snapshot.needsCorrection) return null;
   const existing = queryMemoryIndexSync(memoryDir, {
     type: ['task'],
-    status: ['pending', 'in_progress', 'needs-decomposition', 'blocked'],
+    status: ['pending', 'in_progress', 'hold', 'needs-decomposition', 'blocked'],
   }).find(entry => isCorrectionTask(entry));
   if (existing) return existing;
 

--- a/tests/autonomous-work-closure.test.ts
+++ b/tests/autonomous-work-closure.test.ts
@@ -76,6 +76,35 @@ describe('autonomous work closure', () => {
     expect(queryMemoryIndexSync(memoryDir, { id: hold.id })[0].status).toBe('pending');
   });
 
+  it('deduplicates active held correction tasks instead of letting P0 holds accumulate', async () => {
+    const olderHold = await appendMemoryIndexEntry(memoryDir, {
+      type: 'task',
+      status: 'hold',
+      source: 'scheduler',
+      summary: 'P0 correction gate: resolve low-responsiveness',
+      payload: { origin: 'scheduler', priority: 0, correction_reason_type: 'low-responsiveness' },
+    });
+    const newerPending = await appendMemoryIndexEntry(memoryDir, {
+      type: 'task',
+      status: 'pending',
+      source: 'scheduler',
+      summary: 'P0 correction gate: resolve low-responsiveness',
+      payload: { origin: 'scheduler', priority: 0, correction_reason_type: 'low-responsiveness' },
+    });
+
+    const result = await sweepAutonomousWorkClosure(memoryDir, { repoRoot });
+
+    expect(result.deduplicatedTasks).toBe(1);
+    expect(queryMemoryIndexSync(memoryDir, { id: newerPending.id })[0].status).toBe('pending');
+    expect(queryMemoryIndexSync(memoryDir, { id: olderHold.id })[0]).toEqual(expect.objectContaining({
+      status: 'abandoned',
+      payload: expect.objectContaining({
+        pruned_reason: 'duplicate-active-work',
+        canonical_task_id: newerPending.id,
+      }),
+    }));
+  });
+
   it('closes product repair tasks once the verifier passes', async () => {
     const date = taipeiDate();
     writeAiTrendState(repoRoot, date, {

--- a/tests/correction-gate.test.ts
+++ b/tests/correction-gate.test.ts
@@ -68,6 +68,29 @@ describe('correction gate', () => {
     expect(correctionTasks).toHaveLength(1);
   });
 
+  it('reuses held correction tasks instead of creating a duplicate P0', async () => {
+    await appendMemoryIndexEntry(tmpDir, {
+      type: 'task',
+      status: 'pending',
+      summary: 'P1 finish promised work',
+      payload: { origin: 'pledge', priority: 1 },
+    });
+    const held = await appendMemoryIndexEntry(tmpDir, {
+      type: 'task',
+      status: 'hold',
+      summary: 'P0 correction gate: resolve low-responsiveness',
+      payload: { origin: 'scheduler', priority: 0, correction_reason_type: 'low-responsiveness' },
+    });
+    invalidateIndexCache();
+
+    const task = await ensureCorrectionTask(tmpDir);
+
+    expect(task?.id).toBe(held.id);
+    const correctionTasks = queryMemoryIndexSync(tmpDir, { type: ['task'], status: ['pending', 'hold'] })
+      .filter(t => t.summary?.includes('correction gate'));
+    expect(correctionTasks).toHaveLength(1);
+  });
+
   it('does not suppress exploration for bounded background maintenance tasks', async () => {
     await appendMemoryIndexEntry(tmpDir, {
       type: 'task',


### PR DESCRIPTION
## Summary
- include hold/blocked/needs-decomposition tasks in autonomous work closure dedup
- prefer in-progress/pending tasks over held duplicates when pruning duplicate active work
- make correction gate reuse held correction tasks instead of creating fresh P0 duplicates
- add regressions for held low-responsiveness P0 accumulation

## Verification
- `pnpm vitest run tests/autonomous-work-closure.test.ts tests/correction-gate.test.ts tests/scheduler-dispatch-suppression.test.ts`
- `pnpm typecheck`
- `pnpm build`

## Root cause
`work-closure` showed 11 duplicate `P0 correction gate: resolve low-responsiveness` tasks because held correction tasks were excluded from both deduplication and correction-task reuse.