### PR TITLE
fix(review): accept shell verification evidence

### DIFF
--- a/src/pr-review-runner.ts
+++ b/src/pr-review-runner.ts
@@ -229,7 +229,7 @@ export function createInternalPrReviewClaim(candidate: InternalPrReviewCandidate
   const changedFiles = uniqueStrings(candidate.changedFiles);
   const touchesCode = changedFiles.some(file => /^(src|tests|scripts|plugins|\.githooks)\//.test(file) || file === 'package.json');
   const hasVerification = /(^|\n)##\s+Verification\b/i.test(text)
-    && /\b(pnpm|npm|npx|vitest|tsc|test|typecheck|build|passed|passes|clean|smoke|verified in an isolated worktree|runtime checkout was not used)\b/i.test(text);
+    && /\b(pnpm|npm|npx|node|zsh|vitest|tsc|test|typecheck|build|passed|passes|clean|parses cleanly|exits 0|smoke|verified in an isolated worktree|runtime checkout was not used)\b/i.test(text);
 
   if (changedFiles.length === 0) {
     return createPrReviewClaim({

--- a/tests/pr-review-runner.test.ts
+++ b/tests/pr-review-runner.test.ts
@@ -214,6 +214,24 @@ describe('PR review runner', () => {
     }));
   });
 
+  it('accepts zsh syntax verification evidence in PR bodies', () => {
+    const claim = createInternalPrReviewClaim({
+      prNumber: 358,
+      title: 'fix(launchd): forensic+bulletproof github-ai-trend wrapper',
+      body: '## Verification\n- [x] `zsh -n scripts/launchd-wrappers/github-ai-trend.sh` parses cleanly\n- [ ] Next cron run emits done marker',
+      headSha: 'abc123',
+      reviewer: 'akari',
+      framework: 'tanren-review',
+      changedFiles: ['scripts/launchd-wrappers/github-ai-trend.sh'],
+    }, new Date('2026-05-06T00:00:00Z'));
+
+    expect(claim).toEqual(expect.objectContaining({
+      prNumber: 358,
+      reviewer: 'akari',
+      verdict: 'approve',
+    }));
+  });
+
   it('does not create internal claims for Alex review rows', () => {
     expect(createInternalPrReviewClaim({
       prNumber: 104,


### PR DESCRIPTION
## Summary
- allow internal PR review policy to accept zsh/parses-cleanly shell verification evidence
- add regression coverage for launchd wrapper PRs

## Verification
- pnpm vitest run tests/pr-review-runner.test.ts
- pnpm typecheck
- pnpm build