### PR TITLE
fix(launchd-wrappers): set +e around hn-ai-trend fetcher (mirrors #354)

### DIFF
--- a/scripts/launchd-wrappers/hn-ai-trend.sh
+++ b/scripts/launchd-wrappers/hn-ai-trend.sh
@@ -4,7 +4,18 @@ cd /Users/user/Workspace/mini-agent
 set -a
 . ./.env
 set +a
+# Fetcher: HN firebase API has transient outages. set -e was killing the whole
+# chain on a single fetch failure, leaving today's data empty AND skipping
+# enrichment of yesterday's already-pending posts. Same #354 pattern as the
+# github wrapper — disable ERR_EXIT around the fetcher, log non-zero, continue
+# so enrich + fallback still run on whatever state exists.
+set +e
 /opt/homebrew/bin/node scripts/hn-ai-trend.mjs
+_fetch_exit=$?
+set -e
+if [ $_fetch_exit -ne 0 ]; then
+  echo "[wrapper] hn-ai-trend fetch exited non-zero ($_fetch_exit), continuing to enrich/fallback on existing state"
+fi
 # LLM enrich (local Qwen, then claude-cli remote). Allowed to partially or
 # fully fail — heuristic fallback below always runs to backfill any post
 # still showing 'pending-llm-pass'. See Issue #258 (github wrapper) — same


### PR DESCRIPTION
## Why
Today (2026-05-08) the hn-ai-trend launchd cron failed at 9:00 TST with `exit 1` and produced 0 items. Root cause: a transient HN firebase fetch outage hit `scripts/hn-ai-trend.mjs`, and because the wrapper script had a top-level `set -e`, the failure killed the whole chain — no enrichment of yesterday's pending posts, no heuristic fallback. End result: today's render had only 2 sources / 103 items instead of the usual 4 / 160.

Manually gap-filled this morning (14 posts + Qwen enrichment + rebuild → page restored to 160 items / 4 sources), but the wrapper itself is still vulnerable to the same mode tomorrow.

## What
Wrap the fetcher in `set +e`, capture the exit code, log non-zero, then restore `set -e`. Mirrors the exact pattern already shipped in `scripts/launchd-wrappers/github-ai-trend.sh` via #354.

\`\`\`diff
+set +e
 /opt/homebrew/bin/node scripts/hn-ai-trend.mjs
+_fetch_exit=\$?
+set -e
+if [ \$_fetch_exit -ne 0 ]; then
+  echo "[wrapper] hn-ai-trend fetch exited non-zero (\$_fetch_exit), continuing to enrich/fallback on existing state"
+fi
\`\`\`

## Falsifier
Next 9:00 TST tick: if `hn-ai-trend.mjs` fetch fails again, `~/Library/Logs/hn-ai-trend-launchd.log` should now contain `[wrapper] hn-ai-trend fetch exited non-zero (...), continuing to enrich/fallback on existing state` and the LLM enrich + fallback steps should still execute (their own log lines should appear after the wrapper line). If the chain still aborts silently, the \`set +e\` placement is wrong.

## Verification
- \`bash -n scripts/launchd-wrappers/hn-ai-trend.sh\` passes (parses cleanly, exits 0).
- Pattern is identical to \`github-ai-trend.sh\` (#354) which has been in production since 2026-05-04 with no regressions; that wrapper passes the same bash typecheck and the same smoke test.
- Verified in an isolated worktree (\`/tmp/mini-agent-hn-wrapper-fix\` on branch \`fix/hn-wrapper-set-plus-e\`); runtime checkout was not used for authoring this change.

Authored by \`kuro-agent\` per the agent-relationship boundary registry.