### PR TITLE
fix(launchd): add ~/.local/bin to PATH for claude CLI resolution (#394a)

### DIFF
--- a/scripts/launchd-wrappers/arxiv-ai-trend.sh
+++ b/scripts/launchd-wrappers/arxiv-ai-trend.sh
@@ -1,6 +1,7 @@
 #!/bin/zsh
 set -e
 cd /Users/user/Workspace/mini-agent
+export PATH="$HOME/.local/bin:/opt/homebrew/bin:$PATH"
 set -a
 . ./.env
 set +a

--- a/scripts/launchd-wrappers/github-ai-trend.sh
+++ b/scripts/launchd-wrappers/github-ai-trend.sh
@@ -1,6 +1,7 @@
 #!/bin/zsh
 set -e
 cd /Users/user/Workspace/mini-agent
+export PATH="$HOME/.local/bin:/opt/homebrew/bin:$PATH"
 set -a
 . ./.env
 set +a

--- a/scripts/launchd-wrappers/hn-ai-trend.sh
+++ b/scripts/launchd-wrappers/hn-ai-trend.sh
@@ -1,6 +1,7 @@
 #!/bin/zsh
 set -e
 cd /Users/user/Workspace/mini-agent
+export PATH="$HOME/.local/bin:/opt/homebrew/bin:$PATH"
 set -a
 . ./.env
 set +a

--- a/scripts/launchd-wrappers/latent-space-trend.sh
+++ b/scripts/launchd-wrappers/latent-space-trend.sh
@@ -1,6 +1,7 @@
 #!/bin/zsh
 set -e
 cd /Users/user/Workspace/mini-agent
+export PATH="$HOME/.local/bin:/opt/homebrew/bin:$PATH"
 
 # Idempotency guard: skip if today's file already exists with content
 TODAY=$(date +%Y-%m-%d)

--- a/scripts/launchd-wrappers/x-ai-trend.sh
+++ b/scripts/launchd-wrappers/x-ai-trend.sh
@@ -1,6 +1,7 @@
 #!/bin/zsh
 set -e
 cd /Users/user/Workspace/mini-agent
+export PATH="$HOME/.local/bin:/opt/homebrew/bin:$PATH"
 set -a
 . ./.env
 set +a


### PR DESCRIPTION
## Summary
- ai-trend launchd jobs (`github`/`arxiv`/`hn-ai-trend`) failed remote-enrich 100% with `/bin/sh: claude: command not found` (exit 127), forcing heuristic fallback on every tick.
- Root cause: launchd's default PATH excludes `~/.local/bin` (where `claude` CLI is symlinked).
- Fix: inject `export PATH="$HOME/.local/bin:/opt/homebrew/bin:$PATH"` after `cd $REPO_ROOT` in all 5 wrappers (arxiv, github, hn, latent-space, x).

## Verification
- `zsh -n` syntax check passes for all 5 wrappers.
- Simulated launchd-restricted env:
  ```
  env -i PATH=/usr/bin:/bin HOME=/Users/user zsh -c \
    'export PATH="$HOME/.local/bin:/opt/homebrew/bin:$PATH"; which claude && claude --version'
  → /Users/user/.local/bin/claude
  → 2.1.133 (Claude Code)
  ```

## Falsifier
Tomorrow (2026-05-09) 13:00/15:00 launchd ticks: `~/Workspace/mini-agent/memory/logs/{github,arxiv}-ai-trend-launchd.log` should NOT contain `claude: command not found`. If it still appears → PATH not effective for the spawned `node` subprocess; investigate spawn env (e.g. node child_process inherits parent env, but sandboxing may strip it).

## Scope / non-goals
- Closes part of #394a (Mode A: PATH).
- Mode B (`com.kuro.hn-ai-trend` exits 1, log file never appears) remains a separate issue — that's pre-redirect abort, not a PATH problem.
- Does NOT yet investigate the post-write file disappearance reported in earlier audits (separate issue #394b candidate).

Filed by Kuro autonomously per the audit chain on miles990/mini-agent#394.

🤖 Generated with [Claude Code](https://claude.com/claude-code)