### PR TITLE
fix(tasks): drain stale closure blockers

### DIFF
--- a/src/autonomous-work-closure.ts
+++ b/src/autonomous-work-closure.ts
@@ -23,6 +23,7 @@ export interface AutonomousWorkClosureResult {
   completedExpressionTasks: number;
   deduplicatedTasks: number;
   releasedHolds: number;
+  completedElapsedProviderHolds: number;
   productRepairsQueued: number;
   productRepairsClosed: number;
   productVerifiers: ProductVerifierResult[];
@@ -45,18 +46,20 @@ export async function sweepAutonomousWorkClosure(
   const pruned = await pruneNonActionableRoomTasks(memoryDir, { sources: ['room', 'room-promoted', 'ooda-expression'] });
   const deduplicatedTasks = await deduplicateActiveTasks(memoryDir, now);
   const releasedHolds = await releaseExpiredHolds(memoryDir, now);
+  const completedElapsedProviderHolds = await completeElapsedProviderHoldTasks(memoryDir, now);
   const { queued: productRepairsQueued, closed: productRepairsClosed } = await reconcileProductRepairTasks(memoryDir, productVerifiers, now);
   const result = {
     prunedNonActionable: pruned.pruned,
     completedExpressionTasks,
     deduplicatedTasks,
     releasedHolds,
+    completedElapsedProviderHolds,
     productRepairsQueued,
     productRepairsClosed,
     productVerifiers,
   };
-  const changed = result.prunedNonActionable + completedExpressionTasks + deduplicatedTasks + releasedHolds + productRepairsQueued + productRepairsClosed;
-  if (changed > 0) slog('WORK-CLOSURE', `sweep changed=${changed} pruned=${result.prunedNonActionable} expression=${completedExpressionTasks} dedup=${deduplicatedTasks} holds=${releasedHolds} repairs=${productRepairsQueued} closedRepairs=${productRepairsClosed}`);
+  const changed = result.prunedNonActionable + completedExpressionTasks + deduplicatedTasks + releasedHolds + completedElapsedProviderHolds + productRepairsQueued + productRepairsClosed;
+  if (changed > 0) slog('WORK-CLOSURE', `sweep changed=${changed} pruned=${result.prunedNonActionable} expression=${completedExpressionTasks} dedup=${deduplicatedTasks} holds=${releasedHolds} providerHolds=${completedElapsedProviderHolds} repairs=${productRepairsQueued} closedRepairs=${productRepairsClosed}`);
   return result;
 }
 
@@ -188,13 +191,49 @@ async function releaseExpiredHolds(memoryDir: string, now: Date): Promise<number
     if (condition?.type !== 'date-after' || typeof condition.value !== 'string') continue;
     const resumeAt = Date.parse(condition.value);
     if (!Number.isFinite(resumeAt) || resumeAt > now.getTime()) continue;
+    const providerHold = payload.provider_resource_hold;
+    const nextStatus = providerHold ? 'completed' : 'pending';
+    const completedFields = providerHold
+      ? {
+          completed_by: 'autonomous-work-closure',
+          completed_reason: 'provider quota hold elapsed; this wait task should not return to the P0 queue',
+          completed_at: now.toISOString(),
+        }
+      : {};
     const updated = await updateMemoryIndexEntry(memoryDir, hold.id, {
-      status: 'pending',
-      payload: { ...payload, hold_released_at: now.toISOString(), hold_released_by: 'autonomous-work-closure' },
+      status: nextStatus,
+      payload: {
+        ...payload,
+        ...completedFields,
+        hold_released_at: now.toISOString(),
+        hold_released_by: 'autonomous-work-closure',
+      },
     });
     if (updated) released++;
   }
   return released;
