### PR TITLE
fix(correction): scope responsiveness to actionable work

### DIFF
--- a/src/correction-gate.ts
+++ b/src/correction-gate.ts
@@ -206,8 +206,9 @@ export function evaluateCorrectionGate(memoryDir: string, repoRoot = process.cwd
 function isBackgroundMaintenanceTask(task: MemoryIndexEntry): boolean {
   const payload = (task.payload ?? {}) as Record<string, unknown>;
   if (payload.origin === 'kg-discussion-janitor') return true;
+  if (payload.origin === 'middleware-self-healing') return true;
   const priority = Number(payload.priority);
-  return Number.isFinite(priority) && priority >= 2 && Boolean(task.tags?.includes('discussion-lifecycle'));
+  return Number.isFinite(priority) && priority >= 2;
 }
 
 export async function ensureCorrectionTask(memoryDir: string, snapshot = evaluateCorrectionGate(memoryDir)): Promise<MemoryIndexEntry | null> {

--- a/src/predicate-freshness.ts
+++ b/src/predicate-freshness.ts
@@ -203,8 +203,9 @@ async function checkShipTruth(ctx: FreshnessContext): Promise<boolean | null> {
 function isBackgroundMaintenanceTask(task: MemoryIndexEntry): boolean {
   const payload = (task.payload ?? {}) as Record<string, unknown>;
   if (payload.origin === 'kg-discussion-janitor') return true;
+  if (payload.origin === 'middleware-self-healing') return true;
   const priority = Number(payload.priority);
-  return Number.isFinite(priority) && priority >= 2 && Boolean(task.tags?.includes('discussion-lifecycle'));
+  return Number.isFinite(priority) && priority >= 2;
 }
 
 /**

--- a/tests/correction-gate.test.ts
+++ b/tests/correction-gate.test.ts
@@ -111,6 +111,45 @@ describe('correction gate', () => {
     expect(snapshot.suppressedActions).not.toContain('self-research');
   });
 
+  it('does not escalate low-priority backlog into low-responsiveness correction', async () => {
+    await appendMemoryIndexEntry(tmpDir, {
+      type: 'task',
+      status: 'pending',
+      summary: 'P2 GitHub issue #368: investigate sub-threshold silent exit',
+      tags: ['github', 'issue', 'P2'],
+      payload: {
+        origin: 'github-issue',
+        priority: 2,
+        ticksSinceLastProgress: 50,
+      },
+    });
+    invalidateIndexCache();
+
+    const snapshot = evaluateCorrectionGate(tmpDir, tmpDir);
+
+    expect(snapshot.reasons.map(r => r.type)).not.toContain('low-responsiveness');
+  });
+
+  it('does not let middleware self-healing fallback tasks open the correction gate', async () => {
+    await appendMemoryIndexEntry(tmpDir, {
+      type: 'task',
+      status: 'pending',
+      summary: 'Create fallback for middleware task task-123 after provider budget hold',
+      tags: ['middleware', 'self-healing', 'budget-or-quota'],
+      payload: {
+        origin: 'middleware-self-healing',
+        priority: 0,
+        middleware_failure_bucket: 'budget-or-quota',
+        ticksSinceLastProgress: 50,
+      },
+    });
+    invalidateIndexCache();
+
+    const snapshot = evaluateCorrectionGate(tmpDir, tmpDir);
+
+    expect(snapshot.reasons.map(r => r.type)).not.toContain('low-responsiveness');
+  });
+
   it('does not let stale correction tasks create a self-referential responsiveness loop', async () => {
     await appendMemoryIndexEntry(tmpDir, {
       type: 'task',

--- a/tests/predicate-freshness.test.ts
+++ b/tests/predicate-freshness.test.ts
@@ -24,6 +24,7 @@ import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { reverifyPredicate } from '../src/predicate-freshness.js';
+import { appendMemoryIndexEntry, invalidateIndexCache } from '../src/memory-index.js';
 
 let repoRoot: string;
 let memoryDir: string;
@@ -110,6 +111,37 @@ describe('issue #306 — reverifyPredicate', () => {
   describe('predicate checks', () => {
     it('low-responsiveness returns false when runtime is responsive', async () => {
       const result = await reverifyPredicate('low-responsiveness', { repoRoot, memoryDir });
+      expect(result).toBe(false);
+    });
+
+    it('low-responsiveness ignores low-priority and middleware maintenance backlog', async () => {
+      await appendMemoryIndexEntry(memoryDir, {
+        type: 'task',
+        status: 'pending',
+        summary: 'P2 GitHub issue #368: investigate sub-threshold silent exit',
+        tags: ['github', 'issue', 'P2'],
+        payload: {
+          origin: 'github-issue',
+          priority: 2,
+          ticksSinceLastProgress: 50,
+        },
+      });
+      await appendMemoryIndexEntry(memoryDir, {
+        type: 'task',
+        status: 'pending',
+        summary: 'Create fallback for middleware task task-123 after provider budget hold',
+        tags: ['middleware', 'self-healing', 'budget-or-quota'],
+        payload: {
+          origin: 'middleware-self-healing',
+          priority: 0,
+          middleware_failure_bucket: 'budget-or-quota',
+          ticksSinceLastProgress: 50,
+        },
+      });
+      invalidateIndexCache();
+
+      const result = await reverifyPredicate('low-responsiveness', { repoRoot, memoryDir });
+
       expect(result).toBe(false);
     });
 


### PR DESCRIPTION
## Summary
- scope low-responsiveness correction math to actionable high-priority work
- keep P2/backlog and middleware self-healing fallback tasks in the queue without promoting them into P0 correction storms
- apply the same scope to predicate freshness re-verification so scheduler and correction gate agree

## Root Cause
Operational-efficiency kept warning after KG, memory, and middleware failures had converged because the responsiveness metric counted low-priority backlog and maintenance/self-healing tasks. Those tasks should remain visible and executable, but they should not open the P0 correction gate.

## Verification
- `pnpm vitest run tests/correction-gate.test.ts tests/predicate-freshness.test.ts`
- `pnpm typecheck`
- `pnpm test`
