### PR TITLE
fix(ai-trend): fallback enricher silently skipped after all-fail run (#354)

### DIFF
--- a/scripts/ai-trend-enrich-remote.mjs
+++ b/scripts/ai-trend-enrich-remote.mjs
@@ -129,6 +129,14 @@ for (const post of toEnrich) {
   }
 }
 
+if (ok === 0 && fail > 0) {
+  // Total failure: every post failed the claude-cli call. Exit non-zero so the
+  // launchd wrapper's diagnostic echo fires and the log clearly shows the failure.
+  // The fallback enricher will still run because the wrapper handles this exit code.
+  console.error(`[enrich] total failure: source=${source} ok=0 fail=${fail} — exiting 1 so wrapper triggers fallback`);
+  process.exit(1);
+}
+
 doc.enriched_at = new Date().toISOString();
 doc.enrichment = { ok, fail, model: 'haiku', via: 'claude-cli', source };
 writeFileSync(inFile, JSON.stringify(doc, null, 2));

--- a/scripts/launchd-wrappers/github-ai-trend.sh
+++ b/scripts/launchd-wrappers/github-ai-trend.sh
@@ -9,6 +9,16 @@ set +a
 # fallback below always runs to backfill any post still showing
 # 'pending-llm-pass' so the user-facing output is never the literal
 # placeholder string. Issue #258.
-/opt/homebrew/bin/node scripts/ai-trend-enrich-remote.mjs --source=github \
-  || echo "[wrapper] remote-enrich exited non-zero, continuing to fallback"
+#
+# set -e is disabled around the remote enricher to prevent zsh's ERR_EXIT from
+# aborting the wrapper on non-zero exit — which silently skipped the fallback
+# in all-fail runs (issue #354). set -e is restored before the fallback call so
+# a fatal error in the fallback still surfaces correctly.
+set +e
+/opt/homebrew/bin/node scripts/ai-trend-enrich-remote.mjs --source=github
+_remote_exit=$?
+set -e
+if [ $_remote_exit -ne 0 ]; then
+  echo "[wrapper] remote-enrich exited non-zero ($_remote_exit), continuing to fallback"
+fi
 /opt/homebrew/bin/node scripts/ai-trend-enrich-fallback.mjs --source=github