+}
+
+async function completeElapsedProviderHoldTasks(memoryDir: string, now: Date): Promise<number> {
+  const tasks = queryMemoryIndexSync(memoryDir, { type: ['task'], status: ['pending', 'in_progress'] });
+  let completed = 0;
+  for (const task of tasks) {
+    const payload = (task.payload ?? {}) as Record<string, unknown>;
+    const hold = payload.provider_resource_hold as Record<string, unknown> | undefined;
+    const resumeAt = typeof hold?.resumeAt === 'string' ? Date.parse(hold.resumeAt) : Number.NaN;
+    if (!Number.isFinite(resumeAt) || resumeAt > now.getTime()) continue;
+    const updated = await updateMemoryIndexEntry(memoryDir, task.id, {
+      status: 'completed',
+      payload: {
+        ...payload,
+        completed_by: 'autonomous-work-closure',
+        completed_reason: 'elapsed provider quota hold was already released and should not stay pending',
+        completed_at: now.toISOString(),
+      },
+    });
+    if (updated) completed++;
+  }
+  return completed;
 }
 
 async function reconcileProductRepairTasks(memoryDir: string, verifiers: ProductVerifierResult[], now: Date): Promise<{ queued: number; closed: number }> {

--- a/src/middleware-failure-self-healing.ts
+++ b/src/middleware-failure-self-healing.ts
@@ -410,6 +410,7 @@ async function ensureMiddlewareFailureFollowUpTask(
         failed_task_excerpt: String(task.task ?? '').slice(0, 500),
         acceptance_criteria: plan.acceptance,
         retry_envelope: plan.retryEnvelope,
+        priority: bucket === 'budget-or-quota' ? 1 : 0,
         createdAt: now.toISOString(),
       },
     });

