### PR TITLE
fix(stash): close generated artifact recovery loop

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "sync:github-issues": "pnpm build && node dist/issue-autopilot-cli.js",
     "janitor:workspaces": "tsx scripts/workspace-janitor.ts",
     "janitor:workspaces:apply": "tsx scripts/workspace-janitor.ts --apply",
+    "janitor:stash": "tsx scripts/stash-governance.ts",
+    "janitor:stash:apply": "tsx scripts/stash-governance.ts --apply",
     "check:runtime-workspace": "tsx scripts/check-runtime-workspace.ts",
     "autocorrect:runtime-workspace": "tsx scripts/runtime-workspace-autocorrect.ts",
     "setup:external-memory": "tsx scripts/setup-external-memory.ts",

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -127,6 +127,7 @@ run_workspace_janitor() {
     log "Running workspace janitor..."
     (
         pnpm exec tsx scripts/workspace-janitor.ts --apply --local-only >> "$LOG_FILE" 2>&1
+        pnpm exec tsx scripts/stash-governance.ts --apply >> "$LOG_FILE" 2>&1
     ) &
     JANITOR_PID=$!
     for _ in $(seq 1 "$WORKSPACE_JANITOR_TIMEOUT_SECONDS"); do

--- a/scripts/stash-governance.ts
+++ b/scripts/stash-governance.ts
@@ -1,0 +1,35 @@
+#!/usr/bin/env tsx
+import { getMemoryRootDir } from '../src/memory-paths.js';
+import { governGitStashes } from '../src/stash-governance.js';
+
+const json = process.argv.includes('--json');
+const apply = process.argv.includes('--apply');
+const limit = Number.parseInt(readArg('--limit') ?? (apply ? '3' : '5'), 10);
+const memoryDir = readArg('--memory-dir') ?? getMemoryRootDir();
+const repoRoot = readArg('--repo-root') ?? process.cwd();
+
+const result = await governGitStashes(memoryDir, repoRoot, {
+  createTasks: apply,
+  maxCases: Number.isFinite(limit) && limit > 0 ? limit : 3,
+  record: apply,
+  reason: apply ? 'stash-governance-apply' : 'stash-governance-scan',
+});
+
+if (json) {
+  process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+} else {
+  process.stdout.write(`[stash-governance] cases=${result.cases.length} createdTasks=${result.createdTasks.length}\n`);
+  for (const diagnostic of result.cases) {
+    process.stdout.write(`- ${diagnostic.decision}: ${diagnostic.stashRef} ${diagnostic.files.join(', ')}\n`);
+    process.stdout.write(`  rootCause: ${diagnostic.rootCause}\n`);
+    if (diagnostic.taskId) process.stdout.write(`  task: ${diagnostic.taskId}\n`);
+  }
+}
+
+function readArg(name: string): string | undefined {
+  const argv = process.argv.slice(2);
+  const index = argv.indexOf(name);
+  if (index >= 0) return argv[index + 1];
+  const prefix = `${name}=`;
+  return argv.find(arg => arg.startsWith(prefix))?.slice(prefix.length);
+}

--- a/src/conflict-governance.ts
+++ b/src/conflict-governance.ts
@@ -17,7 +17,7 @@ export interface ConflictAssessment {
 }
 
 const APPEND_ONLY_MEMORY_RE = /^memory\/(?:inner-notes\.md|handoffs\/active\.md|topics\/.+\.md|threads\/.+\.md|research\/.+\.md)$/;
-const GENERATED_RE = /^(?:dist\/|memory\/topics\/\.summaries\/|memory\/index\/.+\.jsonl$)/;
+const GENERATED_RE = /^(?:dist\/|memory\/topics\/\.summaries\/|memory\/index\/.+\.jsonl$|kuro-portfolio\/ai-trend\/(?:index|preview|\d{4}-\d{2}-\d{2}|archive|graph)\.html$|kuro-portfolio\/ai-trend\/data\/.+\.json$)/;
 const CODE_RE = /^(?:src\/|tests\/|scripts\/|plugins\/|\.githooks\/).+/;
 const CONFIG_RE = /^(?:package\.json|pnpm-lock\.yaml|tsconfig\.json|agent-compose\.yaml|\.env(?:\..*)?)$/;
 

--- a/src/housekeeping.ts
+++ b/src/housekeeping.ts
@@ -35,6 +35,7 @@ import { getFeature, setEnabled } from './features.js';
 import { pruneReviewBacklog } from './review-backlog-janitor.js';
 import { sweepKgDiscussionLifecycle } from './kg-discussion-janitor.js';
 import { assertKuroGithubIdentity, kuroGitEnv } from './github-identity.js';
+import { governGitStashes } from './stash-governance.js';
 import type { MemoryIndexEntry } from './memory-index.js';
 import type { InboxItem, ParsedTags } from './types.js';
 
@@ -394,7 +395,18 @@ export async function autoPushIfAhead(): Promise<void> {
     } catch {
       // Rebase failed — abort and skip this push (next cycle will retry)
       try { await execFileAsync('git', ['rebase', '--abort'], { cwd, timeout: 5000 }); } catch { /* already clean */ }
-      if (stashed) { try { await execFileAsync('git', ['stash', 'pop'], { cwd, timeout: 10000 }); } catch { /* conflict — stash stays */ } }
+      if (stashed) {
+        try {
+          await execFileAsync('git', ['stash', 'pop'], { cwd, timeout: 10000 });
+        } catch {
+          await governGitStashes(getMemoryRootDir(), cwd, {
+            createTasks: true,
+            maxCases: 3,
+            record: true,
+            reason: 'auto-push-rebase-failed-stash-conflict',
+          });
+        }
+      }
       slog('HOUSEKEEPING', 'auto-push skipped: rebase failed, will retry next cycle');
       return;
     }
@@ -405,6 +417,12 @@ export async function autoPushIfAhead(): Promise<void> {
         await execFileAsync('git', ['stash', 'pop'], { cwd, encoding: 'utf-8', timeout: 10000 });
       } catch {
         slog('HOUSEKEEPING', 'stash pop had conflicts — changes preserved in stash');
+        await governGitStashes(getMemoryRootDir(), cwd, {
+          createTasks: true,
+          maxCases: 3,
+          record: true,
+          reason: 'auto-push-stash-pop-conflict',
+        });
       }
     }
 

