### PR TITLE
fix(dashboard): show only actionable delegation failures

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -3157,7 +3157,7 @@ async function fetchAll() {
       fetch(API + '/api/perception-streams').catch(() => null),
       fetch(API + '/api/activity?limit=30').catch(() => null),
       fetch(API + '/api/brain/runs?view=state&limit=30').catch(() => null),
-      fetch(API + '/api/delegation-failures?status=open,diagnosing,needs_human').catch(() => null),
+      fetch(API + '/api/delegation-failures?status=open,diagnosing,needs_human&guard=true').catch(() => null),
       fetch(API + '/api/myelin/status?window=500').catch(() => null),
     ]);
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -168,6 +168,7 @@ import { createDefaultMiddlewareProviders } from './middleware-provider.js';
 import { createDefaultMiddlewarePeers } from './middleware-peer-agent.js';
 import { getCachedBrainHealthSnapshot, isBrainRuntimeDelegationEnabled, refreshBrainHealth } from './brain-health.js';
 import {
+  isActionableDelegationFailure,
   isDelegationFailureStatus,
   readDelegationFailureRecordsSync,
   transitionDelegationFailureStatus,
@@ -1947,8 +1948,10 @@ export function createApi(port = 3001): express.Express {
     try {
       const memDir = getMemoryRootDir();
       const statuses = queryList(req.query.status).filter(isDelegationFailureStatus);
+      const guardOnly = String(req.query.guard ?? '').toLowerCase() === 'true';
       let failures = readDelegationFailureRecordsSync(memDir);
       if (statuses.length > 0) failures = failures.filter(failure => statuses.includes(failure.status));
+      if (guardOnly) failures = failures.filter(isActionableDelegationFailure);
       res.json({ failures, total: failures.length });
     } catch (err) {
       res.status(500).json({ error: String(err) });

--- a/src/delegation-failure-guard.ts
+++ b/src/delegation-failure-guard.ts
@@ -224,6 +224,13 @@ export function isDelegationFailureStatus(value: unknown): value is DelegationFa
     && ['open', 'diagnosing', 'resolved', 'ignored', 'needs_human'].includes(value);
 }
 
+export function isActionableDelegationFailure(record: DelegationFailureRecord): boolean {
+  return record.frequency >= REPEAT_THRESHOLD
+    || record.status === 'diagnosing'
+    || record.status === 'needs_human'
+    || Boolean(record.diagnosticTaskId);
+}
+
 function shouldReopen(status: DelegationFailureStatus): boolean {
   return status === 'resolved' || status === 'ignored';
 }

--- a/tests/delegation-failure-guard.test.ts
+++ b/tests/delegation-failure-guard.test.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   getDelegationFailureGuardPath,
+  isActionableDelegationFailure,
   markDelegationFailureDiagnosticCreated,
   readDelegationFailureRecordsSync,
   recordDelegationFailure,
@@ -48,6 +49,28 @@ describe('delegation failure guard', () => {
         status: 'open',
       }),
     ]);
+  });
+
+  it('keeps one-off telemetry out of the actionable guard view', () => {
+    const first = recordDelegationFailure(tmpDir, {
+      taskId: 'del-111-a',
+      taskType: 'code',
+      prompt: 'Try one delegated code task',
+      output: 'task task-123 failed: Claude Code returned an error result: Reached maximum number of turns (15)',
+    });
+
+    expect(first.record.frequency).toBe(1);
+    expect(isActionableDelegationFailure(first.record)).toBe(false);
+
+    const second = recordDelegationFailure(tmpDir, {
+      taskId: 'del-222-b',
+      taskType: 'code',
+      prompt: 'Try one delegated code task',
+      output: 'task task-456 failed: Claude Code returned an error result: Reached maximum number of turns (15)',
+    });
+
+    expect(second.record.frequency).toBe(2);
+    expect(isActionableDelegationFailure(second.record)).toBe(true);
   });
 
   it('does not request duplicate diagnostic tasks after one is linked', () => {


### PR DESCRIPTION
## Summary
- add an actionable delegation-failure predicate
- let `/api/delegation-failures` support `guard=true` for guard/dashboard views
- update dashboard to hide one-off telemetry failures from the red Delegation Failure Guard section

## Root cause
The middleware self-healing path was already classifying terminal task failures, but the dashboard queried all `open` delegation failure records. Single provider failures with `frequency=1` were being rendered like repeated guard failures.

## Verification
- `pnpm vitest run tests/delegation-failure-guard.test.ts tests/delegation-failure-diagnostics.test.ts`
- `pnpm typecheck`
- `pnpm test`