### PR TITLE
fix(error-patterns): add ship-aware resolution markers

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "skill-promotion:autopilot": "tsx scripts/skill-promotion-autopilot.ts",
     "check:autonomy-closure": "tsx scripts/autonomy-closure-health.ts",
     "check:test-health": "tsx scripts/test-health-autopilot.ts",
+    "error-patterns:resolve": "tsx scripts/error-patterns-resolve.ts",
     "setup": "pnpm install && pnpm build && npm link",
     "prepare": "git config core.hooksPath .githooks 2>/dev/null || true",
     "check:pr-lifecycle": "tsx scripts/check-pr-lifecycle.ts",

--- a/scripts/error-patterns-resolve.ts
+++ b/scripts/error-patterns-resolve.ts
@@ -1,0 +1,68 @@
+#!/usr/bin/env tsx
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { getMemoryStateDir } from '../src/memory.js';
+
+type ErrorPattern = {
+  count: number;
+  taskCreated: boolean;
+  lastSeen: string;
+  lastMessage?: string;
+  resolved?: boolean;
+  resolvedAt?: string;
+  resolvedBy?: string;
+};
+
+function usage(): never {
+  process.stderr.write('usage: pnpm error-patterns:resolve <key> --commit <sha-or-url> [--at <iso>] [--json]\n');
+  process.exit(2);
+}
+
+function parseArgs(argv: string[]): { key: string; commit: string; at: string; json: boolean } {
+  const json = argv.includes('--json');
+  const positional: string[] = [];
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--commit' || arg === '--at') {
+      i += 1;
+      continue;
+    }
+    if (!arg.startsWith('--')) positional.push(arg);
+  }
+  const key = positional[0];
+  const commitIdx = argv.indexOf('--commit');
+  const atIdx = argv.indexOf('--at');
+  const commit = commitIdx >= 0 ? argv[commitIdx + 1] : '';
+  const at = atIdx >= 0 ? argv[atIdx + 1] : new Date().toISOString();
+  if (!key || !commit || !Number.isFinite(Date.parse(at))) usage();
+  return { key, commit, at, json };
+}
+
+const { key, commit, at, json } = parseArgs(process.argv.slice(2));
+const stateDir = getMemoryStateDir();
+const statePath = path.join(stateDir, 'error-patterns.json');
+const state: Record<string, ErrorPattern> = existsSync(statePath)
+  ? JSON.parse(readFileSync(statePath, 'utf-8'))
+  : {};
+
+if (!state[key]) {
+  process.stderr.write(`error-pattern not found: ${key}\n`);
+  process.exit(1);
+}
+
+state[key] = {
+  ...state[key],
+  resolvedAt: at,
+  resolvedBy: commit,
+};
+
+mkdirSync(stateDir, { recursive: true });
+writeFileSync(statePath, `${JSON.stringify(state, null, 2)}\n`, 'utf-8');
+
+const result = { key, resolvedAt: at, resolvedBy: commit };
+if (json) {
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+} else {
+  process.stdout.write(`resolved ${key} at ${at} by ${commit}\n`);
+}

--- a/src/feedback-loops.ts
+++ b/src/feedback-loops.ts
@@ -29,6 +29,8 @@ interface ErrorPatternState {
     taskCreated: boolean;
     lastSeen: string;
     lastMessage?: string;
+    resolvedAt?: string;
+    resolvedBy?: string;
   };
 }
 