--- a/src/stash-governance.ts
+++ b/src/stash-governance.ts
@@ -41,6 +41,7 @@ export interface StashGovernanceCase {
 export interface StashGovernanceResult {
   cases: StashGovernanceCase[];
   createdTasks: MemoryIndexEntry[];
+  closedTasks: MemoryIndexEntry[];
 }
 
 export async function governGitStashes(
@@ -57,11 +58,12 @@ export async function governGitStashes(
 ): Promise<StashGovernanceResult> {
   const stashes = opts.stashes ?? listGitStashes(repoRoot);
   const maxCases = opts.maxCases ?? 5;
-  const cases = stashes
+  const allCases = stashes
     .map(stash => classifyStash(stash, opts.reason))
-    .filter(c => c.decision !== 'ignore')
-    .slice(0, maxCases);
+    .filter(c => c.decision !== 'ignore');
+  const cases = allCases.slice(0, maxCases);
   const createdTasks: MemoryIndexEntry[] = [];
+  const closedTasks: MemoryIndexEntry[] = [];
   const absorbedDrops: string[] = [];
 
   if (opts.record || opts.createTasks) appendStashCases(memoryDir, cases);
@@ -77,6 +79,7 @@ export async function governGitStashes(
 
   if (opts.createTasks) {
     const { createTask } = await import('./memory-index.js');
+    closedTasks.push(...await closeObsoleteStashTasks(memoryDir, allCases));
     for (const diagnostic of cases) {
       if (!diagnostic.fallbackTask) continue;
       if (await hasActiveTaskForCase(memoryDir, diagnostic.id)) continue;
@@ -85,7 +88,7 @@ export async function governGitStashes(
           title: diagnostic.fallbackTask.title,
           origin: 'pipeline',
           status: 'pending',
-          priority: 0,
+          priority: 1,
           assignee: 'kuro',
           verify_command: diagnostic.fallbackTask.verifyCommand,
           acceptance_criteria: diagnostic.fallbackTask.acceptanceCriteria,
@@ -104,10 +107,10 @@ export async function governGitStashes(
   }
 
   if (cases.length > 0 && (opts.record || opts.createTasks)) {
-    slog('HOUSEKEEPING', `stash governance diagnosed ${cases.length} stash case(s); tasks=${createdTasks.length} absorbedDrops=${absorbedDrops.length}`);
+    slog('HOUSEKEEPING', `stash governance diagnosed ${cases.length} stash case(s); tasks=${createdTasks.length} closed=${closedTasks.length} absorbedDrops=${absorbedDrops.length}`);
   }
 
-  return { cases, createdTasks };
+  return { cases, createdTasks, closedTasks };
 }
 
 export function listGitStashes(repoRoot = process.cwd()): GitStashRecord[] {
@@ -239,6 +242,37 @@ async function hasActiveTaskForCase(memoryDir: string, caseId: string): Promise<
     const summary = task.summary ?? '';
     return payloadText.includes(caseId) || summary.includes(caseId);
   });
+}
+
+async function closeObsoleteStashTasks(
+  memoryDir: string,
+  currentCases: StashGovernanceCase[],
+): Promise<MemoryIndexEntry[]> {
+  const { queryMemoryIndexSync, updateMemoryIndexEntry } = await import('./memory-index.js');
+  const currentCaseIds = new Set(currentCases.map(c => c.id));
+  const active = queryMemoryIndexSync(memoryDir, { type: 'task' })
+    .filter(task => !['completed', 'abandoned', 'deleted', 'expired', 'resolved'].includes(String(task.status)));
+  const closed: MemoryIndexEntry[] = [];
+
+  for (const task of active) {
+    const text = `${task.summary ?? ''}\n${JSON.stringify(task.payload ?? {})}`;
+    const match = text.match(/\bstash-[a-f0-9]{12}\b/);
+    if (!match || currentCaseIds.has(match[0])) continue;
+
+    const updated = await updateMemoryIndexEntry(memoryDir, task.id, {
+      status: 'completed',
+      payload: {
+        ...((task.payload ?? {}) as Record<string, unknown>),
+        completed_by: 'stash-governance',
+        completed_reason: 'stash case is no longer present in current git stash inventory',
+        completed_at: new Date().toISOString(),
+        obsolete_stash_case: match[0],
+      },
+    });
+    if (updated) closed.push(updated);
+  }
+
+  return closed;
 }
 
 function appendStashCases(memoryDir: string, cases: StashGovernanceCase[]): void {

--- a/tests/autonomous-work-closure.test.ts
+++ b/tests/autonomous-work-closure.test.ts
@@ -52,7 +52,7 @@ describe('autonomous work closure', () => {
       }));
   });
 
-  it('completes emitted expression tasks and releases expired holds', async () => {
+  it('completes emitted expression tasks and releases non-provider expired holds back to pending', async () => {
     const now = new Date('2026-05-07T06:00:00.000Z');
     const expression = await appendMemoryIndexEntry(memoryDir, {
       type: 'task',
@@ -74,6 +74,66 @@ describe('autonomous work closure', () => {
     expect(result.releasedHolds).toBe(1);
     expect(queryMemoryIndexSync(memoryDir, { id: expression.id })[0].status).toBe('completed');
     expect(queryMemoryIndexSync(memoryDir, { id: hold.id })[0].status).toBe('pending');
+  });
+
+  it('completes elapsed provider quota holds instead of returning them to the P0 queue', async () => {
+    const now = new Date('2026-05-08T06:00:00.000Z');
+    const hold = await appendMemoryIndexEntry(memoryDir, {
+      type: 'task',
+      status: 'hold',
+      source: 'middleware-self-healing',
+      summary: 'Hold claude middleware delegation until provider quota resets',
+      payload: {
+        holdCondition: { type: 'date-after', value: '2026-05-08T05:00:00.000Z' },
+        provider_resource_hold: {
+          type: 'provider-quota',
+          provider: 'claude',
+          resumeAt: '2026-05-08T05:00:00.000Z',
+          reason: 'claude provider quota/resource exhausted; retry after 2026-05-08T05:00:00.000Z',
+        },
+      },
+    });
+
+    const result = await sweepAutonomousWorkClosure(memoryDir, { repoRoot, now });
+
+    expect(result.releasedHolds).toBe(1);
+    expect(result.completedElapsedProviderHolds).toBe(0);
+    expect(queryMemoryIndexSync(memoryDir, { id: hold.id })[0]).toEqual(expect.objectContaining({
+      status: 'completed',
+      payload: expect.objectContaining({
+        completed_by: 'autonomous-work-closure',
+        completed_reason: expect.stringContaining('should not return to the P0 queue'),
+      }),
+    }));
+  });
+
+  it('closes provider quota holds that were already released to pending', async () => {
+    const now = new Date('2026-05-08T06:00:00.000Z');
+    const hold = await appendMemoryIndexEntry(memoryDir, {
+      type: 'task',
+      status: 'pending',
+      source: 'middleware-self-healing',
+      summary: 'Hold claude middleware delegation until provider quota resets',
+      payload: {
+        provider_resource_hold: {
+          type: 'provider-quota',
+          provider: 'claude',
+          resumeAt: '2026-05-08T05:00:00.000Z',
+          reason: 'claude provider quota/resource exhausted; retry after 2026-05-08T05:00:00.000Z',
+        },
+        hold_released_by: 'autonomous-work-closure',
+      },
+    });
+
+    const result = await sweepAutonomousWorkClosure(memoryDir, { repoRoot, now });
+
+    expect(result.completedElapsedProviderHolds).toBe(1);
+    expect(queryMemoryIndexSync(memoryDir, { id: hold.id })[0]).toEqual(expect.objectContaining({
+      status: 'completed',
+      payload: expect.objectContaining({
+        completed_reason: expect.stringContaining('already released'),
+      }),
+    }));
   });
 
   it('deduplicates active held correction tasks instead of letting P0 holds accumulate', async () => {

--- a/tests/middleware-failure-self-healing.test.ts
+++ b/tests/middleware-failure-self-healing.test.ts
@@ -69,6 +69,7 @@ describe('middleware failure self-healing', () => {
       strategy: 'compressed-provider-resume',
       maxTurns: 6,
     }));
+    expect(fallbacks[0].payload?.priority).toBe(1);
 
     expect(readDelegationFailureRecordsSync(memoryDir)[0]).toEqual(expect.objectContaining({
       taskId: 'task-budget',

--- a/tests/stash-governance.test.ts
+++ b/tests/stash-governance.test.ts
@@ -69,10 +69,42 @@ describe('stash governance', () => {
     expect(tasks[0]).toEqual(expect.objectContaining({
       status: 'pending',
       summary: expect.stringContaining('regenerate ai-trend artifact'),
+      payload: expect.objectContaining({
+        priority: 1,
+      }),
     }));
     expect(tasks[0].payload).toEqual(expect.objectContaining({
       verify_command: expect.stringContaining('stash-governance.ts'),
       acceptance_criteria: expect.stringContaining('no generated HTML is manually merged'),
+    }));
+  });
+
+  it('closes active stash tasks when the underlying stash case disappears', async () => {
+    const memoryDir = path.join(tmpDir, 'memory');
+    mkdirSync(path.join(memoryDir, 'state'), { recursive: true });
+    mkdirSync(path.join(memoryDir, 'state', 'index'), { recursive: true });
+    writeFileSync(path.join(memoryDir, 'state', 'task-events.jsonl'), '', 'utf-8');
+    writeFileSync(path.join(memoryDir, 'state', 'index', 'relations.jsonl'), '', { encoding: 'utf-8', flag: 'w' });
+
+    const first = await governGitStashes(memoryDir, tmpDir, {
+      createTasks: true,
+      reason: 'test',
+      stashes: [aiTrendStash()],
+    });
+    const second = await governGitStashes(memoryDir, tmpDir, {
+      createTasks: true,
+      reason: 'test',
+      stashes: [],
+    });
+
+    expect(first.createdTasks).toHaveLength(1);
+    expect(second.closedTasks).toHaveLength(1);
+    expect(queryMemoryIndexSync(memoryDir, { id: first.createdTasks[0].id })[0]).toEqual(expect.objectContaining({
+      status: 'completed',
+      payload: expect.objectContaining({
+        completed_by: 'stash-governance',
+        completed_reason: expect.stringContaining('no longer present'),
+      }),
     }));
   });
 });


### PR DESCRIPTION
## Summary
- close active stash-governance tasks once the underlying stash case disappears
- keep stash backlog and provider-budget fallbacks out of P0 by assigning priority 1
- complete elapsed provider quota holds instead of returning them to pending P0 work

## Verification
- pnpm vitest run tests/stash-governance.test.ts tests/autonomous-work-closure.test.ts tests/middleware-failure-self-healing.test.ts
- pnpm typecheck
- pnpm build

## Runtime evidence
- downgraded existing active stash governance tasks from P0 to P1
- completed 2 elapsed provider hold tasks
- active P0 queue is now limited to AI Trend product work