### PR TITLE
fix(closure): queue operational efficiency repairs

### DIFF
--- a/src/autonomy-closure-health.ts
+++ b/src/autonomy-closure-health.ts
@@ -154,8 +154,6 @@ export async function ensureAutonomyClosureTask(
     return null;
   }
 
-  if (snapshot.correction.needsCorrection) return null;
-
   const existing = queryMemoryIndexSync(memoryDir, {
     type: ['task'],
     status: ACTIVE_STATUSES,
@@ -163,6 +161,10 @@ export async function ensureAutonomyClosureTask(
 
   const recommendation = snapshot.recommendedTask;
   if (!recommendation) return null;
+
+  if (snapshot.correction.needsCorrection && !recommendation.title.includes('operational-efficiency')) {
+    return null;
+  }
 
   if (existing) {
     const existingPayload = (existing.payload ?? {}) as Record<string, unknown>;

--- a/tests/autonomy-closure-health.test.ts
+++ b/tests/autonomy-closure-health.test.ts
@@ -40,7 +40,7 @@ describe('autonomy closure health', () => {
     expect(snapshot.stages.map(s => s.stage)).toContain('memory-context');
   });
 
-  it('degrades on correction advisories so healthy does not hide low-efficiency loops', () => {
+  it('degrades and queues operational-efficiency repair when correction advisories are the remaining closure gap', async () => {
     writeFileSync(
       path.join(tmpDir, 'state/task-events.jsonl'),
       JSON.stringify({
@@ -68,6 +68,10 @@ describe('autonomy closure health', () => {
       status: 'warn',
       summary: expect.stringContaining('efficiency signal'),
     }));
+
+    const task = await ensureAutonomyClosureTask(tmpDir, snapshot);
+    expect(task?.summary).toBe('P1 autonomy closure: repair operational-efficiency');
+    expect(task?.payload?.closure_status).toBe('degraded');
   });
 
   it('creates one repair task for exhausted autonomous execution', async () => {


### PR DESCRIPTION
## Summary\n- allow autonomy closure to queue operational-efficiency repair tasks even when correction advisories are active\n- add regression coverage that the remaining efficiency gap becomes an actual P1 closure task\n\n## Verification\n- pnpm vitest run tests/autonomy-closure-health.test.ts\n- pnpm typecheck