--- a/src/prompt-builder.ts
+++ b/src/prompt-builder.ts
@@ -428,21 +428,40 @@ function buildDelegationReviewGate(): string {
  *  Exported for unit testing — production callers should still go through buildAutonomousPrompt. */
 export function buildErrorPatternsHint(): string {
   try {
-    const patterns = readState<Record<string, { count: number; taskCreated: boolean; lastSeen: string; resolved?: boolean }>>('error-patterns.json', {});
+    const patterns = readState<Record<string, {
+      count: number;
+      taskCreated: boolean;
+      lastSeen: string;
+      resolved?: boolean;
+      resolvedAt?: string;
+      resolvedBy?: string;
+    }>>('error-patterns.json', {});
     const STALE_MS = 7 * 24 * 60 * 60 * 1000;
+    const RESOLVED_GRACE_MS = 24 * 60 * 60 * 1000;
     const cutoff = Date.now() - STALE_MS;
     const actionable = Object.entries(patterns)
-      .filter(([, v]) => {
+      .map(([key, v]) => {
         if (v.count < 3 || v.resolved) return false;
         const ts = Date.parse(v.lastSeen);
-        return Number.isFinite(ts) && ts >= cutoff;
+        if (!Number.isFinite(ts) || ts < cutoff) return false;
+        if (!v.resolvedAt) return [key, v, false] as const;
+
+        const resolvedTs = Date.parse(v.resolvedAt);
+        if (!Number.isFinite(resolvedTs)) return [key, v, false] as const;
+
+        const lastSeenTs = /^\d{4}-\d{2}-\d{2}$/.test(v.lastSeen)
+          ? Date.parse(`${v.lastSeen}T23:59:59.999Z`)
+          : ts;
+        const isRegression = lastSeenTs > resolvedTs + RESOLVED_GRACE_MS;
+        return isRegression ? ([key, v, true] as const) : false;
       })
+      .filter((entry): entry is readonly [string, { count: number; taskCreated: boolean; lastSeen: string; resolved?: boolean; resolvedAt?: string; resolvedBy?: string }, boolean] => Boolean(entry))
       .sort(([, a], [, b]) => b.count - a.count)
       .slice(0, 5);
     if (actionable.length === 0) return '';
 
-    const lines = actionable.map(([key, v]) =>
-      `- **${key}** — ${v.count}× (last: ${v.lastSeen}). Same root cause, or different problem wearing the same mask?`);
+    const lines = actionable.map(([key, v, isRegression]) =>
+      `- **${isRegression ? '[REGRESSION] ' : ''}${key}** — ${v.count}× (last: ${v.lastSeen}). Same root cause, or different problem wearing the same mask?`);
     return `## Recurring Errors\n${lines.join('\n')}`;
   } catch { return ''; }
 }

--- a/tests/prompt-builder-error-patterns-hint.test.ts
+++ b/tests/prompt-builder-error-patterns-hint.test.ts
@@ -9,6 +9,8 @@ type Pattern = {
   taskCreated: boolean;
   lastSeen: string;
   resolved?: boolean;
+  resolvedAt?: string;
+  resolvedBy?: string;
 };
 
 const state: { patterns: Record<string, Pattern> } = { patterns: {} };
@@ -112,5 +114,32 @@ describe('buildErrorPatternsHint — issue #315 staleness filter', () => {
       },
     };
     expect(buildErrorPatternsHint()).toBe('');
+  });
+
+  it('omits ship-resolved entries inside the 1 day grace window', () => {
+    state.patterns = {
+      'UNKNOWN:transient_fast_band::callClaude': {
+        count: 9,
+        taskCreated: false,
+        lastSeen: '2026-05-08',
+        resolvedAt: '2026-05-08T02:47:00.000Z',
+        resolvedBy: 'fdfc60b6',
+      },
+    };
+    expect(buildErrorPatternsHint()).toBe('');
+  });
+
+  it('surfaces ship-resolved entries as regressions after the grace window', () => {
+    state.patterns = {
+      'UNKNOWN:transient_fast_band::callClaude': {
+        count: 9,
+        taskCreated: false,
+        lastSeen: '2026-05-10',
+        resolvedAt: '2026-05-08T02:47:00.000Z',
+        resolvedBy: 'fdfc60b6',
+      },
+    };
+    const out = buildErrorPatternsHint();
+    expect(out).toContain('[REGRESSION] UNKNOWN:transient_fast_band::callClaude');
   });
 });


### PR DESCRIPTION
## Summary\n- add resolvedAt/resolvedBy metadata for recurring error patterns\n- add an error-patterns:resolve CLI for explicit ship reconciliation\n- hide ship-resolved patterns inside a 1 day grace window and surface later recurrences as [REGRESSION]\n\nFixes #346\n\n## Verification\n- pnpm vitest run tests/prompt-builder-error-patterns-hint.test.ts\n- pnpm typecheck\n- pnpm build