### PR TITLE
fix(scheduler): filter closed PRs before queueing maintenance tasks (#388)

### DIFF
--- a/src/self-research-autopilot.ts
+++ b/src/self-research-autopilot.ts
@@ -6,6 +6,7 @@
  * scheduler and verification gate.
  */
 
+import { execFileSync } from 'node:child_process';
 import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import path from 'node:path';
 import { eventBus } from './event-bus.js';
@@ -13,10 +14,17 @@ import { createTask, queryMemoryIndexSync, type MemoryIndexEntry } from './memor
 import { createSelfResearchPlan, saveSelfResearchPlan, type SelfResearchRun } from './self-research-loop.js';
 import { evaluateCorrectionGate } from './correction-gate.js';
 
+export type CheckPrOpenFn = (prNumber: number) => Promise<boolean> | boolean;
+
 export interface SelfResearchAutopilotOptions {
   triggerReason?: string | null;
   now?: Date;
   repoRoot?: string;
+  /**
+   * Issue #388: gate maintenance task generation on the PR still being OPEN at
+   * task-firing time. Override in tests; default shells out to `gh pr view`.
+   */
+  checkPrOpen?: CheckPrOpenFn;
 }
 
 export interface SelfResearchAutopilotResult {
@@ -54,7 +62,7 @@ export async function maybeQueueSelfResearch(
     type: ['task'],
     status: ['pending', 'in_progress', 'needs-decomposition', 'blocked', 'hold'],
   });
-  const queuedMaintenance = await maybeQueueMaintenance(memoryDir, openTasks);
+  const queuedMaintenance = await maybeQueueMaintenance(memoryDir, openTasks, opts.checkPrOpen ?? defaultCheckPrOpen);
   if (queuedMaintenance) return queuedMaintenance;
 
   const activeTasks = queryMemoryIndexSync(memoryDir, {
@@ -97,6 +105,7 @@ export async function maybeQueueSelfResearch(
 async function maybeQueueMaintenance(
   memoryDir: string,
   openTasks: MemoryIndexEntry[],
+  checkPrOpen: CheckPrOpenFn,
 ): Promise<SelfResearchAutopilotResult | null> {
   const debt = findTopMaintenanceDebt(memoryDir);
   if (!debt) return null;
@@ -111,6 +120,18 @@ async function maybeQueueMaintenance(
     && !(task.summary ?? '').includes('autonomous maintenance'),
   );
   if (activeNonMaintenance.length > 0) return null;
+
+  // Issue #388: re-check PR open state at task-firing time. Closed/merged PRs
+  // produce phantom maintenance tasks that waste cycles confirming "推不動".
+  const prOpen = await checkPrOpen(debt.prNumber);
+  if (!prOpen) {
+    eventBus.emit('action:task', {
+      event: 'autonomous-maintenance-skipped-pr-closed',
+      prNumber: debt.prNumber,
+      action: debt.action,
+    });
+    return { queued: false, reason: 'pr-not-open', maintenance: debt };
+  }
 
   const task = await createTask(memoryDir, {
     title: `P1 ${marker}: ${maintenanceAction(debt)} for ${debt.title}`,
@@ -200,4 +221,23 @@ function hasSelfResearchProposalToday(memoryDir: string, now: Date): boolean {
 
 function shellQuote(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+/**
+ * Issue #388 default PR-open checker. Shells out to `gh pr view` and treats
+ * any non-OPEN state (CLOSED/MERGED) as "skip". Network/CLI failures are
+ * treated as "open" — fail-open keeps existing behavior on transient errors
+ * rather than silently dropping legitimate maintenance work.
+ */
+async function defaultCheckPrOpen(prNumber: number): Promise<boolean> {
+  try {
+    const out = execFileSync(
+      'gh',
+      ['pr', 'view', String(prNumber), '--repo', 'miles990/mini-agent', '--json', 'state', '--jq', '.state'],
+      { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'], timeout: 10_000 },
+    ).trim();
+    return out === 'OPEN';
+  } catch {
+    return true;
+  }
 }

--- a/tests/self-research-autopilot.test.ts
+++ b/tests/self-research-autopilot.test.ts
@@ -86,6 +86,7 @@ describe('self research autopilot', () => {
       triggerReason: 'heartbeat',
       now: new Date('2026-05-05T00:00:00.000Z'),
       repoRoot: tmpDir,
+      checkPrOpen: async () => true,
     });
 
     expect(result.queued).toBe(true);
@@ -103,6 +104,34 @@ describe('self research autopilot', () => {
       assignee: 'kuro',
       verify_command: expect.stringContaining('gh pr view 90'),
     }));
+  });
+
+  it('skips maintenance task when PR is no longer open (issue #388)', async () => {
+    mkdirSync(path.join(tmpDir, 'handoffs'), { recursive: true });
+    writeFileSync(
+      path.join(tmpDir, 'handoffs/active.md'),
+      [
+        '| From | To | Task | Status | Created | Done |',
+        '| github | kuro | PR #351 conflict diagnostic: runtime preserve dirty (needs-decomposition; conflict spans broad scope) | blocked | 05-08 | - |',
+      ].join('\n'),
+      'utf-8',
+    );
+
+    const result = await maybeQueueSelfResearch(tmpDir, {
+      triggerReason: 'heartbeat',
+      now: new Date('2026-05-08T17:32:00.000Z'),
+      repoRoot: tmpDir,
+      checkPrOpen: async () => false, // PR was closed by the time scheduler fires
+    });
+
+    expect(result).toEqual({
+      queued: false,
+      reason: 'pr-not-open',
+      maintenance: expect.objectContaining({ prNumber: 351 }),
+    });
+
+    // Critical: no task should have been created.
+    expect(queryMemoryIndexSync(tmpDir, { type: ['task'], status: ['pending'] })).toHaveLength(0);
   });
 
   it('does not duplicate an existing autonomous maintenance task', async () => {


### PR DESCRIPTION
## Summary
- Scheduler was firing `P1 autonomous maintenance PR #X` tasks from cached `handoffs/active.md` debt without re-checking PR state at fire time
- Today PR #351 fired ~8hr after it was closed → 3 cycles of Kuro spend confirming "推不動"
- Inject `checkPrOpen` async fn (default = `gh pr view --json state`); short-circuit with `reason='pr-not-open'` when state ≠ OPEN

## Test plan
- [x] New test: `skips maintenance task when PR is no longer open (issue #388)` — stubbed `checkPrOpen: async () => false`, asserts `pr-not-open` + zero tasks created
- [x] Existing maintenance test updated to inject `checkPrOpen: async () => true` (avoids network in unit tests)
- [x] All 7 tests pass locally
- [x] Fail-open on gh CLI errors preserves existing behavior on transient failures

Closes #388