### PR TITLE
fix(feedback-loops): add 4th typed-failure class silent_exit_void_midprompt (#370)

### DIFF
--- a/src/feedback-loops.ts
+++ b/src/feedback-loops.ts
@@ -206,10 +206,14 @@ export function extractErrorSubtype(errorMsg: string): string {
     if (lower.includes('auth') || lower.includes('unauthorized') || lower.includes('401')) return 'silent_exit_auth';
     if (lower.includes('overloaded') || lower.includes('529')) return 'silent_exit_overload';
     if (lower.includes('stdout=empty')) {
-      // 2026-05-07 (Issue #233): silent_exit_void now has >= 3 distinct failure classes.
-      //   - #191 HTTP-stall class: ~970-1007s, prompt 13-16K => already non-retryable in classifyError
-      //   - #77 baseline class:    ~260s, prompt 22-25K => retryable
-      //   - #233 new class:        ~357s, prompt >= 35K  => prompt bloat causing first-token stall
+      // 2026-05-08 (Issue #370 + arxiv 2605.05724 4-class typed-failure schema):
+      // silent_exit_void splits into 4 typed failure classes. Each class needs its own
+      // recovery recipe (paper's "lineage feedback on typed failures" insight — typed
+      // labels that drive different recipe edits, not collapse into one opaque bucket):
+      //   - #191 HTTP-stall:       ~970-1007s, prompt 13-16K  => budget-overrun (non-retryable)
+      //   - #233 prompt-bloat:     ~357s,      prompt >= 35K  => size-fail      (pre-flight drained)
+      //   - #370 midprompt-stall:  ~300-799s,  prompt 20-35K  => first-token stall (NEW bucket)
+      //   - #77  baseline:         ~260s,      prompt 22-25K  => crash-class    (retryable)
       //
       // Bucket by promptChars extracted from the logged error message
       // (format: "prompt NNN chars" from agent.ts:2010 logger call).
@@ -217,8 +221,9 @@ export function extractErrorSubtype(errorMsg: string): string {
       // P1 task instead of all collapsing to TIMEOUT:silent_exit_void::callClaude.
       //
       // Duration band also extracted where present:
-      //   >=800s => silent_exit_void_http  (HTTP-stall / #191 class, non-retryable server hold)
+      //   >=800s => silent_exit_void_http        (HTTP-stall / #191 class, non-retryable server hold)
       //   <800s + >=35K chars => silent_exit_void_40k  (prompt-bloat stall / #233 new class)
+      //   <800s + 20-35K chars + >=300s => silent_exit_void_midprompt  (#370 first-token stall)
       //   <800s + <35K chars => silent_exit_void        (CLI internal hang / #77 baseline)
       const promptMatch = /prompt (\d+) chars/.exec(errorMsg);
       const promptChars = promptMatch ? Number(promptMatch[1]) : 0;
@@ -230,6 +235,13 @@ export function extractErrorSubtype(errorMsg: string): string {
       const totalMs = durationMs || durSec * 1000;
       if (totalMs >= 800_000) return 'silent_exit_void_http';
       if (promptChars >= 35_000) return 'silent_exit_void_40k';
+      // Issue #370 (2026-05-08): 24K-prompt @ ~365s cluster (count=10 on instance 03bbc29a).
+      // Distinct from #77 baseline (~260s) — the longer 300-800s duration band with mid-size
+      // prompt (20K-35K) signals a first-token stall pattern, not the CLI internal hang.
+      // Separating gives this class its own error-patterns key so recovery (e.g. lower
+      // pre-flight drain threshold from 35K to 20K conditional on >=300s history) can be tuned
+      // independently without affecting #77 baseline retry behavior.
+      if (promptChars >= 20_000 && totalMs >= 300_000) return 'silent_exit_void_midprompt';
       return 'silent_exit_void';
     }
     return 'silent_exit';

--- a/tests/extract-error-subtype.test.ts
+++ b/tests/extract-error-subtype.test.ts
@@ -36,3 +36,40 @@ describe('extractErrorSubtype — transient band split (#318)', () => {
     expect(extractErrorSubtype(msg)).toBe('no_diag');
   });
 });
+
+describe('extractErrorSubtype — silent_exit_void 4-class typed-failure schema (#370 + arxiv 2605.05724)', () => {
+  // Format from agent.ts:249 + extractErrorSubtype regex:
+  //   "CLI 靜默中斷（exit N/A，{durSec}s 無 stderr）. stdout=empty"
+  //   plus appended " prompt {N} chars" so promptMatch picks it up.
+  const mkSilentMsg = (durSec: number, promptChars: number) =>
+    `CLI 靜默中斷（exit N/A，${durSec}s 無 stderr）. stdout=empty prompt ${promptChars} chars`;
+
+  it('routes >=800s HTTP-stall to silent_exit_void_http (#191 budget-overrun class)', () => {
+    expect(extractErrorSubtype(mkSilentMsg(970, 14000))).toBe('silent_exit_void_http');
+    expect(extractErrorSubtype(mkSilentMsg(1007, 16000))).toBe('silent_exit_void_http');
+  });
+
+  it('routes >=35K prompt to silent_exit_void_40k (#233 size-fail class)', () => {
+    expect(extractErrorSubtype(mkSilentMsg(357, 35000))).toBe('silent_exit_void_40k');
+    expect(extractErrorSubtype(mkSilentMsg(450, 42000))).toBe('silent_exit_void_40k');
+  });
+
+  it('routes 20-35K prompt + 300-799s duration to silent_exit_void_midprompt (#370 first-token stall)', () => {
+    // Observed cluster: 24K @ 365s, count=10 on instance 03bbc29a 2026-05-08
+    expect(extractErrorSubtype(mkSilentMsg(365, 24419))).toBe('silent_exit_void_midprompt');
+    expect(extractErrorSubtype(mkSilentMsg(300, 20000))).toBe('silent_exit_void_midprompt');
+    expect(extractErrorSubtype(mkSilentMsg(799, 34999))).toBe('silent_exit_void_midprompt');
+  });
+
+  it('keeps short-duration mid-size cluster on silent_exit_void baseline (#77 crash-class)', () => {
+    // #77 baseline: prompt 22-25K @ ~260s — must NOT promote to midprompt
+    expect(extractErrorSubtype(mkSilentMsg(260, 22000))).toBe('silent_exit_void');
+    expect(extractErrorSubtype(mkSilentMsg(260, 25000))).toBe('silent_exit_void');
+    expect(extractErrorSubtype(mkSilentMsg(299, 24000))).toBe('silent_exit_void');
+  });
+
+  it('keeps tiny-prompt cases on silent_exit_void baseline regardless of duration', () => {
+    expect(extractErrorSubtype(mkSilentMsg(500, 10000))).toBe('silent_exit_void');
+    expect(extractErrorSubtype(mkSilentMsg(150, 5000))).toBe('silent_exit_void');
+  });
+});


### PR DESCRIPTION
## Summary
- Translates 4-class typed-failure schema from arxiv 2605.05724 ("Auto Research with Specialist Agents") into `extractErrorSubtype`
- New bucket `silent_exit_void_midprompt` for the 24K-prompt @ ~365s cluster (count=10 on instance 03bbc29a, 2026-05-08) that currently mis-buckets into the #77 baseline despite 1.4x longer duration
- 5 new regression tests covering all 4 classes + boundary cases

## Why
HEARTBEAT P1 silent_exit_void: the 5a9d35eb pre-flight drain gates at >=35K so this 20-35K mid-prompt cluster gets no protection. Paper insight: typed failure labels should drive different recovery recipes per class, not collapse into one opaque bucket.

Mapping:
- #191 HTTP-stall → budget-overrun (>=800s, non-retryable)
- #233 prompt-bloat → size-fail (>=35K, pre-flight drained)
- **#370 midprompt-stall → first-token stall (NEW: 20-35K + 300-799s)**
- #77 baseline → crash-class (~260s @ 22-25K, retryable)

Splitting gives this cluster its own error-patterns key so recovery (e.g. lower drain threshold to 20K conditional on >=300s history) can tune independently.

## Verification
- [x] `npx vitest run tests/extract-error-subtype.test.ts` — 10/10 pass (5 original + 5 new)
- [ ] After merge: monitor error-patterns.json for `silent_exit_void_midprompt` key emerging within 1-2 days; baseline `silent_exit_void` count should drop by ~10
- [ ] Falsifier: if midprompt count never appears (always 0), the bucket boundary is wrong — re-tune

🤖 Authored by Kuro