### PR TITLE
fix(closure): automate memory and KG stale room convergence

### DIFF
--- a/src/housekeeping.ts
+++ b/src/housekeeping.ts
@@ -40,6 +40,8 @@ import type { MemoryIndexEntry } from './memory-index.js';
 import type { InboxItem, ParsedTags } from './types.js';
 
 const execFileAsync = promisify(execFile);
+let externalMemorySnapshotTimer: NodeJS.Timeout | null = null;
+let externalMemorySnapshotInFlight = false;
 
 // =============================================================================
 // Task Progress Tracking
@@ -755,14 +757,15 @@ export async function runHousekeeping(): Promise<void> {
     slog('MIDDLEWARE-SELF-HEAL', `sweep skipped: ${err instanceof Error ? err.message : String(err)}`);
   });
 
+  await sweepKgDiscussionLifecycle(getMemoryRootDir()).catch(err => {
+    slog('KG-DISCUSSION-JANITOR', `sweep skipped: ${err instanceof Error ? err.message : String(err)}`);
+  });
+
   // KG auto-ingest: check every 5 cycles if enough new writes have accumulated
   if (cycleCounter % 5 === 0) {
     dispatchKGIngestIfNeeded();
     await reconcileMiddlewareCommitmentsSafe().catch(err => {
       slog('MIDDLEWARE-TRUTH', `reconcile skipped: ${err instanceof Error ? err.message : String(err)}`);
-    });
-    await sweepKgDiscussionLifecycle(getMemoryRootDir()).catch(err => {
-      slog('KG-DISCUSSION-JANITOR', `sweep skipped: ${err instanceof Error ? err.message : String(err)}`);
     });
   }
 
@@ -788,6 +791,24 @@ export async function runHousekeeping(): Promise<void> {
       if (removed > 0) slog('HOUSEKEEPING', `forensic gc removed ${removed} file(s)`);
     } catch { /* fail-open */ }
   }
