### PR TITLE
fix(launchd): forensic+bulletproof github-ai-trend wrapper (#354)

### DIFF
--- a/scripts/launchd-wrappers/github-ai-trend.sh
+++ b/scripts/launchd-wrappers/github-ai-trend.sh
@@ -1,14 +1,38 @@
 #!/bin/zsh
-set -e
+# Forensic + bulletproof wrapper for github-ai-trend.
+# Issue #354: fallback enricher silently skipped after remote enricher's all-fail run.
+#
+# Design:
+# - No `set -e`: every step is independent; remote-enrich is *expected* to fail
+#   and must never short-circuit the fallback step.
+# - Every step wrapped in `|| echo`: any non-zero exit is logged but absorbed.
+# - Every step gets a `[wrapper TIMESTAMP] step=NAME phase=PHASE` marker,
+#   so if the process is killed mid-run the launchd log shows exactly where it died.
+# - `[wrapper] step=done` only emitted on full success (all four phases reached).
+#   Absence of this line is a hard signal that the wrapper was terminated.
+
 cd /Users/user/Workspace/mini-agent
+
 set -a
 . ./.env
 set +a
-/opt/homebrew/bin/node scripts/github-ai-trend.mjs
-# Remote enrich (claude-cli). Allowed to partially or fully fail —
-# fallback below always runs to backfill any post still showing
-# 'pending-llm-pass' so the user-facing output is never the literal
-# placeholder string. Issue #258.
-/opt/homebrew/bin/node scripts/ai-trend-enrich-remote.mjs --source=github \
-  || echo "[wrapper] remote-enrich exited non-zero, continuing to fallback"
-/opt/homebrew/bin/node scripts/ai-trend-enrich-fallback.mjs --source=github
+
+NODE=/opt/homebrew/bin/node
+ts() { date -u +%FT%TZ }
+
+echo "[wrapper $(ts)] step=fetch phase=start"
+$NODE scripts/github-ai-trend.mjs \
+  || echo "[wrapper $(ts)] step=fetch phase=nonzero (continuing)"
+echo "[wrapper $(ts)] step=fetch phase=end"
+
+echo "[wrapper $(ts)] step=remote-enrich phase=start"
+$NODE scripts/ai-trend-enrich-remote.mjs --source=github \
+  || echo "[wrapper $(ts)] step=remote-enrich phase=nonzero (continuing to fallback)"
+echo "[wrapper $(ts)] step=remote-enrich phase=end"
+
+echo "[wrapper $(ts)] step=fallback phase=start"
+$NODE scripts/ai-trend-enrich-fallback.mjs --source=github \
+  || echo "[wrapper $(ts)] step=fallback phase=nonzero"
+echo "[wrapper $(ts)] step=fallback phase=end"
+
+echo "[wrapper $(ts)] step=done"


### PR DESCRIPTION
## Summary
- Drop `set -e` in `scripts/launchd-wrappers/github-ai-trend.sh`; remote-enrich is *expected* to fail (claude CLI cascade) and must never short-circuit the fallback step.
- Wrap every step in `|| echo "[wrapper ...]"` so non-zero exits are logged but absorbed.
- Add `[wrapper TS] step=NAME phase=start|end|nonzero` markers around every step. If the process is terminated mid-run, the last marker pinpoints where it died.

## Why
Per #354: 2026-05-07 launchd log ends with `[enrich] done: source=github ok=0 fail=60` and never emits the `[fallback-enrich]` line, despite the wrapper having unconditionally invoked it. Either launchd killed the wrapper between the two lines, or `set -e` interacted with the `||` short-circuit in zsh in some unobserved way. Either way the wrapper had no forensic trail. After this patch the launchd log will tell us exactly which step is the last to log, and `[wrapper ... step=done]` becomes the success terminator (its absence = hard kill signal).

## Verification
- [x] `zsh -n scripts/launchd-wrappers/github-ai-trend.sh` parses cleanly
- [ ] Next 3 consecutive 15:00 TST cron runs (2026-05-08, 05-09, 05-10) produce a `[fallback-enrich] source=github changed=N` line in `memory/logs/github-ai-trend-launchd.log`
- [ ] Same 3 runs each emit `[wrapper TS] step=done` as the final line
- [ ] If `step=done` is missing, the last `[wrapper ... phase=end]` marker identifies the killed step → file follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)