### PR TITLE
fix(github): widen PR verification evidence parser

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -1123,7 +1123,7 @@ function replaceMarkdownSection(body: string, heading: RegExp, replacement: stri
 }
 
 function findEvidenceSection(body: string): { start: number; headingEnd: number; heading: string; content: string } | null {
-  const headingRe = /^##\s+(Test plan|Tests|Test Plan|Testing)\b.*$/gim;
+  const headingRe = /^##\s+(Test plan|Tests|Test Plan|Testing|Acceptance checks?)\b.*$/gim;
   let match: RegExpExecArray | null;
   while ((match = headingRe.exec(body)) !== null) {
     const start = match.index;
@@ -1139,9 +1139,10 @@ function findEvidenceSection(body: string): { start: number; headingEnd: number;
 
 function sectionHasCompletedEvidence(section: string): boolean {
   const hasCompletedMarker = /(?:^|\n)\s*-\s*\[[xX]\]\s+/.test(section)
+    || /(?:^|\n)\s*\d+\.\s+`/.test(section)
     || /(?:^|\n)\s*(?:`{3}|[$>])/.test(section);
-  const hasVerificationCommand = /\b(?:pnpm|npm|npx|vitest|tsc|typecheck|build|test|smoke|grep)\b/i.test(section);
-  const hasPassSignal = /\b(?:pass(?:ed|es)?|clean|0 lines|verified|ok|success)\b/i.test(section);
+  const hasVerificationCommand = /\b(?:pnpm|npm|npx|node|zsh|vitest|tsc|typecheck|build|test|smoke|grep|curl)\b/i.test(section);
+  const hasPassSignal = /\b(?:pass(?:ed|es)?|all PASS|clean|parses cleanly|0 lines|verified|ok|success|exits 0)\b/i.test(section);
   return hasCompletedMarker && hasVerificationCommand && hasPassSignal;
 }
 

--- a/tests/github-verification-autorepair.test.ts
+++ b/tests/github-verification-autorepair.test.ts
@@ -39,6 +39,28 @@ describe('GitHub PR verification autorepair', () => {
     expect(result.body.startsWith('## Verification')).toBe(true);
   });
 
+  it('renames completed acceptance checks with command evidence', () => {
+    const result = autofixPrVerificationSection([
+      '## Acceptance checks (all PASS)',
+      '1. `node scripts/build-ai-trend-preview.mjs 2026-05-08` exits 0.',
+      '2. Generated preview contains expected blocks.',
+    ].join('\n'));
+
+    expect(result.changed).toBe(true);
+    expect(result.body.startsWith('## Verification')).toBe(true);
+  });
+
+  it('renames shell syntax test plans that parse cleanly', () => {
+    const result = autofixPrVerificationSection([
+      '## Test plan',
+      '- [x] `zsh -n scripts/launchd-wrappers/github-ai-trend.sh` parses cleanly',
+      '- [ ] Next cron run emits done marker',
+    ].join('\n'));
+
+    expect(result.changed).toBe(true);
+    expect(result.body.startsWith('## Verification')).toBe(true);
+  });
+
   it('promotes completed verification evidence from a PR comment', () => {
     const result = autofixPrVerificationSection('## Summary\n- Wrapper fallback fix.', [{
       body: [


### PR DESCRIPTION
## Summary
- treat Acceptance checks as PR verification evidence when they contain completed command/pass signals
- recognize ordered command lists, node/zsh/curl commands, and parses-cleanly/exits-0/all-PASS signals
- add regression coverage for PR #344/#358-style evidence sections

## Verification
- pnpm vitest run tests/github-verification-autorepair.test.ts
- pnpm typecheck
- pnpm build