### PR TITLE
fix(classifier): split budget_exceeded + user_abort from silent_exit_void (#370)

### DIFF
--- a/src/feedback-loops.ts
+++ b/src/feedback-loops.ts
@@ -200,6 +200,20 @@ export function extractErrorSubtype(errorMsg: string): string {
     if (lower.includes('dur=unknown')) return 'unknown_dur_no_diag';
     return 'no_diag';
   }
+  // 2026-05-08 (Issue #370): non-retryable terminal CLI exits whose stderr text identifies
+  // a hard cap (budget / max-turns / user-abort) — must be classified BEFORE the silent_exit
+  // branch below, otherwise events with stderr like "Reached maximum budget ($5)" or
+  // "Claude Code process aborted by user" land in silent_exit_void due to fall-through paths
+  // that strip stderr from the renderer message but leave 靜默中斷 intact. Splitting these out:
+  //   - drains false silent_exit_void counts (#370 forensic: 6/10 events were budget-cap)
+  //   - surfaces budget-cap / abort frequency as their own metrics
+  //   - restores silent_exit_void to mean only genuine CLI-internal hangs (#77 baseline)
+  // Routes max_turns is already handled at line 155, but mirror it here for defense-in-depth
+  // when the upstream message gets reformatted to lose the original "maximum number of turns"
+  // string. All three are non-retryable terminations.
+  if (lower.includes('reached maximum budget') || lower.includes('maximum budget ($')) return 'budget_exceeded';
+  if (lower.includes('aborted by user') || lower.includes('process aborted')) return 'user_abort';
+
   // 2026-04-20: agent.ts:224 silent_exit message template (shipped 3039f4a3) — complete the label
   // chain so TIMEOUT:generic fallthrough becomes TIMEOUT:silent_exit in recurring-errors.
   if (lower.includes('靜默中斷') || lower.includes('靜默溢位') || lower.includes('silent exit')) {

--- a/tests/extract-error-subtype.test.ts
+++ b/tests/extract-error-subtype.test.ts
@@ -73,3 +73,29 @@ describe('extractErrorSubtype — silent_exit_void 4-class typed-failure schema 
     expect(extractErrorSubtype(mkSilentMsg(150, 5000))).toBe('silent_exit_void');
   });
 });
+
+describe('extractErrorSubtype — non-retryable terminal exits (#370)', () => {
+  // These messages come through agent.ts:258 stderr fallback path:
+  //   "Claude CLI 執行失敗（exit N/A）：Reached maximum budget ($5)"
+  // They previously fell through past silent_exit (no 靜默中斷 keyword) to 'generic',
+  // OR — when reformatted by upstream telemetry to inject 靜默中斷 — landed in
+  // silent_exit_void incorrectly. New branches catch the keyword text directly.
+
+  it('classifies "Reached maximum budget" as budget_exceeded', () => {
+    expect(extractErrorSubtype('Claude CLI 執行失敗（exit N/A）：Reached maximum budget ($5)')).toBe('budget_exceeded');
+    expect(extractErrorSubtype('CLI 靜默中斷（exit N/A，365s 無 stderr）. stdout=empty Reached maximum budget')).toBe('budget_exceeded');
+  });
+
+  it('classifies "aborted by user" as user_abort', () => {
+    expect(extractErrorSubtype('Claude Code process aborted by user')).toBe('user_abort');
+    expect(extractErrorSubtype('CLI 靜默中斷（exit N/A，180s 無 stderr）. stdout=empty aborted by user')).toBe('user_abort');
+  });
+
+  it('still routes max_turns correctly (existing line 155 branch unaffected)', () => {
+    expect(extractErrorSubtype('Claude CLI 執行失敗（exit N/A）：Reached maximum number of turns (30)')).toBe('max_turns');
+  });
+
+  it('does not misroute genuine silent_exit_void to budget/abort', () => {
+    expect(extractErrorSubtype('CLI 靜默中斷（exit N/A，260s 無 stderr）. stdout=empty prompt 22000 chars')).toBe('silent_exit_void');
+  });
+});


### PR DESCRIPTION
## Summary
- Add classifier branches for "Reached maximum budget" → `budget_exceeded` and "aborted by user" → `user_abort` BEFORE the silent_exit_void block in `extractErrorSubtype`.
- Forensic (subprocess-2026-05-08.jsonl, 03bbc29a): 6/10 recent `silent_exit_void` events had stderr `Reached maximum budget ($5)` and were misclassified.
- max_turns is already routed at line 155; new branches are defense-in-depth.

## Falsifier
Post-deploy 7-day window — `error-patterns.json` shows `budget_exceeded` count > `silent_exit_void` count, AND any new `silent_exit_void` events have stderr that is NOT `Reached maximum budget` / `aborted by user` / `maximum number of turns`.

## Verification
- [x] `npx vitest run tests/extract-error-subtype.test.ts` — 14/14 pass (4 new cases)
- [ ] CI green
- [ ] Watch error-patterns.json for 7d post-merge

Closes #370. Refs #368.