### PR TITLE
fix(review): refresh claims after policy changes

### DIFF
--- a/src/pr-review-runner.ts
+++ b/src/pr-review-runner.ts
@@ -59,7 +59,7 @@ export interface InternalPrReviewClaimResult {
 const PR_REVIEW_CLAIMS_FILE = 'pr-review-claims.jsonl';
 const PR_HANDOFF_RE = /^\|\s*github\s*\|\s*(\S+)\s*\|\s*PR #(\d+)\s+(.+?)\s*\|\s*([^|]+?)\s*\|/;
 const REVIEW_STATUSES = ['needs-review', 'review-pending', 'review-approved', 'changes-requested'];
-const REVIEW_INPUT_POLICY_VERSION = 2;
+const REVIEW_INPUT_POLICY_VERSION = 3;
 
 export function getPrReviewClaimsPath(memoryDir: string): string {
   return path.join(memoryDir, 'index', PR_REVIEW_CLAIMS_FILE);


### PR DESCRIPTION
## Summary
- bump the internal PR review input policy version so changed evidence policy regenerates claims instead of reusing stale request_changes results

## Verification
- pnpm vitest run tests/pr-review-runner.test.ts
- pnpm typecheck
- pnpm build