--- a/tests/ai-trend-enrich-wrapper.test.ts
+++ b/tests/ai-trend-enrich-wrapper.test.ts
@@ -1,0 +1,87 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Regression tests for issue #354:
+ * ai-trend fallback enricher silently skipped after remote enricher's all-fail run.
+ *
+ * Root cause: wrapper uses `set -e` which can interact with `||` multi-line
+ * constructs in zsh, silently aborting before the fallback line runs. The remote
+ * enricher also exits 0 on total failure (ok=0, fail=N) making the abort silent.
+ *
+ * Fix:
+ * 1. Wrapper disables `set -e` around remote-enrich via explicit `set +e` / `set -e`
+ *    bracketing so fallback always executes regardless of remote-enrich exit code.
+ * 2. Remote enricher exits 1 when ok=0 and fail>0 (total failure) so that
+ *    the `[wrapper]` diagnostic line appears in logs.
+ */
+
+describe('github-ai-trend wrapper script (issue #354)', () => {
+  const wrapperPath = path.join(process.cwd(), 'scripts', 'launchd-wrappers', 'github-ai-trend.sh');
+  let script: string;
+
+  it('loads the wrapper script', () => {
+    script = readFileSync(wrapperPath, 'utf-8');
+    expect(script.length).toBeGreaterThan(0);
+  });
+
+  it('disables set -e around the remote enricher so fallback always runs', () => {
+    script = readFileSync(wrapperPath, 'utf-8');
+    // set +e must appear BEFORE the remote-enrich call
+    // set -e must appear AFTER the remote-enrich call and BEFORE the fallback call
+    const setPlusEIdx = script.indexOf('set +e');
+    const remoteIdx = script.indexOf('ai-trend-enrich-remote.mjs');
+    const setMinusEIdx = script.indexOf('set -e', remoteIdx);
+    const fallbackIdx = script.indexOf('ai-trend-enrich-fallback.mjs');
+
+    expect(setPlusEIdx).toBeGreaterThan(-1);
+    expect(setPlusEIdx).toBeLessThan(remoteIdx);
+    expect(setMinusEIdx).toBeGreaterThan(remoteIdx);
+    expect(setMinusEIdx).toBeLessThan(fallbackIdx);
+  });
+
+  it('logs a diagnostic message when remote-enrich exits non-zero', () => {
+    script = readFileSync(wrapperPath, 'utf-8');
+    // The wrapper must check the exit code and log a warning
+    expect(script).toContain('[wrapper] remote-enrich exited non-zero');
+    expect(script).toContain('continuing to fallback');
+  });
+
+  it('fallback enricher line is NOT inside an if-block guarded by remote success', () => {
+    script = readFileSync(wrapperPath, 'utf-8');
+    const fallbackIdx = script.indexOf('ai-trend-enrich-fallback.mjs');
+    // The fallback must come after the diagnostic/check but must run unconditionally.
+    // It should not be inside an `if [ ... ]; then ... fi` block that skips it on failure.
+    // Simple invariant: fallback call appears after remote call.
+    const remoteIdx = script.indexOf('ai-trend-enrich-remote.mjs');
+    expect(fallbackIdx).toBeGreaterThan(remoteIdx);
+  });
+});
+
+describe('ai-trend-enrich-remote.mjs exit code on total failure (issue #354)', () => {
+  const remotePath = path.join(process.cwd(), 'scripts', 'ai-trend-enrich-remote.mjs');
+  let script: string;
+
+  it('loads the remote enricher script', () => {
+    script = readFileSync(remotePath, 'utf-8');
+    expect(script.length).toBeGreaterThan(0);
+  });
+
+  it('exits with non-zero status when ok=0 and fail>0 (total failure)', () => {
+    script = readFileSync(remotePath, 'utf-8');
+    // The script must have an explicit non-zero exit when ok===0 and fail>0
+    // so the wrapper's diagnostic echo fires and logs show the failure.
+    expect(script).toMatch(/if\s*\(\s*ok\s*===\s*0\s*&&\s*fail\s*>\s*0\s*\)|process\.exit\s*\(\s*1\s*\)/);
+  });
+
+  it('includes a total-failure guard before the final console.error done line', () => {
+    script = readFileSync(remotePath, 'utf-8');
+    const doneIdx = script.indexOf("[enrich] done:");
+    // There must be a process.exit(1) call somewhere before the done line
+    // that fires on total failure.
+    const exitOneIdx = script.indexOf('process.exit(1)');
+    expect(exitOneIdx).toBeGreaterThan(-1);
+    expect(exitOneIdx).toBeLessThan(doneIdx);
+  });
+});


### PR DESCRIPTION
## Summary

- **Root cause 1**: `set -e` in the wrapper interacted with the multi-line `||` construct, causing zsh ERR_EXIT to abort before reaching the fallback line when remote-enrich failed
- **Root cause 2**: `ai-trend-enrich-remote.mjs` exited 0 even on total failure (ok=0, fail=N), so the `||` gate never triggered and the diagnostic log never appeared
- **Fix**: Bracket remote-enrich call with `set +e` / `set -e` so fallback always executes; exit 1 from remote enricher when ok=0 and fail>0

## Changes

- `scripts/launchd-wrappers/github-ai-trend.sh` — replace `||` pattern with `set +e` / capture exit / `set -e` so fallback unconditionally runs
- `scripts/ai-trend-enrich-remote.mjs` — add total-failure guard: `process.exit(1)` when ok=0 and fail>0
- `tests/ai-trend-enrich-wrapper.test.ts` — 7 regression tests covering both fixes

## Verification

- [x] `pnpm typecheck` passes
- [x] All 7 `tests/ai-trend-enrich-wrapper.test.ts` tests pass
- [x] Pre-existing `runtime-workspace-autocorrect` failures (require `KURO_GITHUB_TOKEN`) confirmed unrelated

Closes #354

🤖 Generated with [Claude Code](https://claude.com/claude-code)