### PR TITLE
fix(tasks): keep pipeline backlog below P0

### DIFF
--- a/src/memory-index.ts
+++ b/src/memory-index.ts
@@ -1068,8 +1068,11 @@ export async function incrementTaskStaleness(
     }
 
     const payload = (task.payload ?? {}) as Record<string, unknown>;
-    // Pipeline tasks AND pipeline goals are exempt from staleness
-    if (payload.goal_id || (task.type === 'goal' && payload.origin === 'pipeline')) continue;
+    // Pipeline goals are exempt from staleness. Pipeline tasks still get ticked
+    // and eventually auto-abandoned, but they are backlog/recovery work and must
+    // not be promoted to P0 by age alone.
+    const isPipelineBacklog = payload.origin === 'pipeline';
+    if (payload.goal_id || (task.type === 'goal' && isPipelineBacklog)) continue;
     const currentTicks = (payload.ticksSinceLastProgress as number) ?? 0;
     const newTicks = currentTicks + 1;
 
@@ -1088,7 +1091,7 @@ export async function incrementTaskStaleness(
     // by external syncs (issue-autopilot, github-issue) writing the original
     // priority back between cycles, only to be clobbered to 0 again here.
     const alreadyEscalated = !!payload.escalated_at;
-    const shouldEscalateNow = newTicks > 5 && !alreadyEscalated;
+    const shouldEscalateNow = newTicks > 5 && !alreadyEscalated && !isPipelineBacklog;
 
     const updatedPayload: Record<string, unknown> = {
       ...payload,

--- a/tests/staleness-escalation-idempotency.test.ts
+++ b/tests/staleness-escalation-idempotency.test.ts
@@ -119,4 +119,26 @@ describe('issue #156 — staleness escalation idempotency', () => {
     // Priority stays at 2 — no oscillation.
     expect((getTask(e.id).payload as Record<string, unknown>).priority).toBe(2);
   });
+
+  it('does not promote pipeline backlog tasks to P0 by staleness alone', async () => {
+    const e = await appendMemoryIndexEntry(tmpDir, {
+      type: 'task',
+      status: 'pending',
+      summary: 'stash-backlog diagnostic',
+      payload: { origin: 'pipeline', priority: 1 },
+    });
+
+    const stale = await bumpTicks(tmpDir, 6);
+
+    const found = stale.find(s => s.id === e.id);
+    expect(found).toEqual(expect.objectContaining({
+      id: e.id,
+      firstEscalation: false,
+    }));
+    expect(getTask(e.id).payload).toEqual(expect.objectContaining({
+      priority: 1,
+      ticksSinceLastProgress: 6,
+    }));
+    expect((getTask(e.id).payload as Record<string, unknown>).escalated_at).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary
- prevent staleness escalation from promoting pipeline backlog/recovery tasks to P0
- still tick pipeline tasks so stale backlog can auto-abandon normally
- add regression coverage for stash/backlog-style pipeline tasks

## Verification
- pnpm vitest run tests/staleness-escalation-idempotency.test.ts tests/scheduler-phantom-guard.test.ts
- pnpm typecheck
- pnpm build