### PR TITLE
fix(autonomy): close obsolete maintenance loops

### DIFF
--- a/src/external-memory-health.ts
+++ b/src/external-memory-health.ts
@@ -13,6 +13,7 @@ export interface ExternalMemoryHealthResult {
 export interface KgExternalMemoryOptions {
   kgUrl?: string;
   timeoutSeconds?: number;
+  probeAttempts?: number;
   staleDiscussionDays?: number;
 }
 
@@ -95,12 +96,13 @@ export function evaluateKgExternalMemoryTruth(memoryDir: string, now = new Date(
 
   const kgUrl = (options.kgUrl ?? process.env.KG_URL ?? 'http://127.0.0.1:3300').replace(/\/+$/, '');
   const timeout = options.timeoutSeconds ?? 2;
-  const health = curlJson(`${kgUrl}/health`, timeout);
+  const probeAttempts = options.probeAttempts ?? 3;
+  const health = curlJsonWithRetry(`${kgUrl}/health`, timeout, probeAttempts);
   if (!health.ok) {
     return {
       status: 'warn',
       summary: 'KG context fabric service is unreachable',
-      evidence: [`kgUrl=${kgUrl}`, health.error ?? 'unknown curl failure'],
+      evidence: [`kgUrl=${kgUrl}`, `probeAttempts=${probeAttempts}`, health.error ?? 'unknown curl failure'],
       repair: 'Start knowledge-graph or disable KG-backed context exchange until the service is intentionally unavailable.',
     };
   }
@@ -343,6 +345,21 @@ function curlJson(url: string, timeoutSeconds: number): { ok: true; value: unkno
   } catch (err) {
     return { ok: false, error: String(err).slice(0, 200) };
   }
+}
+
+function curlJsonWithRetry(
+  url: string,
+  timeoutSeconds: number,
+  attempts: number,
+): { ok: true; value: unknown } | { ok: false; error?: string } {
+  const count = Math.max(1, Math.floor(attempts));
+  let lastError: string | undefined;
+  for (let i = 0; i < count; i++) {
+    const result = curlJson(url, timeoutSeconds);
+    if (result.ok) return result;
+    lastError = result.error;
+  }
+  return { ok: false, error: lastError };
 }
 
 function findStaleOpenDiscussions(value: unknown, now: Date, staleDays: number): Array<Record<string, unknown>> {

--- a/src/self-research-autopilot.ts
+++ b/src/self-research-autopilot.ts
@@ -7,9 +7,10 @@
  */
 
 import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
 import path from 'node:path';
 import { eventBus } from './event-bus.js';
-import { createTask, queryMemoryIndexSync, type MemoryIndexEntry } from './memory-index.js';
+import { createTask, queryMemoryIndexSync, updateMemoryIndexEntry, type MemoryIndexEntry } from './memory-index.js';
 import { createSelfResearchPlan, saveSelfResearchPlan, type SelfResearchRun } from './self-research-loop.js';
 import { evaluateCorrectionGate } from './correction-gate.js';
 
@@ -17,6 +18,7 @@ export interface SelfResearchAutopilotOptions {
   triggerReason?: string | null;
   now?: Date;
   repoRoot?: string;
+  prStateLookup?: PrStateLookup;
 }
 
 export interface SelfResearchAutopilotResult {
@@ -36,6 +38,13 @@ export interface MaintenanceDebt {
   reason: string;
 }
 
+export interface MaintenancePrState {
+  state: string;
+  mergeable?: string | null;
+}
+
+export type PrStateLookup = (prNumber: number) => MaintenancePrState | null;
+
 export async function maybeQueueSelfResearch(
   memoryDir: string,
   opts: SelfResearchAutopilotOptions = {},
@@ -54,7 +63,7 @@ export async function maybeQueueSelfResearch(
     type: ['task'],
     status: ['pending', 'in_progress', 'needs-decomposition', 'blocked', 'hold'],
   });
-  const queuedMaintenance = await maybeQueueMaintenance(memoryDir, openTasks);
+  const queuedMaintenance = await maybeQueueMaintenance(memoryDir, openTasks, opts.prStateLookup);
   if (queuedMaintenance) return queuedMaintenance;
 
   const activeTasks = queryMemoryIndexSync(memoryDir, {
@@ -97,8 +106,10 @@ export async function maybeQueueSelfResearch(
 async function maybeQueueMaintenance(
   memoryDir: string,
   openTasks: MemoryIndexEntry[],
+  prStateLookup: PrStateLookup = readPrState,
 ): Promise<SelfResearchAutopilotResult | null> {
-  const debt = findTopMaintenanceDebt(memoryDir);
+  await closeObsoleteMaintenanceTasks(memoryDir, openTasks, prStateLookup);
+  const debt = findTopMaintenanceDebt(memoryDir, prStateLookup);
   if (!debt) return null;
 
   const marker = `autonomous maintenance PR #${debt.prNumber}`;
@@ -132,14 +143,44 @@ async function maybeQueueMaintenance(
   return { queued: true, reason: 'maintenance-queued', maintenance: debt, task };
 }
 
-function findTopMaintenanceDebt(memoryDir: string): MaintenanceDebt | null {
+async function closeObsoleteMaintenanceTasks(
+  memoryDir: string,
+  openTasks: MemoryIndexEntry[],
+  prStateLookup: PrStateLookup,
+): Promise<void> {
+  for (const task of openTasks) {
+    const match = (task.summary ?? '').match(/autonomous maintenance PR #(\d+)/);
+    if (!match) continue;
+    const prNumber = Number(match[1]);
+    if (!Number.isFinite(prNumber)) continue;
+    const state = prStateLookup(prNumber);
+    if (!state || isActiveConflictPr(state)) continue;
+    await updateMemoryIndexEntry(memoryDir, task.id, {
+      status: 'completed',
+      payload: {
+        ...((task.payload ?? {}) as Record<string, unknown>),
+        closed_by: 'autonomous-maintenance-pr-state-sweep',
+        pr_state: state.state,
+        pr_mergeable: state.mergeable ?? null,
+        completed_at: new Date().toISOString(),
+      },
+      tags: [...new Set([...(task.tags ?? []), 'autonomous-maintenance', 'obsolete-pr-closed'])],
+    });
+  }
+}
+
+function findTopMaintenanceDebt(memoryDir: string, prStateLookup: PrStateLookup): MaintenanceDebt | null {
   const activePath = path.join(memoryDir, 'handoffs', 'active.md');
   if (!existsSync(activePath)) return null;
 
   const debts = readFileSync(activePath, 'utf-8')
     .split('\n')
     .map(parseConflictDebtRow)
-    .filter((debt): debt is MaintenanceDebt => debt !== null);
+    .filter((debt): debt is MaintenanceDebt => {
+      if (debt === null) return false;
+      const state = prStateLookup(debt.prNumber);
+      return state === null || isActiveConflictPr(state);
+    });
 
   return debts.sort((a, b) => maintenancePriority(b) - maintenancePriority(a))[0] ?? null;
 }
@@ -178,9 +219,33 @@ function prConflictVerifyCommand(prNumber: number): string {
   return [
     'test "$(',
     `gh pr view ${prNumber} --repo miles990/mini-agent --json state,mergeable --jq `,
-    shellQuote('if .state == "MERGED" or .mergeable != "CONFLICTING" then "ok" else "blocked" end'),
+    shellQuote('if .state != "OPEN" or .mergeable != "CONFLICTING" then "ok" else "blocked" end'),
     ')" = ok',
   ].join('');
+}
+
+function isActiveConflictPr(state: MaintenancePrState): boolean {
+  return String(state.state).toUpperCase() === 'OPEN'
+    && String(state.mergeable ?? '').toUpperCase() === 'CONFLICTING';
+}
+
+function readPrState(prNumber: number): MaintenancePrState | null {
+  try {
+    const stdout = execFileSync('gh', [
+      'pr', 'view', String(prNumber),
+      '--repo', 'miles990/mini-agent',
+      '--json', 'state,mergeable',
+    ], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 10_000,
+    }).trim();
+    if (!stdout) return null;
+    const parsed = JSON.parse(stdout) as MaintenancePrState;
+    return parsed && typeof parsed.state === 'string' ? parsed : null;
+  } catch {
+    return null;
+  }
 }
 
 function unescapeTable(value: string): string {

--- a/tests/external-memory-health.test.ts
+++ b/tests/external-memory-health.test.ts
@@ -117,6 +117,7 @@ describe('external memory health', () => {
 
     expect(result.status).toBe('warn');
     expect(result.summary).toContain('unreachable');
+    expect(result.evidence).toContain('probeAttempts=3');
     expect(result.repair).toContain('context exchange');
   });
 });

--- a/tests/self-research-autopilot.test.ts
+++ b/tests/self-research-autopilot.test.ts
@@ -22,6 +22,7 @@ describe('self research autopilot', () => {
       triggerReason: 'heartbeat',
       now: new Date('2026-05-05T00:00:00.000Z'),
       repoRoot: tmpDir,
+      prStateLookup: prNumber => ({ state: 'OPEN', mergeable: prNumber === 90 ? 'CONFLICTING' : 'MERGEABLE' }),
     });
 
     expect(result.queued).toBe(true);
@@ -62,6 +63,7 @@ describe('self research autopilot', () => {
       triggerReason: 'heartbeat',
       now: new Date('2026-05-05T00:00:00.000Z'),
       repoRoot: tmpDir,
+      prStateLookup: () => ({ state: 'OPEN', mergeable: 'CONFLICTING' }),
     });
 
     expect(result).toEqual({ queued: false, reason: 'active-tasks-present' });
@@ -86,6 +88,7 @@ describe('self research autopilot', () => {
       triggerReason: 'heartbeat',
       now: new Date('2026-05-05T00:00:00.000Z'),
       repoRoot: tmpDir,
+      prStateLookup: () => ({ state: 'OPEN', mergeable: 'CONFLICTING' }),
     });
 
     expect(result.queued).toBe(true);
@@ -134,6 +137,7 @@ describe('self research autopilot', () => {
       triggerReason: 'heartbeat',
       now: new Date('2026-05-05T00:00:00.000Z'),
       repoRoot: tmpDir,
+      prStateLookup: () => ({ state: 'OPEN', mergeable: 'CONFLICTING' }),
     });
 
     expect(result).toEqual({
@@ -141,6 +145,72 @@ describe('self research autopilot', () => {
       reason: 'maintenance-task-exists',
       maintenance: expect.objectContaining({ prNumber: 90 }),
     });
+  });
+
+  it('filters closed PR conflict rows before queuing phantom maintenance', async () => {
+    mkdirSync(path.join(tmpDir, 'handoffs'), { recursive: true });
+    writeFileSync(
+      path.join(tmpDir, 'handoffs/active.md'),
+      [
+        '| From | To | Task | Status | Created | Done |',
+        '| github | kuro | PR #351 conflict diagnostic: obsolete branch (needs-decomposition; conflict spans broad scope) | blocked | 05-08 | - |',
+      ].join('\n'),
+      'utf-8',
+    );
+
+    const result = await maybeQueueSelfResearch(tmpDir, {
+      triggerReason: 'heartbeat',
+      now: new Date('2026-05-05T00:00:00.000Z'),
+      repoRoot: tmpDir,
+      prStateLookup: () => ({ state: 'CLOSED', mergeable: 'UNKNOWN' }),
+    });
+
+    expect(result.queued).toBe(true);
+    expect(result.reason).toBe('queued');
+    expect(result.maintenance).toBeUndefined();
+    expect(result.task?.summary).toContain('P2 execute self-research');
+  });
+
+  it('completes existing autonomous maintenance tasks once the referenced PR is closed', async () => {
+    mkdirSync(path.join(tmpDir, 'handoffs'), { recursive: true });
+    mkdirSync(path.join(tmpDir, 'state'), { recursive: true });
+    writeFileSync(
+      path.join(tmpDir, 'handoffs/active.md'),
+      [
+        '| From | To | Task | Status | Created | Done |',
+        '| github | kuro | PR #351 conflict diagnostic: obsolete branch (needs-decomposition; conflict spans broad scope) | blocked | 05-08 | - |',
+      ].join('\n'),
+      'utf-8',
+    );
+    writeFileSync(
+      path.join(tmpDir, 'state/task-events.jsonl'),
+      JSON.stringify({
+        id: 'idx-maintenance-351',
+        ts: '2026-05-08T00:00:00.000Z',
+        type: 'task',
+        status: 'pending',
+        summary: 'P1 autonomous maintenance PR #351: rebuild or split conflicting broad PR from current main',
+        refs: [],
+        payload: { origin: 'scheduler', priority: 1 },
+      }) + '\n',
+      'utf-8',
+    );
+
+    const result = await maybeQueueSelfResearch(tmpDir, {
+      triggerReason: 'heartbeat',
+      now: new Date('2026-05-05T00:00:00.000Z'),
+      repoRoot: tmpDir,
+      prStateLookup: () => ({ state: 'CLOSED', mergeable: 'UNKNOWN' }),
+    });
+    const task = queryMemoryIndexSync(tmpDir, { id: 'idx-maintenance-351' })[0];
+
+    expect(result.queued).toBe(true);
+    expect(result.reason).toBe('queued');
+    expect(task?.status).toBe('completed');
+    expect(task?.payload).toEqual(expect.objectContaining({
+      closed_by: 'autonomous-maintenance-pr-state-sweep',
+      pr_state: 'CLOSED',
+    }));
   });
 
   it('does not queue more than one proposal per day', async () => {


### PR DESCRIPTION
## Summary
- filter autonomous maintenance PR conflict rows through live PR state before queuing work
- complete existing autonomous maintenance tasks when the referenced PR is no longer OPEN+CONFLICTING
- retry KG external-memory health probes to avoid transient timeout warnings

Fixes #388.

## Verification
- pnpm typecheck
- pnpm test -- tests/self-research-autopilot.test.ts tests/external-memory-health.test.ts tests/runtime-workspace-autocorrect.test.ts (Vitest expanded to 113 files: 897 passed, 2 skipped)