--- a/src/stash-governance.ts
+++ b/src/stash-governance.ts
@@ -1,0 +1,230 @@
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { assessConflicts, type ConflictAssessment } from './conflict-governance.js';
+import type { MemoryIndexEntry } from './memory-index.js';
+import { slog } from './utils.js';
+
+export interface GitStashRecord {
+  ref: string;
+  message: string;
+  files: string[];
+}
+
+export type StashGovernanceDecision =
+  | 'ignore'
+  | 'regenerate-generated-artifacts'
+  | 'manual-diagnostic';
+
+export interface StashGovernanceCase {
+  id: string;
+  ts: string;
+  stashRef: string;
+  message: string;
+  files: string[];
+  assessment: ConflictAssessment;
+  decision: StashGovernanceDecision;
+  rootCause: string;
+  evidence: string[];
+  mechanicalAction: string;
+  fallbackTask: {
+    title: string;
+    verifyCommand: string;
+    acceptanceCriteria: string;
+  } | null;
+  taskId?: string;
+}
+
+export interface StashGovernanceResult {
+  cases: StashGovernanceCase[];
+  createdTasks: MemoryIndexEntry[];
+}
+
+export async function governGitStashes(
+  memoryDir: string,
+  repoRoot = process.cwd(),
+  opts: {
+    createTasks?: boolean;
+    maxCases?: number;
+    record?: boolean;
+    reason?: string;
+    stashes?: GitStashRecord[];
+  } = {},
+): Promise<StashGovernanceResult> {
+  const stashes = opts.stashes ?? listGitStashes(repoRoot);
+  const maxCases = opts.maxCases ?? 5;
+  const cases = stashes
+    .map(stash => classifyStash(stash, opts.reason))
+    .filter(c => c.decision !== 'ignore')
+    .slice(0, maxCases);
+  const createdTasks: MemoryIndexEntry[] = [];
+
+  if (opts.record || opts.createTasks) appendStashCases(memoryDir, cases);
+
+  if (opts.createTasks) {
+    const { createTask } = await import('./memory-index.js');
+    for (const diagnostic of cases) {
+      if (!diagnostic.fallbackTask) continue;
+      if (await hasActiveTaskForCase(memoryDir, diagnostic.id)) continue;
+      try {
+        const task = await createTask(memoryDir, {
+          title: diagnostic.fallbackTask.title,
+          origin: 'pipeline',
+          status: 'pending',
+          priority: 0,
+          assignee: 'kuro',
+          verify_command: diagnostic.fallbackTask.verifyCommand,
+          acceptance_criteria: diagnostic.fallbackTask.acceptanceCriteria,
+        });
+        diagnostic.taskId = task.id;
+        createdTasks.push(task);
+        appendStashCases(memoryDir, [diagnostic]);
+      } catch (error) {
+        if (error instanceof Error && /duplicate of existing task/i.test(error.message)) {
+          slog('HOUSEKEEPING', `stash governance skipped duplicate task for ${diagnostic.id}`);
+          continue;
+        }
+        throw error;
+      }
+    }
+  }
+
+  if (cases.length > 0 && (opts.record || opts.createTasks)) {
+    slog('HOUSEKEEPING', `stash governance diagnosed ${cases.length} stash case(s); tasks=${createdTasks.length}`);
+  }
+
+  return { cases, createdTasks };
+}
+
+export function listGitStashes(repoRoot = process.cwd()): GitStashRecord[] {
+  const list = safeGit(repoRoot, ['stash', 'list', '--format=%gd%x09%gs']);
+  if (!list.trim()) return [];
+  return list.split('\n').map(line => {
+    const [ref, ...messageParts] = line.split('\t');
+    const message = messageParts.join('\t').trim();
+    const files = safeGit(repoRoot, ['stash', 'show', '--name-only', '--format=', ref.trim()])
+      .split('\n')
+      .map(f => f.trim())
+      .filter(Boolean);
+    return { ref: ref.trim(), message, files };
+  }).filter(stash => stash.ref && stash.files.length > 0);
+}
+
+export function classifyStash(stash: GitStashRecord, reason = 'periodic-scan'): StashGovernanceCase {
+  const assessment = assessConflicts(stash.files);
+  const allGenerated = assessment.conflicted.length > 0
+    && assessment.conflicted.every(file => file.class === 'generated');
+  const allAiTrend = stash.files.length > 0
+    && stash.files.every(file => file.startsWith('kuro-portfolio/ai-trend/'));
+  const id = `stash-${hashCase(stash.message, stash.files)}`;
+
+  if (!isManagedStash(stash) && !allGenerated) {
+    return {
+      id,
+      ts: new Date().toISOString(),
+      stashRef: stash.ref,
+      message: stash.message,
+      files: stash.files,
+      assessment,
+      decision: 'ignore',
+      rootCause: 'Stash is unrelated to autonomous runtime recovery.',
+      evidence: [`reason=${reason}`, `message=${stash.message}`],
+      mechanicalAction: 'none',
+      fallbackTask: null,
+    };
+  }
+
+  if (allGenerated && allAiTrend) {
+    return {
+      id,
+      ts: new Date().toISOString(),
+      stashRef: stash.ref,
+      message: stash.message,
+      files: stash.files,
+      assessment,
+      decision: 'regenerate-generated-artifacts',
+      rootCause: 'Generated ai-trend HTML was preserved in stash after main advanced on the same rendered files.',
+      evidence: [
+        `trigger=${reason}`,
+        `stash=${stash.ref}`,
+        `message=${stash.message}`,
+        `files=${stash.files.join(',')}`,
+        'policy=generated artifacts are regenerated from source instead of hand-merged',
+      ],
+      mechanicalAction: 'rerender-ai-trend-from-current-source',
+      fallbackTask: {
+        title: `${id}: regenerate ai-trend artifact ${stash.ref} from source, then drop or PR leftovers`,
+        verifyCommand: 'pnpm exec tsx scripts/stash-governance.ts --json && node scripts/build-ai-trend-preview.mjs && pnpm vitest run tests/conflict-governance.test.ts tests/stash-governance.test.ts',
+        acceptanceCriteria: `Stash ${stash.ref} is classified as absorbed, dropped after regeneration, or converted to an isolated PR; no generated HTML is manually merged.`,
+      },
+    };
+  }
+
+  return {
+    id,
+    ts: new Date().toISOString(),
+    stashRef: stash.ref,
+    message: stash.message,
+    files: stash.files,
+    assessment,
+    decision: 'manual-diagnostic',
+    rootCause: 'Autonomous stash recovery found non-generated or mixed files that need semantic review.',
+    evidence: [
+      `trigger=${reason}`,
+      `stash=${stash.ref}`,
+      `message=${stash.message}`,
+      `files=${stash.files.join(',')}`,
+    ],
+    mechanicalAction: 'none',
+    fallbackTask: {
+      title: `${id}: diagnose preserved stash ${stash.ref}: ${stash.files.slice(0, 3).join(', ')}`,
+      verifyCommand: 'git stash list && git status --short && pnpm typecheck',
+      acceptanceCriteria: `Stash ${stash.ref} is either safely applied through an isolated worktree PR, intentionally dropped with evidence, or split into smaller tasks.`,
+    },
+  };
+}
+
+function isManagedStash(stash: GitStashRecord): boolean {
+  return /auto-push|keep-ai-trend-dirty|runtime|autocorrect|pre-rebase/i.test(stash.message);
+}
+
+async function hasActiveTaskForCase(memoryDir: string, caseId: string): Promise<boolean> {
+  const { queryMemoryIndexSync } = await import('./memory-index.js');
+  const active = queryMemoryIndexSync(memoryDir, { type: 'task' })
+    .filter(task => !['completed', 'abandoned', 'deleted', 'expired', 'resolved'].includes(String(task.status)));
+  return active.some(task => {
+    const payloadText = JSON.stringify(task.payload ?? {});
+    const summary = task.summary ?? '';
+    return payloadText.includes(caseId) || summary.includes(caseId);
+  });
+}
+
+function appendStashCases(memoryDir: string, cases: StashGovernanceCase[]): void {
+  if (cases.length === 0) return;
+  const file = path.join(memoryDir, 'state', 'stash-governance.jsonl');
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.appendFileSync(file, cases.map(c => JSON.stringify(c)).join('\n') + '\n', 'utf-8');
+}
+
+function hashCase(message: string, files: string[]): string {
+  return createHash('sha1')
+    .update(message)
+    .update('\0')
+    .update([...files].sort().join('\0'))
+    .digest('hex')
+    .slice(0, 12);
+}
+
+function safeGit(repoRoot: string, args: string[]): string {
+  try {
+    return execFileSync('git', args, {
+      cwd: repoRoot,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 15_000,
+    });
+  } catch {
+    return '';
+  }
+}

