### PR TITLE
fix(memory): keep index reads side-effect free

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ memory/handoffs/*
 !memory/digestions/
 !memory/topics/
 !memory/state/
+memory/state/*
 !memory/state/kuro-content/
 !memory/state/kuro-content/*
 sessions/

--- a/src/memory-index.ts
+++ b/src/memory-index.ts
@@ -271,8 +271,6 @@ function ensureBucketFileSync(memoryDir: string, bucket: Bucket): string {
 }
 
 function ensureIndexFileSync(memoryDir: string): string {
-  // Pre-warm both buckets so query paths have a file to read from.
-  ensureBucketFileSync(memoryDir, 'task-events');
   return ensureBucketFileSync(memoryDir, 'relations');
 }
 

--- a/tests/memory-index-buckets.test.ts
+++ b/tests/memory-index-buckets.test.ts
@@ -33,6 +33,13 @@ afterEach(() => {
 });
 
 describe('memory-index — bucket routing', () => {
+  it('querying an empty memory root does not create task-events telemetry', () => {
+    const result = queryMemoryIndexSync(tmpDir, { type: 'task' });
+
+    expect(result).toEqual([]);
+    expect(fs.existsSync(getTaskEventsPath(tmpDir))).toBe(false);
+  });
+
   it('task entries land in state/task-events.jsonl', async () => {
     await appendMemoryIndexEntry(tmpDir, {
       type: 'task',


### PR DESCRIPTION
## Summary
- stop read-only memory index queries from creating empty task-events telemetry files
- ignore repo-local memory/state runtime telemetry by default while preserving explicit kuro-content exceptions
- add regression coverage for empty memory-root queries

## Root cause
`queryMemoryIndexSync()` pre-warmed both buckets through `ensureIndexFileSync()`. Read-only checks such as autonomy closure could therefore create `memory/state/task-events.jsonl` in a runtime checkout when `MINI_AGENT_MEMORY_DIR` was absent from the shell, making the checkout look dirty even though no real task event existed.

## Verification
- pnpm typecheck
- pnpm test -- tests/memory-index-buckets.test.ts tests/memory-repo-policy.test.ts tests/memory-paths.test.ts (Vitest expanded to 113 files: 898 passed, 2 skipped)
- ad hoc query harness: empty memory-root query reports `not-created`