### PR TITLE
fix(middleware): sweep failed delegations every cycle

### DIFF
--- a/src/housekeeping.ts
+++ b/src/housekeeping.ts
@@ -749,14 +749,17 @@ export async function runHousekeeping(): Promise<void> {
     slog('MEMORY-SNAPSHOT', `snapshot skipped: ${err instanceof Error ? err.message : String(err)}`);
   });
 
+  // User-visible delegation failures should converge quickly; the sweep is
+  // idempotent for already-classified failures and only writes on transitions.
+  await sweepMiddlewareFailures(getMemoryRootDir(), { workdir: process.cwd() }).catch(err => {
+    slog('MIDDLEWARE-SELF-HEAL', `sweep skipped: ${err instanceof Error ? err.message : String(err)}`);
+  });
+
   // KG auto-ingest: check every 5 cycles if enough new writes have accumulated
   if (cycleCounter % 5 === 0) {
     dispatchKGIngestIfNeeded();
     await reconcileMiddlewareCommitmentsSafe().catch(err => {
       slog('MIDDLEWARE-TRUTH', `reconcile skipped: ${err instanceof Error ? err.message : String(err)}`);
-    });
-    await sweepMiddlewareFailures(getMemoryRootDir(), { workdir: process.cwd() }).catch(err => {
-      slog('MIDDLEWARE-SELF-HEAL', `sweep skipped: ${err instanceof Error ? err.message : String(err)}`);
     });
     await sweepKgDiscussionLifecycle(getMemoryRootDir()).catch(err => {
       slog('KG-DISCUSSION-JANITOR', `sweep skipped: ${err instanceof Error ? err.message : String(err)}`);


### PR DESCRIPTION
## Summary
- run middleware failure self-healing on every housekeeping cycle
- keep heavier KG ingest and KG discussion janitor work on the existing 5-cycle cadence
- reduces dashboard/closure lag for stale delegation failures without changing classifier behavior

## Root cause
Middleware itself was healthy, but failed delegated tasks could remain visible until the 5-cycle housekeeping gate ran `sweepMiddlewareFailures()`. That made the dashboard look stuck even after failures were classifiable or recovered.

## Verification
- `pnpm vitest run tests/middleware-failure-self-healing.test.ts tests/middleware-quality-health.test.ts`
- `pnpm typecheck`
- `pnpm test`