### PR TITLE
fix(autonomy): dedupe closure block notifications

### DIFF
--- a/src/autonomy-closure-notifier.ts
+++ b/src/autonomy-closure-notifier.ts
@@ -22,7 +22,6 @@ export function autonomyClosureSignature(snapshot: AutonomyClosureNotificationSn
   return JSON.stringify({
     status: snapshot.status,
     blockingStages: snapshot.blockingStages,
-    warningStages: snapshot.warningStages,
     recommendedTask: snapshot.recommendedTask?.title ?? null,
   });
 }
@@ -33,6 +32,23 @@ export function shouldNotifyAutonomyClosureBlock(
 ): boolean {
   if (snapshot.blockingStages.length === 0) return false;
   return autonomyClosureSignature(snapshot) !== previousSignature;
+}
+
+export function shouldNotifyAutonomyClosureResolved(
+  snapshot: AutonomyClosureNotificationSnapshot,
+  previousSignature: string | null,
+): boolean {
+  if (snapshot.blockingStages.length > 0) return false;
+  if (!previousSignature) return false;
+  return previousSignature !== autonomyClosureSignature(snapshot);
+}
+
+export function buildAutonomyClosureResolvedMessage(snapshot: AutonomyClosureNotificationSnapshot): string {
+  return [
+    `✅ Autonomy closure healthy (score ${snapshot.score})`,
+    snapshot.warningStages.length > 0 ? `warnings: ${snapshot.warningStages.join(', ')}` : 'warnings: none',
+    snapshot.recommendedTask ? `next: ${snapshot.recommendedTask.title}` : 'next: none',
+  ].join('\n');
 }
 
 export function buildAutonomyClosureBlockMessage(snapshot: AutonomyClosureNotificationSnapshot): string {

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -135,8 +135,10 @@ import {
 import {
   autonomyClosureSignature,
   buildAutonomyClosureBlockMessage,
+  buildAutonomyClosureResolvedMessage,
   readAutonomyClosureNotificationSignature,
   shouldNotifyAutonomyClosureBlock,
+  shouldNotifyAutonomyClosureResolved,
   writeAutonomyClosureNotificationSignature,
 } from './autonomy-closure-notifier.js';
 import {
@@ -301,8 +303,12 @@ function notifyAutonomyClosureBlockIfChanged(
 ): void {
   try {
     const previous = readAutonomyClosureNotificationSignature(stateDir);
-    if (!shouldNotifyAutonomyClosureBlock(closure, previous)) return;
-    const message = buildAutonomyClosureBlockMessage(closure);
+    const shouldNotifyBlock = shouldNotifyAutonomyClosureBlock(closure, previous);
+    const shouldNotifyResolved = shouldNotifyAutonomyClosureResolved(closure, previous);
+    if (!shouldNotifyBlock && !shouldNotifyResolved) return;
+    const message = shouldNotifyBlock
+      ? buildAutonomyClosureBlockMessage(closure)
+      : buildAutonomyClosureResolvedMessage(closure);
     sendChat(message, { directReply: true });
     writeAutonomyClosureNotificationSignature(stateDir, autonomyClosureSignature(closure));
   } catch (err) {
@@ -2442,7 +2448,7 @@ export class AgentLoop {
           const refreshed = diagnostic.actionsRun.length > 0 ? evaluateAutonomyClosure(memDir) : closure;
           const task = await ensureAutonomyClosureTask(memDir, refreshed);
           slog('AUTONOMY', `closure ${refreshed.status} score=${refreshed.score} blocking=${refreshed.blockingStages.join(',') || 'none'} diagnostics=${diagnostic.cases.length} actions=${diagnostic.actionsRun.join(',') || 'none'} task=${task?.id.slice(0, 12) ?? 'none'}`);
-          notifyAutonomyClosureBlockIfChanged(getInstanceDir(getCurrentInstanceId()), closure);
+          notifyAutonomyClosureBlockIfChanged(getInstanceDir(getCurrentInstanceId()), refreshed);
         }
       } catch (e) { slog('WARN', `autonomy closure health failed: ${e}`); }
 

--- a/tests/autonomy-closure-notifier.test.ts
+++ b/tests/autonomy-closure-notifier.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from 'vitest';
 import {
   autonomyClosureSignature,
   buildAutonomyClosureBlockMessage,
+  buildAutonomyClosureResolvedMessage,
   shouldNotifyAutonomyClosureBlock,
+  shouldNotifyAutonomyClosureResolved,
 } from '../src/autonomy-closure-notifier.js';
 
 const blockedSnapshot = {
@@ -30,12 +32,36 @@ describe('autonomy closure notifier', () => {
     expect(shouldNotifyAutonomyClosureBlock(blockedSnapshot, autonomyClosureSignature(blockedSnapshot))).toBe(false);
   });
 
+  it('does not repeat a block notification when only warning stages change', () => {
+    const sameBlockDifferentWarnings = {
+      ...blockedSnapshot,
+      score: 70,
+      warningStages: ['operational-efficiency'],
+    };
+
+    expect(shouldNotifyAutonomyClosureBlock(sameBlockDifferentWarnings, autonomyClosureSignature(blockedSnapshot))).toBe(false);
+  });
+
   it('does not notify when there are no blocking stages', () => {
     expect(shouldNotifyAutonomyClosureBlock({
       ...blockedSnapshot,
       status: 'healthy',
       blockingStages: [],
     }, null)).toBe(false);
+  });
+
+  it('notifies once when a previously blocked closure becomes healthy', () => {
+    const healthySnapshot = {
+      ...blockedSnapshot,
+      status: 'healthy',
+      score: 100,
+      blockingStages: [],
+      warningStages: [],
+      recommendedTask: null,
+    };
+
+    expect(shouldNotifyAutonomyClosureResolved(healthySnapshot, autonomyClosureSignature(blockedSnapshot))).toBe(true);
+    expect(shouldNotifyAutonomyClosureResolved(healthySnapshot, autonomyClosureSignature(healthySnapshot))).toBe(false);
   });
 
   it('renders blocking evidence and next action', () => {
@@ -45,5 +71,19 @@ describe('autonomy closure notifier', () => {
     expect(message).toContain('blocking: task-execution');
     expect(message).toContain('next: P0 autonomy closure: repair task-execution');
     expect(message).toContain('idx-github-i hold');
+  });
+
+  it('renders resolved notification', () => {
+    const message = buildAutonomyClosureResolvedMessage({
+      ...blockedSnapshot,
+      status: 'healthy',
+      score: 100,
+      blockingStages: [],
+      warningStages: [],
+      recommendedTask: null,
+    });
+
+    expect(message).toContain('Autonomy closure healthy');
+    expect(message).toContain('warnings: none');
   });
 });


### PR DESCRIPTION
## Summary
- dedupe autonomy closure blocked notifications by stable blocking stage/task, not warning-stage churn
- notify from the refreshed post-diagnostic closure snapshot, so self-repair in the same cycle does not still emit a stale blocked message
- emit a one-time healthy/resolved message after a previous blocked signature clears

## Root Cause
Room showed repeated similar blocked messages because warning-stage changes produced new notifier signatures, and loop notification used the pre-diagnostic closure snapshot even when diagnostic/autocorrect had already changed state.

## Verification
- pnpm test -- tests/autonomy-closure-notifier.test.ts tests/autonomy-closure-diagnostics.test.ts
- pnpm typecheck
- full vitest run completed: 113 test files passed, 895 tests passed, 2 skipped