--- a/tests/conflict-governance.test.ts
+++ b/tests/conflict-governance.test.ts
@@ -36,6 +36,11 @@ describe('conflict governance', () => {
       autoResolvable: false,
       resolution: 'regenerate',
     }));
+    expect(classifyConflictPath('kuro-portfolio/ai-trend/2026-05-08.html')).toEqual(expect.objectContaining({
+      class: 'generated',
+      autoResolvable: false,
+      resolution: 'regenerate',
+    }));
   });
 
   it('blocks whenever unresolved conflicts exist and separates auto/manual sets', () => {

--- a/tests/stash-governance.test.ts
+++ b/tests/stash-governance.test.ts
@@ -1,0 +1,76 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { classifyStash, governGitStashes, type GitStashRecord } from '../src/stash-governance.js';
+import { queryMemoryIndexSync } from '../src/memory-index.js';
+
+describe('stash governance', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(path.join(os.tmpdir(), 'mini-agent-stash-governance-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('routes ai-trend generated stash conflicts to regeneration, not HTML merge', () => {
+    const diagnostic = classifyStash(aiTrendStash());
+
+    expect(diagnostic).toEqual(expect.objectContaining({
+      decision: 'regenerate-generated-artifacts',
+      rootCause: expect.stringContaining('Generated ai-trend HTML'),
+      mechanicalAction: 'rerender-ai-trend-from-current-source',
+      fallbackTask: expect.objectContaining({
+        verifyCommand: expect.stringContaining('build-ai-trend-preview.mjs'),
+      }),
+    }));
+    expect(diagnostic.assessment.conflicted.map(file => file.class)).toEqual(['generated', 'generated', 'generated']);
+  });
+
+  it('creates one scheduler-visible diagnostic task for a preserved generated stash', async () => {
+    const memoryDir = path.join(tmpDir, 'memory');
+    mkdirSync(path.join(memoryDir, 'state'), { recursive: true });
+    mkdirSync(path.join(memoryDir, 'state', 'index'), { recursive: true });
+    writeFileSync(path.join(memoryDir, 'state', 'task-events.jsonl'), '', 'utf-8');
+    writeFileSync(path.join(memoryDir, 'state', 'index', 'relations.jsonl'), '', { encoding: 'utf-8', flag: 'w' });
+
+    const first = await governGitStashes(memoryDir, tmpDir, {
+      createTasks: true,
+      reason: 'test',
+      stashes: [aiTrendStash()],
+    });
+    const second = await governGitStashes(memoryDir, tmpDir, {
+      createTasks: true,
+      reason: 'test',
+      stashes: [aiTrendStash()],
+    });
+
+    expect(first.createdTasks).toHaveLength(1);
+    expect(second.createdTasks).toHaveLength(0);
+    const tasks = queryMemoryIndexSync(memoryDir, { type: 'task' });
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0]).toEqual(expect.objectContaining({
+      status: 'pending',
+      summary: expect.stringContaining('regenerate ai-trend artifact'),
+    }));
+    expect(tasks[0].payload).toEqual(expect.objectContaining({
+      verify_command: expect.stringContaining('stash-governance.ts'),
+      acceptance_criteria: expect.stringContaining('no generated HTML is manually merged'),
+    }));
+  });
+});
+
+function aiTrendStash(): GitStashRecord {
+  return {
+    ref: 'stash@{0}',
+    message: 'On runtime/main: keep-ai-trend-dirty',
+    files: [
+      'kuro-portfolio/ai-trend/2026-05-08.html',
+      'kuro-portfolio/ai-trend/index.html',
+      'kuro-portfolio/ai-trend/preview.html',
+    ],
+  };
+}


### PR DESCRIPTION
## Summary
- classify ai-trend rendered files as generated conflicts that must be regenerated from source
- add bounded stash governance scanning and task creation for preserved stash conflicts
- run stash governance from auto-push conflict handling and deploy janitor

## Verification
- pnpm vitest run tests/conflict-governance.test.ts tests/stash-governance.test.ts
- pnpm typecheck
- pnpm build