### PR TITLE
feat(kg): add context observatory dashboard

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -2213,7 +2213,7 @@
   <nav class="main-tabs">
     <button class="tab-btn active" data-tab="dashboard">Dashboard</button>
     <button class="tab-btn" data-tab="memory">Memory Lab</button>
-    <a class="ext-link" href="/kg-graph" target="_blank" rel="noopener" title="Knowledge Graph — D3 force layout viz">Knowledge Graph &#8599;</a>
+    <a class="ext-link" href="/kg-dashboard" target="_blank" rel="noopener" title="Knowledge Graph context observatory">KG Observatory &#8599;</a>
   </nav>
 
   <!-- Dashboard Tab -->

--- a/kg-dashboard.html
+++ b/kg-dashboard.html
@@ -1,0 +1,403 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>KG Context Observatory</title>
+<style>
+  :root {
+    --bg: #0b0d10;
+    --panel: #11151a;
+    --panel2: #151b22;
+    --line: #26313c;
+    --line2: #1a222b;
+    --text: #e6edf3;
+    --muted: #8b98a5;
+    --faint: #5d6874;
+    --green: #48d597;
+    --cyan: #5db7ff;
+    --yellow: #f4c95d;
+    --red: #ff6b6b;
+    --violet: #ad8cff;
+    --pink: #f187c6;
+    --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    --sans: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; min-height: 100%; background: var(--bg); color: var(--text); font: 13px/1.45 var(--sans); }
+  body { padding: 20px; }
+  button, input, select { font: inherit; }
+  .shell { max-width: 1500px; margin: 0 auto; }
+  header { display: flex; align-items: flex-end; justify-content: space-between; gap: 20px; margin-bottom: 18px; border-bottom: 1px solid var(--line2); padding-bottom: 14px; }
+  h1 { margin: 0; font-size: 22px; letter-spacing: 0; font-weight: 650; }
+  .subtitle { margin-top: 4px; color: var(--muted); font-family: var(--mono); font-size: 12px; }
+  .actions { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+  .btn, .input, .select {
+    border: 1px solid var(--line);
+    background: var(--panel);
+    color: var(--text);
+    border-radius: 6px;
+    padding: 7px 10px;
+    min-height: 34px;
+  }
+  .btn { cursor: pointer; color: var(--muted); }
+  .btn:hover { border-color: var(--cyan); color: var(--text); }
+  .input { width: min(420px, 44vw); outline: none; }
+  .input:focus { border-color: var(--cyan); }
+  .grid { display: grid; gap: 12px; }
+  .metrics { grid-template-columns: repeat(6, minmax(120px, 1fr)); margin-bottom: 12px; }
+  .metric { border: 1px solid var(--line2); background: var(--panel); border-radius: 8px; padding: 12px; min-height: 82px; }
+  .metric .label { font-family: var(--mono); color: var(--muted); font-size: 11px; text-transform: uppercase; }
+  .metric .value { margin-top: 8px; font-size: 24px; font-weight: 650; }
+  .metric .hint { margin-top: 2px; font-family: var(--mono); color: var(--faint); font-size: 11px; }
+  .main { grid-template-columns: minmax(0, 1.5fr) minmax(360px, .85fr); align-items: start; }
+  .band { border-top: 1px solid var(--line); padding-top: 12px; margin-top: 12px; }
+  .section-head { display: flex; justify-content: space-between; align-items: center; gap: 12px; margin-bottom: 10px; }
+  h2 { margin: 0; font-size: 13px; color: var(--text); font-weight: 650; }
+  .count { font-family: var(--mono); color: var(--faint); font-size: 11px; }
+  .graph-wrap { position: relative; height: 650px; border: 1px solid var(--line); background: #090b0e; border-radius: 8px; overflow: hidden; }
+  canvas { width: 100%; height: 100%; display: block; }
+  .graph-tools { position: absolute; top: 10px; left: 10px; right: 10px; display: flex; gap: 8px; justify-content: space-between; pointer-events: none; }
+  .tool-group { display: flex; gap: 6px; pointer-events: auto; flex-wrap: wrap; }
+  .chip { border: 1px solid var(--line); background: rgba(17,21,26,.9); color: var(--muted); border-radius: 5px; padding: 4px 7px; font-family: var(--mono); font-size: 11px; cursor: pointer; }
+  .chip.active { border-color: var(--cyan); color: var(--cyan); }
+  .detail { border: 1px solid var(--line); background: var(--panel); border-radius: 8px; padding: 12px; min-height: 160px; }
+  .detail-title { font-size: 16px; font-weight: 650; margin-bottom: 5px; }
+  .tag-row { display: flex; flex-wrap: wrap; gap: 6px; margin: 8px 0; }
+  .tag { font-family: var(--mono); font-size: 11px; color: var(--muted); border: 1px solid var(--line); border-radius: 4px; padding: 2px 6px; }
+  .tag.green { color: var(--green); border-color: rgba(72,213,151,.35); }
+  .tag.yellow { color: var(--yellow); border-color: rgba(244,201,93,.35); }
+  .tag.red { color: var(--red); border-color: rgba(255,107,107,.35); }
+  .bars { display: grid; gap: 7px; }
+  .bar-row { display: grid; grid-template-columns: 110px 1fr 54px; align-items: center; gap: 8px; font-family: var(--mono); font-size: 11px; color: var(--muted); }
+  .bar-track { height: 8px; background: #0c1014; border: 1px solid var(--line2); border-radius: 99px; overflow: hidden; }
+  .bar-fill { height: 100%; background: var(--cyan); border-radius: 99px; }
+  .split { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .list { display: grid; gap: 6px; }
+  .row { border: 1px solid var(--line2); background: var(--panel); border-radius: 6px; padding: 8px 9px; cursor: pointer; }
+  .row:hover { border-color: var(--cyan); }
+  .row-top { display: flex; justify-content: space-between; gap: 12px; }
+  .row-name { color: var(--text); font-weight: 560; overflow-wrap: anywhere; }
+  .row-meta { color: var(--muted); font-family: var(--mono); font-size: 11px; margin-top: 4px; }
+  .search-results { margin-top: 8px; max-height: 280px; overflow: auto; display: grid; gap: 6px; }
+  .empty { color: var(--faint); font-family: var(--mono); padding: 10px 0; }
+  .status-line { color: var(--muted); font-family: var(--mono); font-size: 11px; }
+  a { color: var(--cyan); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  @media (max-width: 1050px) {
+    body { padding: 12px; }
+    header { align-items: flex-start; flex-direction: column; }
+    .metrics { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    .main, .split { grid-template-columns: 1fr; }
+    .input { width: 100%; }
+    .graph-wrap { height: 520px; }
+  }
+</style>
+</head>
+<body>
+<div class="shell">
+  <header>
+    <div>
+      <h1>KG Context Observatory</h1>
+      <div class="subtitle" id="subtitle">loading context fabric...</div>
+    </div>
+    <div class="actions">
+      <input class="input" id="search" placeholder="Search entity, alias, context anchor...">
+      <button class="btn" id="refresh">Refresh</button>
+      <a class="btn" href="/kg-graph">Graph Page</a>
+      <a class="btn" href="/dashboard">Runtime Dashboard</a>
+    </div>
+  </header>
+
+  <section class="grid metrics" id="metrics"></section>
+
+  <section class="grid main">
+    <div>
+      <div class="section-head">
+        <h2>Context Link Map</h2>
+        <div class="count" id="graphCount">--</div>
+      </div>
+      <div class="graph-wrap">
+        <canvas id="graph"></canvas>
+        <div class="graph-tools">
+          <div class="tool-group" id="typeFilters"></div>
+          <div class="tool-group">
+            <span class="chip active" id="showLabels">labels</span>
+            <span class="chip" id="pinLayout">pin</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="band grid split">
+        <div>
+          <div class="section-head"><h2>Entity Types</h2><span class="count" id="typeCount">--</span></div>
+          <div class="bars" id="typeBars"></div>
+        </div>
+        <div>
+          <div class="section-head"><h2>Relation Types</h2><span class="count" id="edgeCount">--</span></div>
+          <div class="bars" id="edgeBars"></div>
+        </div>
+      </div>
+    </div>
+
+    <aside>
+      <div class="detail" id="detail">
+        <div class="empty">Click a node or search an entity.</div>
+      </div>
+
+      <div class="band">
+        <div class="section-head"><h2>Search Results</h2><span class="count" id="searchCount">--</span></div>
+        <div class="search-results" id="searchResults"><div class="empty">Type to search KG.</div></div>
+      </div>
+
+      <div class="band">
+        <div class="section-head"><h2>Top Context Anchors</h2><span class="count" id="topCount">--</span></div>
+        <div class="list" id="topEntities"></div>
+      </div>
+
+      <div class="band">
+        <div class="section-head"><h2>Fresh Context</h2><span class="count" id="recentCount">--</span></div>
+        <div class="list" id="recentEntities"></div>
+      </div>
+
+      <div class="band">
+        <div class="section-head"><h2>Attention Queue</h2><span class="count" id="conflictCount">--</span></div>
+        <div class="list" id="conflictEntities"></div>
+      </div>
+    </aside>
+  </section>
+</div>
+
+<script>
+const API = location.origin;
+const COLORS = {
+  actor: '#ffb86c', concept: '#5db7ff', project: '#ad8cff', tool: '#48d597',
+  artifact: '#f4c95d', 'code-symbol': '#6ccff5', event: '#f187c6',
+  claim: '#d6dee7', decision: '#ff6b6b', unknown: '#8b98a5'
+};
+let overview = null;
+let nodes = [];
+let links = [];
+let selected = null;
+let hiddenTypes = new Set();
+let labels = true;
+let pinned = false;
+let raf = 0;
+
+const $ = (id) => document.getElementById(id);
+const esc = (s) => String(s ?? '').replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;', "'":'&#39;'}[c]));
+const fmt = (n) => Number(n ?? 0).toLocaleString();
+
+async function load() {
+  $('subtitle').textContent = 'loading context fabric...';
+  const res = await fetch(API + '/api/kg/overview?graphLimit=150');
+  overview = await res.json();
+  renderOverview();
+  setupGraph();
+  $('subtitle').textContent = 'built ' + (overview.generated_at || '').slice(0, 16).replace('T', ' ') + ' · observable context and links';
+}
+
+function renderOverview() {
+  const s = overview.stats;
+  $('metrics').innerHTML = [
+    metric('Entities', s.entities, 'context anchors'),
+    metric('Edges', s.edges, 'typed relationships'),
+    metric('Resolved', s.resolved, 'typed by resolver'),
+    metric('Pending Conflicts', s.pending_conflicts, 'needs attention'),
+    metric('Orphans', s.orphan_entities, 'no graph degree'),
+    metric('Low Confidence', s.low_confidence_entities + s.low_confidence_edges, 'entities + edges')
+  ].join('');
+  renderBars('typeBars', overview.type_counts, 'typeCount', COLORS);
+  renderBars('edgeBars', overview.edge_type_counts.map(e => ({ type: e.type, count: e.count })), 'edgeCount', {});
+  renderRows('topEntities', overview.top_entities, 'topCount', e => `${e.refs} refs · degree ${e.degree} · ${e.confidence || 'unknown'}`);
+  renderRows('recentEntities', overview.recent_entities, 'recentCount', e => `${e.refs} refs · ${String(e.last_referenced || '').slice(0, 10) || 'no date'}`);
+  renderRows('conflictEntities', overview.conflict_entities, 'conflictCount', e => e.conflicts.join(', ') || 'pending');
+  renderTypeFilters();
+}
+
+function metric(label, value, hint) {
+  return `<div class="metric"><div class="label">${esc(label)}</div><div class="value">${fmt(value)}</div><div class="hint">${esc(hint)}</div></div>`;
+}
+
+function renderBars(id, rows, countId, palette) {
+  $(countId).textContent = rows.length + ' kinds';
+  const max = Math.max(1, ...rows.map(r => r.count));
+  $(id).innerHTML = rows.slice(0, 14).map(r => {
+    const color = palette[r.type] || '#5db7ff';
+    return `<div class="bar-row"><span>${esc(r.type)}</span><div class="bar-track"><div class="bar-fill" style="width:${Math.max(2, r.count / max * 100)}%;background:${color}"></div></div><span>${fmt(r.count)}</span></div>`;
+  }).join('');
+}
+
+function renderRows(id, rows, countId, meta) {
+  $(countId).textContent = rows.length;
+  $(id).innerHTML = rows.length ? rows.map(e => `<div class="row" data-id="${esc(e.id)}"><div class="row-top"><div class="row-name">${esc(e.name)}</div><span class="tag">${esc(e.type)}</span></div><div class="row-meta">${esc(meta(e))}</div></div>`).join('') : '<div class="empty">No entries.</div>';
+  $(id).querySelectorAll('[data-id]').forEach(el => el.addEventListener('click', () => showEntity(el.dataset.id)));
+}
+
+function renderTypeFilters() {
+  $('typeFilters').innerHTML = overview.type_counts.slice(0, 9).map(t => `<span class="chip active" data-type="${esc(t.type)}">${esc(t.type)}</span>`).join('');
+  $('typeFilters').querySelectorAll('[data-type]').forEach(chip => {
+    chip.addEventListener('click', () => {
+      const t = chip.dataset.type;
+      if (hiddenTypes.has(t)) { hiddenTypes.delete(t); chip.classList.add('active'); }
+      else { hiddenTypes.add(t); chip.classList.remove('active'); }
+      draw();
+    });
+  });
+}
+
+function setupGraph() {
+  const canvas = $('graph');
+  const rect = canvas.getBoundingClientRect();
+  canvas.width = Math.floor(rect.width * devicePixelRatio);
+  canvas.height = Math.floor(rect.height * devicePixelRatio);
+  nodes = overview.graph.nodes.map((n, i) => ({
+    ...n,
+    x: rect.width / 2 + Math.cos(i) * 180,
+    y: rect.height / 2 + Math.sin(i) * 180,
+    vx: 0,
+    vy: 0,
+    r: Math.max(4, Math.min(14, 4 + Math.sqrt(n.refs || 1) + Math.sqrt(n.degree || 0) * .6))
+  }));
+  const byId = new Map(nodes.map(n => [n.id, n]));
+  links = overview.graph.links.map(l => ({ ...l, sourceNode: byId.get(l.source), targetNode: byId.get(l.target) })).filter(l => l.sourceNode && l.targetNode);
+  $('graphCount').textContent = nodes.length + ' nodes · ' + links.length + ' links';
+  canvas.onclick = (ev) => {
+    const hit = pickNode(ev);
+    if (hit) showEntity(hit.id, hit);
+  };
+  canvas.onmousemove = (ev) => { canvas.style.cursor = pickNode(ev) ? 'pointer' : 'default'; };
+  if (!raf) tick();
+}
+
+function tick() {
+  if (!pinned) simulate();
+  draw();
+  raf = requestAnimationFrame(tick);
+}
+
+function simulate() {
+  const canvas = $('graph');
+  const w = canvas.clientWidth;
+  const h = canvas.clientHeight;
+  for (const a of nodes) {
+    if (hiddenTypes.has(a.type)) continue;
+    for (const b of nodes) {
+      if (a === b || hiddenTypes.has(b.type)) continue;
+      const dx = a.x - b.x, dy = a.y - b.y;
+      const d2 = Math.max(80, dx * dx + dy * dy);
+      const f = 38 / d2;
+      a.vx += dx * f; a.vy += dy * f;
+    }
+  }
+  for (const l of links) {
+    const a = l.sourceNode, b = l.targetNode;
+    if (hiddenTypes.has(a.type) || hiddenTypes.has(b.type)) continue;
+    const dx = b.x - a.x, dy = b.y - a.y;
+    const d = Math.max(1, Math.sqrt(dx * dx + dy * dy));
+    const target = 70 + (1 - Math.min(1, l.weight)) * 90;
+    const f = (d - target) * 0.0025;
+    a.vx += dx * f; a.vy += dy * f; b.vx -= dx * f; b.vy -= dy * f;
+  }
+  for (const n of nodes) {
+    n.vx += (w / 2 - n.x) * 0.0007;
+    n.vy += (h / 2 - n.y) * 0.0007;
+    n.vx *= 0.84; n.vy *= 0.84;
+    n.x = Math.max(24, Math.min(w - 24, n.x + n.vx));
+    n.y = Math.max(24, Math.min(h - 24, n.y + n.vy));
+  }
+}
+
+function draw() {
+  const canvas = $('graph');
+  const ctx = canvas.getContext('2d');
+  const dpr = devicePixelRatio;
+  const w = canvas.clientWidth, h = canvas.clientHeight;
+  if (canvas.width !== Math.floor(w * dpr) || canvas.height !== Math.floor(h * dpr)) {
+    canvas.width = Math.floor(w * dpr); canvas.height = Math.floor(h * dpr);
+  }
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  ctx.clearRect(0, 0, w, h);
+  ctx.fillStyle = '#090b0e';
+  ctx.fillRect(0, 0, w, h);
+  for (const l of links) {
+    if (hiddenTypes.has(l.sourceNode.type) || hiddenTypes.has(l.targetNode.type)) continue;
+    ctx.globalAlpha = 0.12 + Math.min(.35, l.confidence * .35);
+    ctx.strokeStyle = COLORS[l.type] || '#5d6874';
+    ctx.lineWidth = Math.max(1, l.weight * 2);
+    ctx.beginPath();
+    ctx.moveTo(l.sourceNode.x, l.sourceNode.y);
+    ctx.lineTo(l.targetNode.x, l.targetNode.y);
+    ctx.stroke();
+  }
+  ctx.globalAlpha = 1;
+  for (const n of nodes) {
+    if (hiddenTypes.has(n.type)) continue;
+    ctx.fillStyle = COLORS[n.type] || COLORS.unknown;
+    ctx.strokeStyle = n.conflict ? '#ff6b6b' : (selected && selected.id === n.id ? '#ffffff' : '#0b0d10');
+    ctx.lineWidth = n.conflict || (selected && selected.id === n.id) ? 2.5 : 1.2;
+    ctx.beginPath(); ctx.arc(n.x, n.y, n.r, 0, Math.PI * 2); ctx.fill(); ctx.stroke();
+    if (labels && (n.degree > 8 || n.refs > 4 || (selected && selected.id === n.id))) {
+      ctx.fillStyle = '#d6dee7';
+      ctx.font = '11px ' + getComputedStyle(document.body).fontFamily;
+      ctx.fillText(n.name.slice(0, 28), n.x + n.r + 5, n.y + 4);
+    }
+  }
+}
+
+function pickNode(ev) {
+  const rect = $('graph').getBoundingClientRect();
+  const x = ev.clientX - rect.left, y = ev.clientY - rect.top;
+  return nodes.find(n => !hiddenTypes.has(n.type) && Math.hypot(n.x - x, n.y - y) <= n.r + 4);
+}
+
+async function showEntity(id, localNode) {
+  selected = localNode || nodes.find(n => n.id === id) || null;
+  draw();
+  $('detail').innerHTML = '<div class="empty">Loading entity...</div>';
+  const res = await fetch(API + '/api/kg/entities/' + encodeURIComponent(id));
+  if (!res.ok) { $('detail').innerHTML = '<div class="empty">Entity not found.</div>'; return; }
+  const e = await res.json();
+  const type = Array.isArray(e.resolved_type) ? e.resolved_type.join(' + ') : (e.resolved_type || e.type);
+  $('detail').innerHTML = `
+    <div class="detail-title">${esc(e.canonical_name)}</div>
+    <div class="status-line">${esc(e.id)}</div>
+    <div class="tag-row">
+      <span class="tag green">${esc(type)}</span>
+      <span class="tag ${e.resolution_confidence === 'low' ? 'red' : e.resolution_confidence === 'medium' ? 'yellow' : ''}">conf ${esc(e.resolution_confidence || 'unknown')}</span>
+      <span class="tag">${fmt(e.reference_count)} refs</span>
+      <span class="tag">${fmt((e.neighbors || []).length)} neighbors</span>
+    </div>
+    ${e.aliases && e.aliases.length ? '<div class="status-line">aliases: ' + esc(e.aliases.slice(0, 8).join(', ')) + '</div>' : ''}
+    <div class="band"><div class="section-head"><h2>Neighbors</h2><span class="count">${(e.neighbors || []).length}</span></div>
+    <div class="list">${(e.neighbors || []).slice(0, 10).map(n => `<div class="row" data-id="${esc(n.id)}"><div class="row-top"><div class="row-name">${esc(n.canonical_name)}</div><span class="tag">${esc(n.edge_type)}</span></div><div class="row-meta">${esc(n.direction)} · w=${Number(n.weight || 0).toFixed(2)} · conf=${Number(n.confidence || 0).toFixed(2)}</div></div>`).join('') || '<div class="empty">No strong neighbors.</div>'}</div></div>
+  `;
+  $('detail').querySelectorAll('[data-id]').forEach(el => el.addEventListener('click', () => showEntity(el.dataset.id)));
+}
+
+let searchTimer = 0;
+$('search').addEventListener('input', () => {
+  clearTimeout(searchTimer);
+  searchTimer = setTimeout(runSearch, 180);
+});
+$('refresh').onclick = load;
+$('showLabels').onclick = () => { labels = !labels; $('showLabels').classList.toggle('active', labels); draw(); };
+$('pinLayout').onclick = () => { pinned = !pinned; $('pinLayout').classList.toggle('active', pinned); };
+
+async function runSearch() {
+  const q = $('search').value.trim();
+  if (!q) { $('searchResults').innerHTML = '<div class="empty">Type to search KG.</div>'; $('searchCount').textContent = '--'; return; }
+  const res = await fetch(API + '/api/kg/entities/search?q=' + encodeURIComponent(q) + '&limit=30');
+  const data = await res.json();
+  $('searchCount').textContent = (data.hits || []).length;
+  $('searchResults').innerHTML = (data.hits || []).map(h => `<div class="row" data-id="${esc(h.id)}"><div class="row-top"><div class="row-name">${esc(h.canonical_name)}</div><span class="tag">${esc(h.type)}</span></div><div class="row-meta">${fmt(h.reference_count)} refs · match ${esc(h.match)}</div></div>`).join('') || '<div class="empty">No matches.</div>';
+  $('searchResults').querySelectorAll('[data-id]').forEach(el => el.addEventListener('click', () => showEntity(el.dataset.id)));
+}
+
+load().catch(err => {
+  $('subtitle').textContent = 'failed to load';
+  $('metrics').innerHTML = '<div class="metric"><div class="label">Error</div><div class="hint">' + esc(err.message || err) + '</div></div>';
+});
+</script>
+</body>
+</html>

--- a/kg-graph.html
+++ b/kg-graph.html
@@ -1,0 +1,170 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>KG Graph</title>
+<style>
+  :root {
+    --bg: #07090c; --panel: #10151b; --line: #25313c; --text: #e8eef5; --muted: #8895a3;
+    --cyan: #5db7ff; --green: #48d597; --yellow: #f4c95d; --red: #ff6b6b; --violet: #ad8cff;
+    --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; --sans: Inter, ui-sans-serif, system-ui, sans-serif;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; width: 100%; height: 100%; overflow: hidden; background: var(--bg); color: var(--text); font: 13px/1.4 var(--sans); }
+  #graph { width: 100vw; height: 100vh; display: block; }
+  .topbar, .side, .bottom {
+    position: fixed; border: 1px solid var(--line); background: rgba(16,21,27,.88); backdrop-filter: blur(10px); border-radius: 8px;
+  }
+  .topbar { top: 14px; left: 14px; right: 14px; display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 10px 12px; }
+  .brand { display: flex; flex-direction: column; gap: 2px; min-width: 220px; }
+  h1 { margin: 0; font-size: 15px; font-weight: 650; letter-spacing: 0; }
+  .sub { color: var(--muted); font-family: var(--mono); font-size: 11px; }
+  .controls { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; justify-content: flex-end; }
+  input, button, select, a.btn {
+    border: 1px solid var(--line); background: #0b1015; color: var(--text); min-height: 32px; border-radius: 6px; padding: 6px 9px; font: inherit; text-decoration: none;
+  }
+  input { width: min(440px, 34vw); outline: none; }
+  input:focus { border-color: var(--cyan); }
+  button, a.btn { cursor: pointer; color: var(--muted); }
+  button:hover, a.btn:hover { color: var(--text); border-color: var(--cyan); }
+  button.active { color: var(--cyan); border-color: var(--cyan); }
+  .side { top: 82px; right: 14px; width: 360px; max-height: calc(100vh - 116px); overflow: auto; padding: 12px; }
+  .detail-title { font-size: 17px; font-weight: 650; overflow-wrap: anywhere; }
+  .meta { color: var(--muted); font-family: var(--mono); font-size: 11px; margin-top: 4px; }
+  .tags { display: flex; flex-wrap: wrap; gap: 6px; margin: 10px 0; }
+  .tag { border: 1px solid var(--line); border-radius: 4px; padding: 2px 6px; color: var(--muted); font-family: var(--mono); font-size: 11px; }
+  .tag.hot { color: var(--cyan); border-color: rgba(93,183,255,.45); }
+  .tag.warn { color: var(--yellow); border-color: rgba(244,201,93,.45); }
+  .tag.bad { color: var(--red); border-color: rgba(255,107,107,.45); }
+  .list { display: grid; gap: 6px; margin-top: 8px; }
+  .row { border: 1px solid #1b2530; border-radius: 6px; padding: 8px; cursor: pointer; }
+  .row:hover { border-color: var(--cyan); }
+  .row-name { font-weight: 560; overflow-wrap: anywhere; }
+  .bottom { left: 14px; bottom: 14px; padding: 8px 10px; display: flex; gap: 12px; align-items: center; color: var(--muted); font-family: var(--mono); font-size: 11px; }
+  .dot { display: inline-block; width: 8px; height: 8px; border-radius: 50%; margin-right: 5px; }
+  @media (max-width: 900px) {
+    .topbar { flex-direction: column; align-items: stretch; }
+    input { width: 100%; }
+    .side { left: 14px; right: 14px; width: auto; top: auto; bottom: 14px; max-height: 45vh; }
+    .bottom { display: none; }
+  }
+</style>
+</head>
+<body>
+<canvas id="graph"></canvas>
+<div class="topbar">
+  <div class="brand">
+    <h1>Knowledge Graph</h1>
+    <div class="sub" id="summary">loading...</div>
+  </div>
+  <div class="controls">
+    <input id="search" placeholder="Search and focus an entity...">
+    <select id="limit"><option value="80">80 nodes</option><option value="150" selected>150 nodes</option><option value="240">240 nodes</option></select>
+    <button id="labels" class="active">labels</button>
+    <button id="freeze">freeze</button>
+    <button id="refresh">refresh</button>
+    <a class="btn" href="/kg-dashboard">dashboard</a>
+  </div>
+</div>
+<aside class="side" id="detail"><div class="meta">Click a node to inspect context, references, and neighbors.</div></aside>
+<div class="bottom" id="legend"></div>
+
+<script>
+const COLORS = { actor:'#ffb86c', concept:'#5db7ff', project:'#ad8cff', tool:'#48d597', artifact:'#f4c95d', 'code-symbol':'#6ccff5', event:'#f187c6', claim:'#d6dee7', decision:'#ff6b6b', unknown:'#8895a3' };
+let data, nodes = [], links = [], selected = null, showLabels = true, frozen = false, q = '', raf = 0;
+const $ = id => document.getElementById(id);
+const esc = s => String(s ?? '').replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;', "'":'&#39;'}[c]));
+const fmt = n => Number(n || 0).toLocaleString();
+
+async function load() {
+  const limit = $('limit').value;
+  const res = await fetch('/api/kg/overview?graphLimit=' + encodeURIComponent(limit));
+  data = await res.json();
+  const rect = $('graph').getBoundingClientRect();
+  nodes = data.graph.nodes.map((n, i) => ({...n, x: rect.width/2 + Math.cos(i*2.399)*220, y: rect.height/2 + Math.sin(i*2.399)*220, vx:0, vy:0, r: Math.max(4, Math.min(16, 4 + Math.sqrt(n.refs || 1) + Math.sqrt(n.degree || 0)*.7))}));
+  const byId = new Map(nodes.map(n => [n.id, n]));
+  links = data.graph.links.map(l => ({...l, a: byId.get(l.source), b: byId.get(l.target)})).filter(l => l.a && l.b);
+  $('summary').textContent = `${fmt(data.stats.entities)} entities · ${fmt(data.stats.edges)} edges · ${fmt(data.stats.pending_conflicts)} pending conflicts · built ${(data.generated_at || '').slice(0,16).replace('T',' ')}`;
+  $('legend').innerHTML = data.type_counts.slice(0, 9).map(t => `<span><i class="dot" style="background:${COLORS[t.type] || COLORS.unknown}"></i>${esc(t.type)} ${fmt(t.count)}</span>`).join('');
+  if (!raf) tick();
+}
+
+function tick() {
+  if (!frozen) simulate();
+  draw();
+  raf = requestAnimationFrame(tick);
+}
+
+function visible(n) {
+  if (!q) return true;
+  return n.name.toLowerCase().includes(q) || n.id.toLowerCase().includes(q) || n.type.toLowerCase().includes(q);
+}
+
+function simulate() {
+  const c = $('graph'), w = c.clientWidth, h = c.clientHeight;
+  for (let i = 0; i < nodes.length; i++) for (let j = i + 1; j < nodes.length; j++) {
+    const a = nodes[i], b = nodes[j], dx = a.x-b.x, dy = a.y-b.y, d2 = Math.max(120, dx*dx+dy*dy), f = 52/d2;
+    a.vx += dx*f; a.vy += dy*f; b.vx -= dx*f; b.vy -= dy*f;
+  }
+  for (const l of links) {
+    const dx = l.b.x-l.a.x, dy = l.b.y-l.a.y, d = Math.max(1, Math.hypot(dx, dy)), target = 70 + (1-Math.min(1,l.weight))*120, f = (d-target)*0.0027;
+    l.a.vx += dx*f; l.a.vy += dy*f; l.b.vx -= dx*f; l.b.vy -= dy*f;
+  }
+  for (const n of nodes) {
+    n.vx += (w/2-n.x)*0.0008; n.vy += (h/2-n.y)*0.0008; n.vx*=.84; n.vy*=.84;
+    n.x = Math.max(24, Math.min(w-24, n.x+n.vx)); n.y = Math.max(88, Math.min(h-24, n.y+n.vy));
+  }
+}
+
+function draw() {
+  const c = $('graph'), dpr = devicePixelRatio, w = c.clientWidth, h = c.clientHeight;
+  if (c.width !== Math.floor(w*dpr) || c.height !== Math.floor(h*dpr)) { c.width = Math.floor(w*dpr); c.height = Math.floor(h*dpr); }
+  const ctx = c.getContext('2d'); ctx.setTransform(dpr,0,0,dpr,0,0); ctx.clearRect(0,0,w,h); ctx.fillStyle = '#07090c'; ctx.fillRect(0,0,w,h);
+  for (const l of links) {
+    const active = visible(l.a) || visible(l.b);
+    ctx.globalAlpha = q && !active ? .03 : .12 + l.confidence*.26; ctx.strokeStyle = '#3c4855'; ctx.lineWidth = Math.max(1, l.weight*2);
+    ctx.beginPath(); ctx.moveTo(l.a.x,l.a.y); ctx.lineTo(l.b.x,l.b.y); ctx.stroke();
+  }
+  ctx.globalAlpha = 1;
+  for (const n of nodes) {
+    const active = visible(n); ctx.globalAlpha = q && !active ? .12 : 1;
+    ctx.fillStyle = COLORS[n.type] || COLORS.unknown; ctx.strokeStyle = n.conflict ? '#ff6b6b' : selected === n ? '#fff' : '#05070a'; ctx.lineWidth = selected === n || n.conflict ? 2.5 : 1;
+    ctx.beginPath(); ctx.arc(n.x,n.y,n.r,0,Math.PI*2); ctx.fill(); ctx.stroke();
+    if (showLabels && active && (n.degree > 5 || n.refs > 3 || selected === n || q)) {
+      ctx.fillStyle = '#e8eef5'; ctx.font = '11px system-ui'; ctx.fillText(n.name.slice(0, 34), n.x + n.r + 5, n.y + 4);
+    }
+  }
+  ctx.globalAlpha = 1;
+}
+
+function pick(ev) {
+  const r = $('graph').getBoundingClientRect(), x = ev.clientX-r.left, y = ev.clientY-r.top;
+  return nodes.find(n => Math.hypot(n.x-x,n.y-y) <= n.r+5);
+}
+
+async function inspect(id, node) {
+  selected = node || nodes.find(n => n.id === id); draw();
+  $('detail').innerHTML = '<div class="meta">loading...</div>';
+  const res = await fetch('/api/kg/entities/' + encodeURIComponent(id));
+  const e = await res.json();
+  const type = Array.isArray(e.resolved_type) ? e.resolved_type.join(' + ') : (e.resolved_type || e.type);
+  $('detail').innerHTML = `<div class="detail-title">${esc(e.canonical_name)}</div><div class="meta">${esc(e.id)}</div>
+    <div class="tags"><span class="tag hot">${esc(type)}</span><span class="tag ${e.resolution_confidence === 'low' ? 'bad' : e.resolution_confidence === 'medium' ? 'warn' : ''}">conf ${esc(e.resolution_confidence || 'unknown')}</span><span class="tag">${fmt(e.reference_count)} refs</span></div>
+    ${e.aliases?.length ? `<div class="meta">aliases: ${esc(e.aliases.slice(0,10).join(', '))}</div>` : ''}
+    <div class="meta" style="margin-top:12px">neighbors</div>
+    <div class="list">${(e.neighbors || []).slice(0,14).map(n => `<div class="row" data-id="${esc(n.id)}"><div class="row-name">${esc(n.canonical_name)}</div><div class="meta">${esc(n.edge_type)} · ${esc(n.direction)} · w=${Number(n.weight||0).toFixed(2)}</div></div>`).join('') || '<div class="meta">No strong neighbors.</div>'}</div>`;
+  $('detail').querySelectorAll('[data-id]').forEach(el => el.onclick = () => inspect(el.dataset.id));
+}
+
+$('graph').onclick = ev => { const n = pick(ev); if (n) inspect(n.id, n); };
+$('graph').onmousemove = ev => $('graph').style.cursor = pick(ev) ? 'pointer' : 'default';
+$('search').oninput = ev => { q = ev.target.value.trim().toLowerCase(); draw(); };
+$('labels').onclick = () => { showLabels = !showLabels; $('labels').classList.toggle('active', showLabels); };
+$('freeze').onclick = () => { frozen = !frozen; $('freeze').classList.toggle('active', frozen); };
+$('refresh').onclick = load;
+$('limit').onchange = load;
+load().catch(err => $('summary').textContent = 'failed: ' + (err.message || err));
+</script>
+</body>
+</html>

--- a/src/api.ts
+++ b/src/api.ts
@@ -129,7 +129,7 @@ import { parseInterval } from './cycle-tasks.js';
 import { findComposeFile, readComposeFile } from './compose.js';
 import { setSelfStatusProvider, setPerceptionProviders, setCustomExtensions, getMemoryStateDir } from './memory.js';
 import { createTelegramPoller, getTelegramPoller, getNotificationStats } from './telegram.js';
-import { searchEntities as kgSearchEntities, getEntityCard as kgGetEntityCard, getKgStats } from './kg-entity-search.js';
+import { searchEntities as kgSearchEntities, getEntityCard as kgGetEntityCard, getKgStats, getKgOverview } from './kg-entity-search.js';
 import { getIngestStats as kgGetIngestStats } from './kg-live-ingest.js';
 import { query as kgQuery, formatReport as kgFormatReport } from './kg-query.js';
 import { getKGPromotionLedgerPath, readKGPromotionRecords, summarizeKGPromotions } from './kg-promotion.js';
@@ -3121,6 +3121,11 @@ export function createApi(port = 3001): express.Express {
 
   // Knowledge Graph viz — self-contained HTML rebuilt by kg-viz.ts
   app.get('/kg-graph', (_req: Request, res: Response) => {
+    const liveGraphPath = path.join(process.cwd(), 'kg-graph.html');
+    if (fs.existsSync(liveGraphPath)) {
+      res.sendFile(liveGraphPath);
+      return;
+    }
     const htmlPath = resolveMemoryPath('index', 'kg-graph.html');
     if (fs.existsSync(htmlPath)) {
       res.sendFile(htmlPath);
@@ -3128,6 +3133,15 @@ export function createApi(port = 3001): express.Express {
       res.status(404).type('text/plain').send(
         'kg-graph.html not built yet.\nRun: pnpm tsx scripts/kg-viz.ts',
       );
+    }
+  });
+
+  app.get('/kg-dashboard', (_req: Request, res: Response) => {
+    const htmlPath = path.join(process.cwd(), 'kg-dashboard.html');
+    if (fs.existsSync(htmlPath)) {
+      res.sendFile(htmlPath);
+    } else {
+      res.status(404).send('kg-dashboard.html not found');
     }
   });
 
@@ -3239,6 +3253,15 @@ export function createApi(port = 3001): express.Express {
   app.get('/api/kg/stats', (_req: Request, res: Response) => {
     try {
       res.json(getKgStats());
+    } catch (err) {
+      res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  app.get('/api/kg/overview', (req: Request, res: Response) => {
+    try {
+      const graphLimit = Math.min(Number(req.query.graphLimit ?? 120) || 120, 300);
+      res.json(getKgOverview({ graphLimit }));
     } catch (err) {
       res.status(500).json({ error: (err as Error).message });
     }

--- a/src/kg-entity-search.ts
+++ b/src/kg-entity-search.ts
@@ -5,6 +5,8 @@ const ROOT = process.cwd();
 const ENTITIES_PATH = path.join(ROOT, 'memory/index/entities.jsonl');
 const RESOLVED_PATH = path.join(ROOT, 'memory/index/entities-resolved.jsonl');
 const EDGES_PATH = path.join(ROOT, 'memory/index/edges.jsonl');
+const MANIFEST_PATH = path.join(ROOT, 'memory/index/manifest.json');
+const CONFLICTS_PATH = path.join(ROOT, 'memory/index/conflicts.jsonl');
 
 interface EntityReference {
   chunk_id: string;
@@ -34,6 +36,14 @@ interface Edge {
   weight?: number;
   detector?: string;
   evidence_chunk_id?: string;
+}
+
+interface Conflict {
+  id: string;
+  type: string;
+  entities: string[];
+  status: string;
+  detected_at?: string;
 }
 
 export interface SearchHit {
@@ -71,6 +81,32 @@ export interface EntityCard {
   neighbors: Neighbor[];
 }
 
+export interface KgOverview {
+  generated_at: string;
+  manifest: Record<string, unknown> | null;
+  stats: {
+    entities: number;
+    edges: number;
+    resolved: number;
+    conflicts: number;
+    pending_conflicts: number;
+    orphan_entities: number;
+    low_confidence_entities: number;
+    low_confidence_edges: number;
+  };
+  type_counts: Array<{ type: string; count: number }>;
+  edge_type_counts: Array<{ type: string; count: number; avg_confidence: number; avg_weight: number }>;
+  confidence_bands: Array<{ band: string; count: number }>;
+  detector_counts: Array<{ detector: string; count: number }>;
+  top_entities: Array<{ id: string; name: string; type: string; refs: number; degree: number; confidence?: string }>;
+  recent_entities: Array<{ id: string; name: string; type: string; last_referenced?: string; refs: number }>;
+  conflict_entities: Array<{ id: string; name: string; type: string; conflicts: string[] }>;
+  graph: {
+    nodes: Array<{ id: string; name: string; type: string; refs: number; degree: number; confidence?: string; conflict: boolean }>;
+    links: Array<{ source: string; target: string; type: string; weight: number; confidence: number; detector?: string }>;
+  };
+}
+
 interface Cache {
   entitiesMtime: number;
   resolvedMtime: number;
@@ -96,6 +132,11 @@ function readJsonl<T>(p: string): T[] {
     try { out.push(JSON.parse(s)); } catch { /* skip */ }
   }
   return out;
+}
+
+function readJson<T>(p: string): T | null {
+  if (!fs.existsSync(p)) return null;
+  try { return JSON.parse(fs.readFileSync(p, 'utf8')) as T; } catch { return null; }
 }
 
 function primaryType(ent: Entity): string {
@@ -270,5 +311,139 @@ export function getKgStats(): { entities: number; edges: number; resolved: numbe
     edges,
     resolved,
     generated_at: new Date(Math.max(state.entitiesMtime, state.resolvedMtime, state.edgesMtime)).toISOString(),
+  };
+}
+
+export function getKgOverview(opts: { graphLimit?: number } = {}): KgOverview {
+  const graphLimit = Math.max(20, Math.min(opts.graphLimit ?? 120, 300));
+  const state = loadCache();
+  const conflicts = readJsonl<Conflict>(CONFLICTS_PATH);
+  const manifest = readJson<Record<string, unknown>>(MANIFEST_PATH);
+
+  const degree = new Map<string, number>();
+  const edgeType = new Map<string, { count: number; confidence: number; weight: number }>();
+  const detector = new Map<string, number>();
+  let lowConfidenceEdges = 0;
+
+  for (const arr of state.edgesFrom.values()) {
+    for (const edge of arr) {
+      degree.set(edge.from, (degree.get(edge.from) ?? 0) + 1);
+      degree.set(edge.to, (degree.get(edge.to) ?? 0) + 1);
+      const bucket = edgeType.get(edge.type) ?? { count: 0, confidence: 0, weight: 0 };
+      bucket.count += 1;
+      bucket.confidence += edge.confidence ?? 0;
+      bucket.weight += edge.weight ?? edge.confidence ?? 0;
+      edgeType.set(edge.type, bucket);
+      detector.set(edge.detector ?? 'unknown', (detector.get(edge.detector ?? 'unknown') ?? 0) + 1);
+      if ((edge.confidence ?? 0) < 0.6) lowConfidenceEdges++;
+    }
+  }
+
+  const conflictByEntity = new Map<string, string[]>();
+  for (const conflict of conflicts) {
+    if (conflict.status && conflict.status !== 'pending') continue;
+    for (const id of conflict.entities ?? []) {
+      conflictByEntity.set(id, [...(conflictByEntity.get(id) ?? []), conflict.type]);
+    }
+  }
+
+  const typeCounts = new Map<string, number>();
+  const confidenceBands = new Map<string, number>([
+    ['high', 0],
+    ['medium', 0],
+    ['low', 0],
+    ['unknown', 0],
+  ]);
+  let resolved = 0;
+  let orphanEntities = 0;
+  let lowConfidenceEntities = 0;
+
+  const entities = [...state.byId.values()];
+  for (const ent of entities) {
+    const type = primaryType(ent);
+    typeCounts.set(type, (typeCounts.get(type) ?? 0) + 1);
+    if (ent.resolved_type) resolved++;
+    if ((degree.get(ent.id) ?? 0) === 0) orphanEntities++;
+    const band = ent.resolution_confidence ?? 'unknown';
+    confidenceBands.set(band, (confidenceBands.get(band) ?? 0) + 1);
+    if (band === 'low') lowConfidenceEntities++;
+  }
+
+  const ranked = entities
+    .map((ent) => ({
+      id: ent.id,
+      name: ent.canonical_name ?? ent.id,
+      type: primaryType(ent),
+      refs: ent.references?.length ?? 0,
+      degree: degree.get(ent.id) ?? 0,
+      confidence: ent.resolution_confidence,
+    }))
+    .sort((a, b) => b.degree - a.degree || b.refs - a.refs || a.name.localeCompare(b.name));
+
+  const selected = new Set(ranked.slice(0, graphLimit).map((ent) => ent.id));
+  const graphLinks: KgOverview['graph']['links'] = [];
+  for (const arr of state.edgesFrom.values()) {
+    for (const edge of arr) {
+      if (!selected.has(edge.from) || !selected.has(edge.to)) continue;
+      graphLinks.push({
+        source: edge.from,
+        target: edge.to,
+        type: edge.type,
+        weight: edge.weight ?? edge.confidence ?? 0,
+        confidence: edge.confidence ?? 0,
+        detector: edge.detector,
+      });
+    }
+  }
+  graphLinks.sort((a, b) => b.weight - a.weight || b.confidence - a.confidence);
+
+  return {
+    generated_at: new Date(Math.max(state.entitiesMtime, state.resolvedMtime, state.edgesMtime)).toISOString(),
+    manifest,
+    stats: {
+      entities: state.byId.size,
+      edges: [...state.edgesFrom.values()].reduce((sum, arr) => sum + arr.length, 0),
+      resolved,
+      conflicts: conflicts.length,
+      pending_conflicts: conflicts.filter((c) => !c.status || c.status === 'pending').length,
+      orphan_entities: orphanEntities,
+      low_confidence_entities: lowConfidenceEntities,
+      low_confidence_edges: lowConfidenceEdges,
+    },
+    type_counts: [...typeCounts.entries()].map(([type, count]) => ({ type, count })).sort((a, b) => b.count - a.count),
+    edge_type_counts: [...edgeType.entries()].map(([type, bucket]) => ({
+      type,
+      count: bucket.count,
+      avg_confidence: bucket.count ? bucket.confidence / bucket.count : 0,
+      avg_weight: bucket.count ? bucket.weight / bucket.count : 0,
+    })).sort((a, b) => b.count - a.count),
+    confidence_bands: [...confidenceBands.entries()].map(([band, count]) => ({ band, count })),
+    detector_counts: [...detector.entries()].map(([name, count]) => ({ detector: name, count })).sort((a, b) => b.count - a.count),
+    top_entities: ranked.slice(0, 24),
+    recent_entities: entities
+      .map((ent) => ({
+        id: ent.id,
+        name: ent.canonical_name ?? ent.id,
+        type: primaryType(ent),
+        last_referenced: ent.last_referenced,
+        refs: ent.references?.length ?? 0,
+      }))
+      .sort((a, b) => String(b.last_referenced ?? '').localeCompare(String(a.last_referenced ?? '')))
+      .slice(0, 18),
+    conflict_entities: [...conflictByEntity.entries()]
+      .map(([id, conflictsForEntity]) => {
+        const ent = state.byId.get(id);
+        return {
+          id,
+          name: ent?.canonical_name ?? id,
+          type: ent ? primaryType(ent) : 'unknown',
+          conflicts: [...new Set(conflictsForEntity)],
+        };
+      })
+      .slice(0, 18),
+    graph: {
+      nodes: ranked.slice(0, graphLimit).map((ent) => ({ ...ent, conflict: conflictByEntity.has(ent.id) })),
+      links: graphLinks.slice(0, graphLimit * 4),
+    },
   };
 }


### PR DESCRIPTION
## Summary
- add `/kg-dashboard` as a KG context observatory for entity/edge counts, type distribution, relation distribution, confidence, conflicts, top anchors, fresh context, search, and an interactive graph slice
- replace `/kg-graph` with a live full-screen graph page backed by the KG overview API, with labels, freeze, search focus, node inspection, and graph-size controls
- add `/api/kg/overview` so UI can observe KG context and relationship state without parsing JSONL in the browser
- update the main dashboard link to the KG observatory

## Verification
- pnpm typecheck
- pnpm test -- tests/kg-paths.test.ts tests/kg-context-cache.test.ts tests/kg-promotion.test.ts (Vitest expanded to full suite: 114 files, 902 passed, 2 skipped)
