### PR TITLE
fix(delegation): normalize resolved failure guard state

### DIFF
--- a/src/delegation-failure-guard.ts
+++ b/src/delegation-failure-guard.ts
@@ -61,6 +61,7 @@ export function recordDelegationFailure(
   const signature = failureSignature(input.taskType, input.prompt, input.output);
   const existing = latest.get(signature);
   const timestamp = now.toISOString();
+  const reopened = existing ? shouldReopen(existing.status) : false;
   const record: DelegationFailureRecord = existing
     ? {
       ...existing,
@@ -69,8 +70,9 @@ export function recordDelegationFailure(
       prompt: input.prompt.slice(0, 500),
       error: failureError(input.output),
       frequency: existing.frequency + 1,
-      status: shouldReopen(existing.status) ? 'open' : existing.status,
+      status: reopened ? 'open' : existing.status,
       lastSeen: timestamp,
+      ...(reopened ? { resolution: undefined, resolvedAt: undefined } : {}),
     }
     : {
       signature,
@@ -170,7 +172,12 @@ function parseRecord(line: string): DelegationFailureRecord | null {
     const lastSeen = stringField(raw.lastSeen);
     const frequency = typeof raw.frequency === 'number' ? raw.frequency : 0;
     if (!signature || !taskId || !prompt || !error || !firstSeen || !lastSeen || frequency <= 0) return null;
-    const status = isDelegationFailureStatus(raw.status) ? raw.status : 'open';
+    const rawStatus = isDelegationFailureStatus(raw.status) ? raw.status : 'open';
+    const resolution = typeof raw.resolution === 'string' ? raw.resolution : undefined;
+    const resolvedAt = typeof raw.resolvedAt === 'string' ? raw.resolvedAt : undefined;
+    const status = resolvedAt && (rawStatus === 'open' || rawStatus === 'diagnosing')
+      ? 'resolved'
+      : rawStatus;
     return {
       signature,
       taskId,
@@ -182,8 +189,8 @@ function parseRecord(line: string): DelegationFailureRecord | null {
       lastSeen,
       ...(typeof raw.taskType === 'string' ? { taskType: raw.taskType } : {}),
       ...(typeof raw.diagnosticTaskId === 'string' ? { diagnosticTaskId: raw.diagnosticTaskId } : {}),
-      ...(typeof raw.resolution === 'string' ? { resolution: raw.resolution } : {}),
-      ...(typeof raw.resolvedAt === 'string' ? { resolvedAt: raw.resolvedAt } : {}),
+      ...(resolution ? { resolution } : {}),
+      ...(resolvedAt ? { resolvedAt } : {}),
     };
   } catch {
     return null;
@@ -225,6 +232,7 @@ export function isDelegationFailureStatus(value: unknown): value is DelegationFa
 }
 
 export function isActionableDelegationFailure(record: DelegationFailureRecord): boolean {
+  if (record.status === 'resolved' || record.status === 'ignored') return false;
   return record.frequency >= REPEAT_THRESHOLD
     || record.status === 'diagnosing'
     || record.status === 'needs_human'

--- a/tests/delegation-failure-guard.test.ts
+++ b/tests/delegation-failure-guard.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -146,5 +146,34 @@ describe('delegation failure guard', () => {
 
     expect(second.record.status).toBe('open');
     expect(second.record.frequency).toBe(2);
+    expect(second.record.resolution).toBeUndefined();
+    expect(second.record.resolvedAt).toBeUndefined();
+  });
+
+  it('normalizes historical records that are open but already resolved', () => {
+    const filePath = getDelegationFailureGuardPath(tmpDir);
+    mkdirSync(path.dirname(filePath), { recursive: true });
+    writeFileSync(filePath, JSON.stringify({
+      signature: 'sig-open-resolved',
+      taskId: 'del-1',
+      taskType: 'code',
+      prompt: 'historical failure',
+      error: 'historical error',
+      frequency: 9,
+      status: 'open',
+      firstSeen: '2026-05-05T00:00:00.000Z',
+      lastSeen: '2026-05-08T00:00:00.000Z',
+      resolution: 'self-healing sweep closed it',
+      resolvedAt: '2026-05-08T00:01:00.000Z',
+    }) + '\n', 'utf-8');
+
+    const [record] = readDelegationFailureRecordsSync(tmpDir);
+
+    expect(record).toEqual(expect.objectContaining({
+      signature: 'sig-open-resolved',
+      status: 'resolved',
+      resolvedAt: '2026-05-08T00:01:00.000Z',
+    }));
+    expect(isActionableDelegationFailure(record!)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- clear stale resolution metadata when a resolved delegation failure genuinely reopens
- normalize historical `status=open` + `resolvedAt` records as resolved on read
- exclude resolved/ignored records from actionable guard calculations

## Root Cause
The failure guard used append-only last-write-wins records, but reopened records inherited terminal metadata from prior resolved records. That produced contradictory dashboard/API rows such as `status=open` with `resolvedAt`, making closed historical failures look actionable.

## Verification
- `pnpm vitest run tests/delegation-failure-guard.test.ts`
- `pnpm typecheck`
- `pnpm test`
