### PR TITLE
content(ai-trend): fill zh summaries for 3 GH stubs (2026-05-08)

### DIFF
--- a/kuro-portfolio/ai-trend/2026-05-08.html
+++ b/kuro-portfolio/ai-trend/2026-05-08.html
@@ -109,7 +109,7 @@ footer a{color:var(--acc);text-decoration:none;border-bottom:1px solid #334}
     <span class="src-stamp"><b>X</b><span class="">2026-05-08 10:28</span></span>
     <span class="src-stamp"><b>arXiv</b><span class="">2026-05-08 10:26</span></span>
     <span class="src-stamp"><b>GitHub</b><span class="">2026-05-08 10:26</span></span>
-    <span class="src-stamp"><b>頁面 build</b><span>2026-05-08 10:51</span></span>
+    <span class="src-stamp"><b>頁面 build</b><span>2026-05-08 11:56</span></span>
   </div>
 </header>
 
@@ -1576,9 +1576,9 @@ footer a{color:var(--acc);text-decoration:none;border-bottom:1px solid #334}
   </li><li>
     <span class="rk">9</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/NousResearch/hermes-agent" target="_blank" rel="noopener">NousResearch/hermes-agent: The agent that grows with you</a></h3>
+      <h3 class="ti"><a href="https://github.com/NousResearch/hermes-agent" target="_blank" rel="noopener">Nous Research 的 agentic LLM framework — 主打『隨使用者成長』</a></h3>
       
-      <div class="zh todo">中文摘要待 LLM enrich pass — 先點右側「閱讀原文 →」</div>
+      <div class="zh">open-source agent 圈在尋找 ChatGPT 記憶體驗的對標方案，這個是一個值得追蹤的嘗試</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#代理</span>
@@ -1674,9 +1674,9 @@ footer a{color:var(--acc);text-decoration:none;border-bottom:1px solid #334}
   </li><li>
     <span class="rk">16</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/punkpeye/awesome-mcp-servers" target="_blank" rel="noopener">punkpeye/awesome-mcp-servers: A collection of MCP servers.</a></h3>
+      <h3 class="ti"><a href="https://github.com/punkpeye/awesome-mcp-servers" target="_blank" rel="noopener">MCP server 收錄清單，社群維護的 awesome-list</a></h3>
       
-      <div class="zh todo">中文摘要待 LLM enrich pass — 先點右側「閱讀原文 →」</div>
+      <div class="zh">找現成 connector 先翻這份，比逐個 google 快</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#代理</span>
@@ -1926,9 +1926,9 @@ footer a{color:var(--acc);text-decoration:none;border-bottom:1px solid #334}
   </li><li>
     <span class="rk">34</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/FlowiseAI/Flowise" target="_blank" rel="noopener">FlowiseAI/Flowise: Build AI Agents, Visually</a></h3>
+      <h3 class="ti"><a href="https://github.com/FlowiseAI/Flowise" target="_blank" rel="noopener">拖拉式視覺化 AI agent builder</a></h3>
       
-      <div class="zh todo">中文摘要待 LLM enrich pass — 先點右側「閱讀原文 →」</div>
+      <div class="zh">複雜 workflow 仍需 code-first，但 prototype / demo 場景很方便</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -2674,7 +2674,7 @@ _生成於 2026-05-08T02:51:31.335Z_
 </section>
 
 <footer>
-  <div>Kuro 自動生成 · <a href="https://github.com/miles990/mini-agent">原始碼</a> · 建置 2026-05-08 10:51 (Asia/Taipei)</div>
+  <div>Kuro 自動生成 · <a href="https://github.com/miles990/mini-agent">原始碼</a> · 建置 2026-05-08 11:56 (Asia/Taipei)</div>
   <div class="nav-row">
     <a href="./graph.html">主題圖譜</a>
     <a href="./swimlane.html">主題泳道</a>

--- a/kuro-portfolio/ai-trend/index.html
+++ b/kuro-portfolio/ai-trend/index.html
@@ -109,7 +109,7 @@ footer a{color:var(--acc);text-decoration:none;border-bottom:1px solid #334}
     <span class="src-stamp"><b>X</b><span class="">2026-05-08 10:28</span></span>
     <span class="src-stamp"><b>arXiv</b><span class="">2026-05-08 10:26</span></span>
     <span class="src-stamp"><b>GitHub</b><span class="">2026-05-08 10:26</span></span>
-    <span class="src-stamp"><b>頁面 build</b><span>2026-05-08 10:51</span></span>
+    <span class="src-stamp"><b>頁面 build</b><span>2026-05-08 11:56</span></span>
   </div>
 </header>
 
@@ -1576,9 +1576,9 @@ footer a{color:var(--acc);text-decoration:none;border-bottom:1px solid #334}
   </li><li>
     <span class="rk">9</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/NousResearch/hermes-agent" target="_blank" rel="noopener">NousResearch/hermes-agent: The agent that grows with you</a></h3>
+      <h3 class="ti"><a href="https://github.com/NousResearch/hermes-agent" target="_blank" rel="noopener">Nous Research 的 agentic LLM framework — 主打『隨使用者成長』</a></h3>
       
-      <div class="zh todo">中文摘要待 LLM enrich pass — 先點右側「閱讀原文 →」</div>
+      <div class="zh">open-source agent 圈在尋找 ChatGPT 記憶體驗的對標方案，這個是一個值得追蹤的嘗試</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#代理</span>
@@ -1674,9 +1674,9 @@ footer a{color:var(--acc);text-decoration:none;border-bottom:1px solid #334}
   </li><li>
     <span class="rk">16</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/punkpeye/awesome-mcp-servers" target="_blank" rel="noopener">punkpeye/awesome-mcp-servers: A collection of MCP servers.</a></h3>
+      <h3 class="ti"><a href="https://github.com/punkpeye/awesome-mcp-servers" target="_blank" rel="noopener">MCP server 收錄清單，社群維護的 awesome-list</a></h3>
       
-      <div class="zh todo">中文摘要待 LLM enrich pass — 先點右側「閱讀原文 →」</div>
+      <div class="zh">找現成 connector 先翻這份，比逐個 google 快</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#代理</span>
@@ -1926,9 +1926,9 @@ footer a{color:var(--acc);text-decoration:none;border-bottom:1px solid #334}
   </li><li>
     <span class="rk">34</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/FlowiseAI/Flowise" target="_blank" rel="noopener">FlowiseAI/Flowise: Build AI Agents, Visually</a></h3>
+      <h3 class="ti"><a href="https://github.com/FlowiseAI/Flowise" target="_blank" rel="noopener">拖拉式視覺化 AI agent builder</a></h3>
       
-      <div class="zh todo">中文摘要待 LLM enrich pass — 先點右側「閱讀原文 →」</div>
+      <div class="zh">複雜 workflow 仍需 code-first，但 prototype / demo 場景很方便</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -2674,7 +2674,7 @@ _生成於 2026-05-08T02:51:31.335Z_
 </section>
 
 <footer>
-  <div>Kuro 自動生成 · <a href="https://github.com/miles990/mini-agent">原始碼</a> · 建置 2026-05-08 10:51 (Asia/Taipei)</div>
+  <div>Kuro 自動生成 · <a href="https://github.com/miles990/mini-agent">原始碼</a> · 建置 2026-05-08 11:56 (Asia/Taipei)</div>
   <div class="nav-row">
     <a href="./graph.html">主題圖譜</a>
     <a href="./swimlane.html">主題泳道</a>

--- a/kuro-portfolio/ai-trend/preview.html
+++ b/kuro-portfolio/ai-trend/preview.html
@@ -109,7 +109,7 @@ footer a{color:var(--acc);text-decoration:none;border-bottom:1px solid #334}
     <span class="src-stamp"><b>X</b><span class="">2026-05-08 10:28</span></span>
     <span class="src-stamp"><b>arXiv</b><span class="">2026-05-08 10:26</span></span>
     <span class="src-stamp"><b>GitHub</b><span class="">2026-05-08 10:26</span></span>
-    <span class="src-stamp"><b>頁面 build</b><span>2026-05-08 10:51</span></span>
+    <span class="src-stamp"><b>頁面 build</b><span>2026-05-08 11:56</span></span>
   </div>
 </header>
 
@@ -1576,9 +1576,9 @@ footer a{color:var(--acc);text-decoration:none;border-bottom:1px solid #334}
   </li><li>
     <span class="rk">9</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/NousResearch/hermes-agent" target="_blank" rel="noopener">NousResearch/hermes-agent: The agent that grows with you</a></h3>
+      <h3 class="ti"><a href="https://github.com/NousResearch/hermes-agent" target="_blank" rel="noopener">Nous Research 的 agentic LLM framework — 主打『隨使用者成長』</a></h3>
       
-      <div class="zh todo">中文摘要待 LLM enrich pass — 先點右側「閱讀原文 →」</div>
+      <div class="zh">open-source agent 圈在尋找 ChatGPT 記憶體驗的對標方案，這個是一個值得追蹤的嘗試</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#代理</span>
@@ -1674,9 +1674,9 @@ footer a{color:var(--acc);text-decoration:none;border-bottom:1px solid #334}
   </li><li>
     <span class="rk">16</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/punkpeye/awesome-mcp-servers" target="_blank" rel="noopener">punkpeye/awesome-mcp-servers: A collection of MCP servers.</a></h3>
+      <h3 class="ti"><a href="https://github.com/punkpeye/awesome-mcp-servers" target="_blank" rel="noopener">MCP server 收錄清單，社群維護的 awesome-list</a></h3>
       
-      <div class="zh todo">中文摘要待 LLM enrich pass — 先點右側「閱讀原文 →」</div>
+      <div class="zh">找現成 connector 先翻這份，比逐個 google 快</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#代理</span>
@@ -1926,9 +1926,9 @@ footer a{color:var(--acc);text-decoration:none;border-bottom:1px solid #334}
   </li><li>
     <span class="rk">34</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/FlowiseAI/Flowise" target="_blank" rel="noopener">FlowiseAI/Flowise: Build AI Agents, Visually</a></h3>
+      <h3 class="ti"><a href="https://github.com/FlowiseAI/Flowise" target="_blank" rel="noopener">拖拉式視覺化 AI agent builder</a></h3>
       
-      <div class="zh todo">中文摘要待 LLM enrich pass — 先點右側「閱讀原文 →」</div>
+      <div class="zh">複雜 workflow 仍需 code-first，但 prototype / demo 場景很方便</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -2674,7 +2674,7 @@ _生成於 2026-05-08T02:51:31.335Z_
 </section>
 
 <footer>
-  <div>Kuro 自動生成 · <a href="https://github.com/miles990/mini-agent">原始碼</a> · 建置 2026-05-08 10:51 (Asia/Taipei)</div>
+  <div>Kuro 自動生成 · <a href="https://github.com/miles990/mini-agent">原始碼</a> · 建置 2026-05-08 11:56 (Asia/Taipei)</div>
   <div class="nav-row">
     <a href="./graph.html">主題圖譜</a>
     <a href="./swimlane.html">主題泳道</a>


### PR DESCRIPTION
## Summary
- 3 github-trend items on today's AI trend page rendered as `zh todo` placeholders (missing `summary.claim`/`so_what` after LLM enrich pass)
- Hand-wrote zh summaries for 3 well-known repos: hermes-agent, awesome-mcp-servers, Flowise
- Rebuilt page → 0 `zh todo` placeholders (was 3) → page is 100% enriched

## Resolves
- P0 「Repair AI trend closure: render all enriched source items for 2026-05-08」
- P0 「更新 AI Trend 頁面 — 今天的資料已就緒」

## Test plan
- [x] `grep -c 'class="zh todo"' kuro-portfolio/ai-trend/2026-05-08.html` returns `0`
- [x] kuro.page returns HTTP 200 (will be re-deployed by GH Pages on merge)
- [x] Visual diff: 3 stubs replaced with Chinese descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)