### PR TITLE
fix(delegation): diagnose repeated open failures

### DIFF
--- a/src/delegation-failure-diagnostics.ts
+++ b/src/delegation-failure-diagnostics.ts
@@ -23,7 +23,7 @@ export interface DelegationFailureDiagnosis {
   signature: string;
   code: string;
   status: DelegationFailureStatus;
-  category: 'missing_environment' | 'provider_quota' | 'shell_prompt_injection' | 'command_failed' | 'middleware_failed' | 'unknown';
+  category: 'missing_environment' | 'provider_quota' | 'max_turns' | 'shell_prompt_injection' | 'command_failed' | 'middleware_failed' | 'unknown';
   summary: string;
   recommendedAction: string;
   reportPath: string;
@@ -80,7 +80,10 @@ export async function diagnosePendingDelegationFailures(
   limit = 5,
 ): Promise<DelegationFailureDiagnosis[]> {
   const failures = readDelegationFailureRecordsSync(memoryDir)
-    .filter(failure => failure.status === 'diagnosing' && Boolean(failure.diagnosticTaskId))
+    .filter(failure =>
+      (failure.status === 'diagnosing' && Boolean(failure.diagnosticTaskId))
+      || (failure.status === 'open' && failure.frequency >= 2)
+    )
     .slice(0, limit);
   const results: DelegationFailureDiagnosis[] = [];
   for (const failure of failures) {
@@ -115,6 +118,18 @@ function buildDiagnosis(memoryDir: string, record: DelegationFailureRecord): Del
       category: 'provider_quota',
       summary: 'The repeated failure is provider quota/resource exhaustion, not a task defect.',
       recommendedAction: 'Hold the origin task with a date-after provider resource condition and retry after reset.',
+      reportPath,
+    };
+  }
+
+  if (/maximum number of turns|reached max(?:imum)? turns|max turns/.test(lower)) {
+    return {
+      signature: record.signature,
+      code,
+      status: 'resolved',
+      category: 'max_turns',
+      summary: 'The repeated failure is a provider turn-budget exhaustion pattern, usually caused by an oversized delegated task.',
+      recommendedAction: 'Do not retry the same prompt unchanged; split the origin task into smaller probes or implementation slices.',
       reportPath,
     };
   }

--- a/tests/delegation-failure-diagnostics.test.ts
+++ b/tests/delegation-failure-diagnostics.test.ts
@@ -108,6 +108,58 @@ describe('delegation failure diagnostics', () => {
     }));
   });
 
+  it('classifies repeated open max-turn failures without waiting for a linked diagnostic task', async () => {
+    recordDelegationFailure(tmpDir, {
+      taskId: 'del-1',
+      taskType: 'code',
+      prompt: 'Run oversized implementation task',
+      output: 'Claude Code returned an error result: Reached maximum number of turns (15)',
+    });
+    const second = recordDelegationFailure(tmpDir, {
+      taskId: 'del-2',
+      taskType: 'code',
+      prompt: 'Run oversized implementation task',
+      output: 'Claude Code returned an error result: Reached maximum number of turns (15)',
+    });
+
+    const diagnoses = await diagnosePendingDelegationFailures(tmpDir);
+
+    expect(second.record.frequency).toBe(2);
+    expect(diagnoses).toHaveLength(1);
+    expect(diagnoses[0]).toEqual(expect.objectContaining({
+      status: 'resolved',
+      category: 'max_turns',
+      taskId: undefined,
+    }));
+    expect(readDelegationFailureRecordsSync(tmpDir)[0]).toEqual(expect.objectContaining({
+      status: 'resolved',
+    }));
+  });
+
+  it('picks up repeated open records when diagnosing pending failures', async () => {
+    recordDelegationFailure(tmpDir, {
+      taskId: 'del-1',
+      taskType: 'code',
+      prompt: 'Run provider task',
+      output: "Claude Code returned an error result: You're out of extra usage · resets 2:40am (Asia/Taipei)",
+    });
+    recordDelegationFailure(tmpDir, {
+      taskId: 'del-2',
+      taskType: 'code',
+      prompt: 'Run provider task',
+      output: "Claude Code returned an error result: You're out of extra usage · resets 2:40am (Asia/Taipei)",
+    });
+
+    const diagnoses = await diagnosePendingDelegationFailures(tmpDir);
+
+    expect(diagnoses).toEqual([
+      expect.objectContaining({
+        status: 'resolved',
+        category: 'provider_quota',
+      }),
+    ]);
+  });
+
   it('diagnoses pending linked failures in batches', async () => {
     const first = recordDelegationFailure(tmpDir, {
       taskId: 'del-1',


### PR DESCRIPTION
## Summary
- diagnose repeated `open` delegation failures even when no diagnostic task was linked yet
- classify max-turn failures as an oversized-task/decomposition pattern
- keep provider quota and max-turn repeated failures from lingering indefinitely in the guard view

## Root cause
Historical or raced repeated failures could remain `open` with frequency >= 2 but no `diagnosticTaskId`; `diagnose-pending` only scanned `diagnosing` records with a linked diagnostic task.

## Verification
- `pnpm vitest run tests/delegation-failure-diagnostics.test.ts tests/delegation-failure-guard.test.ts`
- `pnpm typecheck`
- `pnpm test`