+}
+
+export function startExternalMemorySnapshotDaemon(memoryDir = getMemoryRootDir(), intervalMs = 60_000): void {
+  if (externalMemorySnapshotTimer) return;
+  externalMemorySnapshotTimer = setInterval(() => {
+    const feature = getFeature('auto-commit');
+    if (feature && !feature.enabled) return;
+    if (externalMemorySnapshotInFlight) return;
+    externalMemorySnapshotInFlight = true;
+    snapshotExternalMemoryChanges(memoryDir)
+      .catch(err => {
+        slog('MEMORY-SNAPSHOT', `daemon skipped: ${err instanceof Error ? err.message : String(err)}`);
+      })
+      .finally(() => {
+        externalMemorySnapshotInFlight = false;
+      });
+  }, intervalMs);
+  externalMemorySnapshotTimer.unref?.();
 }
 
 export interface ExternalMemorySnapshotResult {

--- a/src/kg-discussion-janitor.ts
+++ b/src/kg-discussion-janitor.ts
@@ -33,6 +33,7 @@ export interface KgDiscussionLifecycleRecord {
 export interface KgDiscussionSweepResult {
   scanned: number;
   stale: number;
+  closed: number;
   queued: number;
   skippedKnown: number;
 }
@@ -47,6 +48,7 @@ export async function sweepKgDiscussionLifecycle(
     roomStaleDays?: number;
     maxQueuedPerSweep?: number;
     maxActiveLifecycleTasks?: number;
+    maxAutoCloseRoomsPerSweep?: number;
   } = {},
 ): Promise<KgDiscussionSweepResult> {
   const now = options.now ?? new Date();
@@ -58,7 +60,14 @@ export async function classifyKgDiscussions(
   memoryDir: string,
   discussions: KgDiscussionRecord[],
   now = new Date(),
-  options: { staleDays?: number; roomStaleDays?: number; maxQueuedPerSweep?: number; maxActiveLifecycleTasks?: number } = {},
+  options: {
+    staleDays?: number;
+    roomStaleDays?: number;
+    maxQueuedPerSweep?: number;
+    maxActiveLifecycleTasks?: number;
+    maxAutoCloseRoomsPerSweep?: number;
+    kgUrl?: string;
+  } = {},
 ): Promise<KgDiscussionSweepResult> {
   const known = new Set(readKgDiscussionLifecycleRecords(memoryDir).map(record => record.discussionId));
   const stale = discussions
@@ -69,9 +78,28 @@ export async function classifyKgDiscussions(
   const result: KgDiscussionSweepResult = {
     scanned: discussions.length,
     stale: stale.length,
+    closed: 0,
     queued: 0,
     skippedKnown: 0,
   };
+
+  const maxAutoCloseRooms = options.maxAutoCloseRoomsPerSweep ?? 5;
+  for (const item of stale) {
+    if (result.closed >= maxAutoCloseRooms) break;
+    if (item.bucket !== 'stale-room') continue;
+    if (known.has(item.discussion.id)) continue;
+    const closed = await closeStaleRoomDiscussion(item.discussion, options.kgUrl);
+    if (!closed) continue;
+    appendLifecycleRecord(memoryDir, {
+      discussionId: item.discussion.id,
+      topic: item.discussion.topic ?? item.discussion.description ?? item.discussion.id,
+      bucket: item.bucket,
+      seenAt: now.toISOString(),
+      followUpTaskId: 'auto-closed',
+    });
+    known.add(item.discussion.id);
+    result.closed++;
+  }
 
   const maxActiveLifecycleTasks = options.maxActiveLifecycleTasks ?? DEFAULT_MAX_ACTIVE_LIFECYCLE_TASKS;
   await rebalanceActiveLifecycleTasks(memoryDir, maxActiveLifecycleTasks);
@@ -101,6 +129,9 @@ export async function classifyKgDiscussions(
 
   if (result.queued > 0) {
     slog('KG-DISCUSSION-JANITOR', `queued ${result.queued}/${result.stale} stale KG discussion follow-up(s); active=${activeLifecycleTasks}, budget=${queueBudget}`);
+  }
+  if (result.closed > 0) {
+    slog('KG-DISCUSSION-JANITOR', `closed ${result.closed}/${result.stale} stale room discussion(s)`);
   }
   return result;
 }
@@ -246,6 +277,28 @@ async function fetchOpenDiscussions(kgUrl?: string): Promise<KgDiscussionRecord[
     return Array.isArray(body.discussions) ? body.discussions as KgDiscussionRecord[] : [];
   } catch {
     return [];
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function closeStaleRoomDiscussion(discussion: KgDiscussionRecord, kgUrl?: string): Promise<boolean> {
+  const base = (kgUrl ?? process.env.KG_URL ?? 'http://127.0.0.1:3300').replace(/\/+$/, '');
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 2500);
+  try {
+    const response = await fetch(`${base}/api/discussion/${encodeURIComponent(discussion.id)}/close`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      signal: controller.signal,
+      body: JSON.stringify({
+        source_agent: 'system',
+        summary: `Auto-closed stale Kuro room discussion ${discussion.topic ?? discussion.id}; room context has aged past the lifecycle window and remains available in KG history.`,
+      }),
+    });
+    return response.ok;
+  } catch {
+    return false;
   } finally {
     clearTimeout(timeout);
   }

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -61,7 +61,7 @@ import { claimMessage, isMessageClaimed, releaseMessage } from './message-claime
 import type { PendingPriorityState } from './event-wal.js';
 import { snapshotTelegramMsgs, matchReplyTarget, recordReply } from './reply-context.js';
 import type { TelegramMsgSnapshot } from './reply-context.js';
-import { runHousekeeping, autoPushIfAhead, trackTaskProgress, markTaskProgressDone, buildTaskProgressSection } from './housekeeping.js';
+import { runHousekeeping, autoPushIfAhead, trackTaskProgress, markTaskProgressDone, buildTaskProgressSection, startExternalMemorySnapshotDaemon } from './housekeeping.js';
 import { isEnabled, trackStart } from './features.js';
 import { writeRoomMessage, sendChat } from './observability.js';
 import { truncateAtSectionBoundary } from './context-pipeline.js';
@@ -1251,6 +1251,7 @@ export class AgentLoop {
 
     // Sentinel: watch file-based event sources not covered by API handlers
     startSentinel(process.cwd());
+    startExternalMemorySnapshotDaemon();
 
     // KG Discussions: auto-subscribe to discussions where Kuro is participant
     import('./kg-discussions.js').then(m => m.subscribeToKGDiscussions()).catch(err => {

--- a/tests/kg-discussion-janitor.test.ts
+++ b/tests/kg-discussion-janitor.test.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, rmSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   classifyKgDiscussions,
@@ -16,6 +16,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.unstubAllGlobals();
   rmSync(memoryDir, { recursive: true, force: true });
 });
 
@@ -29,7 +30,7 @@ describe('KG discussion lifecycle janitor', () => {
       updated_at: '2026-04-25T00:00:00.000Z',
     }], new Date('2026-05-07T00:00:00.000Z'));
 
-    expect(result).toEqual({ scanned: 1, stale: 1, queued: 1, skippedKnown: 0 });
+    expect(result).toEqual({ scanned: 1, stale: 1, closed: 0, queued: 1, skippedKnown: 0 });
     expect(readKgDiscussionLifecycleRecords(memoryDir)[0]).toEqual(expect.objectContaining({
       discussionId: 'disc-old',
       bucket: 'stale-discussion',
@@ -55,7 +56,7 @@ describe('KG discussion lifecycle janitor', () => {
     await classifyKgDiscussions(memoryDir, [discussion], new Date('2026-05-07T00:00:00.000Z'));
     const second = await classifyKgDiscussions(memoryDir, [discussion], new Date('2026-05-07T01:00:00.000Z'));
 
-    expect(second).toEqual({ scanned: 1, stale: 1, queued: 0, skippedKnown: 1 });
+    expect(second).toEqual({ scanned: 1, stale: 1, closed: 0, queued: 0, skippedKnown: 1 });
     expect(queryMemoryIndexSync(memoryDir, { type: ['task'], status: ['pending'] })).toHaveLength(1);
   });
 
@@ -73,7 +74,7 @@ describe('KG discussion lifecycle janitor', () => {
       maxActiveLifecycleTasks: 8,
     });
 
-    expect(result).toEqual({ scanned: 8, stale: 8, queued: 3, skippedKnown: 0 });
+    expect(result).toEqual({ scanned: 8, stale: 8, closed: 0, queued: 3, skippedKnown: 0 });
     expect(queryMemoryIndexSync(memoryDir, { type: ['task'], status: ['pending'] })).toHaveLength(3);
   });
 
@@ -94,7 +95,7 @@ describe('KG discussion lifecycle janitor', () => {
     });
 
     expect(first.queued).toBe(2);
-    expect(second).toEqual({ scanned: 2, stale: 2, queued: 0, skippedKnown: 0 });
+    expect(second).toEqual({ scanned: 2, stale: 2, closed: 0, queued: 0, skippedKnown: 0 });
     expect(queryMemoryIndexSync(memoryDir, { type: ['task'], status: ['pending'] })).toHaveLength(2);
   });
 
@@ -121,5 +122,36 @@ describe('KG discussion lifecycle janitor', () => {
       priority: 2,
       hold_reason: expect.stringContaining('maintenance lane capped'),
     }));
+  });
+
+  it('auto-closes stale Kuro room discussions instead of queueing manual lifecycle tasks', async () => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({ status: 'closed' }), { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await classifyKgDiscussions(memoryDir, [{
+      id: 'room-disc',
+      namespace: 'kuro',
+      topic: 'room-2026-05-01',
+      status: 'open',
+      position_count: 2,
+      updated_at: '2026-05-01T00:00:00.000Z',
+    }], new Date('2026-05-08T00:00:00.000Z'), {
+      kgUrl: 'http://kg.test',
+    });
+
+    expect(result).toEqual({ scanned: 1, stale: 1, closed: 1, queued: 0, skippedKnown: 1 });
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://kg.test/api/discussion/room-disc/close',
+      expect.objectContaining({
+        method: 'POST',
+        body: expect.stringContaining('source_agent'),
+      }),
+    );
+    expect(readKgDiscussionLifecycleRecords(memoryDir)[0]).toEqual(expect.objectContaining({
+      discussionId: 'room-disc',
+      bucket: 'stale-room',
+      followUpTaskId: 'auto-closed',
+    }));
+    expect(queryMemoryIndexSync(memoryDir, { type: ['task'], status: ['pending'] })).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Summary
- snapshot curated external memory on a 60s daemon so memory-state-truth does not wait for a full agent cycle to converge
- run KG discussion lifecycle janitor every housekeeping pass
- auto-close stale Kuro room discussions mechanically while keeping non-room stale discussions as explicit lifecycle tasks

## Root Cause
Autonomy closure still had two slow-converging edges: external memory dirtiness could persist until the next successful cycle, and KG room discussions aged into stale operational-efficiency warnings faster than the low-frequency janitor could close or route them.

## Verification
- `pnpm vitest run tests/kg-discussion-janitor.test.ts tests/external-memory-health.test.ts tests/memory-repo-policy.test.ts`
- `pnpm typecheck`
- `pnpm test`
