### PR TITLE
feat(394): cron-wire build-kuro-content via launchd 16:25 daily

### DIFF
--- a/scripts/launchd-wrappers/README.md
+++ b/scripts/launchd-wrappers/README.md
@@ -47,3 +47,25 @@ rm ~/Library/LaunchAgents/com.kuro.hn-ai-trend.plist
 After a day of observation: if `hn-ai-trend` 09:00 launchd run produces
 `memory/state/hn-ai-trend/2026-05-06.json` with mtime 09:00:xx (regardless of
 whether mac was asleep at 09:00), migrate the rest.
+
+## build-kuro-content (issue #394)
+
+Daily generator that fills `memory/state/kuro-content/<DATE>.md` so the
+build-ai-trend-index step downstream renders blocks ①③④ with real Kuro voice
+instead of degrading to placeholder.
+
+| field | value |
+|---|---|
+| schedule | 16:25 daily (between enrich ~15:30 and index 16:30) |
+| script | `scripts/build-kuro-content.mjs` (PR #399) |
+| wrapper | `scripts/launchd-wrappers/build-kuro-content.sh` |
+| plist | `scripts/launchd-wrappers/com.kuro.build-kuro-content.plist` |
+| log | `memory/logs/build-kuro-content-launchd.log` |
+| exit codes | 0=live wrote, 1=draft only (gate fail), 2=hard error |
+
+Install:
+
+```sh
+cp scripts/launchd-wrappers/com.kuro.build-kuro-content.plist ~/Library/LaunchAgents/
+launchctl load -w ~/Library/LaunchAgents/com.kuro.build-kuro-content.plist
+```

--- a/scripts/launchd-wrappers/build-kuro-content.sh
+++ b/scripts/launchd-wrappers/build-kuro-content.sh
@@ -1,9 +1,25 @@
 #!/bin/zsh
-# build-kuro-content launchd wrapper (#394)
-# Schedule: 16:25 daily -- after enrich (~15:30), before build-ai-trend-index (16:30)
+# Wrapper for com.kuro.build-kuro-content (issue #394).
+# Runs daily 16:25 between enrich (~15:30) and build-ai-trend-index (16:30)
+# so the index step naturally consumes today's generated kuro-content.
 set -e
 cd /Users/user/Workspace/mini-agent
+# launchd's default PATH excludes ~/.local/bin and homebrew — without these
+# the inner `claude` CLI call (build-kuro-content.mjs:181) can't resolve.
+# Same fix shipped in #398 for the other ai-trend wrappers.
+export PATH="$HOME/.local/bin:/opt/homebrew/bin:$PATH"
 set -a
 . ./.env
 set +a
+# build-kuro-content.mjs returns:
+#   0 = wrote live <DATE>.md (gate passed)
+#   1 = wrote <DATE>.md.draft (gate failed — DO NOT promote)
+#   2 = hard error
+set +e
 /opt/homebrew/bin/node scripts/build-kuro-content.mjs
+_exit=$?
+set -e
+if [ $_exit -ne 0 ]; then
+  echo "[wrapper] build-kuro-content exited $_exit (1=draft-only,2=hard-error)"
+fi
+exit $_exit

--- a/scripts/launchd-wrappers/com.kuro.build-kuro-content.plist
+++ b/scripts/launchd-wrappers/com.kuro.build-kuro-content.plist
@@ -16,9 +16,9 @@
         <integer>25</integer>
     </dict>
     <key>StandardOutPath</key>
-    <string>/Users/user/Workspace/mini-agent/memory/logs/kuro-content-cron.log</string>
+    <string>/Users/user/Workspace/mini-agent/memory/logs/build-kuro-content-launchd.log</string>
     <key>StandardErrorPath</key>
-    <string>/Users/user/Workspace/mini-agent/memory/logs/kuro-content-cron.log</string>
+    <string>/Users/user/Workspace/mini-agent/memory/logs/build-kuro-content-launchd.log</string>
     <key>WorkingDirectory</key>
     <string>/Users/user/Workspace/mini-agent</string>
 </dict>


### PR DESCRIPTION
## Summary
- Closes acceptance criterion #3 of #394: from 2026-05-09 onward, `memory/state/kuro-content/<DATE>.md` is generated daily so `build-ai-trend-index` renders blocks ①③④ with real Kuro voice instead of placeholder.
- Wraps the v0 generator (`scripts/build-kuro-content.mjs`, shipped in #399) in a launchd job + zsh wrapper that fixes the same PATH issue resolved in #398.

## Pieces
| file | purpose |
|---|---|
| `scripts/launchd-wrappers/build-kuro-content.sh` | exports `PATH=~/.local/bin:/opt/homebrew/bin:$PATH` (so inner `claude` CLI resolves under launchd's restricted env), sources `.env`, runs `node scripts/build-kuro-content.mjs`, surfaces exit code |
| `scripts/launchd-wrappers/com.kuro.build-kuro-content.plist` | fires 16:25 TST daily — slot is between enrich (~15:30) and build-ai-trend-index (16:30) so the index step naturally consumes today's file |
| `scripts/launchd-wrappers/README.md` | install + exit-code docs |

## Verification done
- `zsh -n` on the wrapper → OK
- `plutil -lint` on the plist → OK
- `launchctl load -w ~/Library/LaunchAgents/com.kuro.build-kuro-content.plist` → registered (`launchctl list | grep build-kuro-content` returns `- 0 com.kuro.build-kuro-content`)
- Generator script itself (`scripts/build-kuro-content.mjs`): syntax-check passes; review/runtime sign-off was on #399.

## Falsifier (next 24h)
- ✅ `memory/state/kuro-content/2026-05-09.md` exists with mtime ~16:25 TST AND `memory/logs/build-kuro-content-launchd.log` records a non-empty run.
- ❌ If 2026-05-09 file missing OR exit=2 in log → fix is incomplete and root cause is in the script, not the wiring; reopen #394 with that evidence.

## Test plan
- [ ] 2026-05-09 16:25 TST run produces `memory/state/kuro-content/2026-05-09.md` (live, not `.draft`)
- [ ] `build-ai-trend-index` 16:30 TST run loads it (loadKuroContent resolves to non-placeholder)
- [ ] live page (kuro.page) blocks ①③④ render real content rather than mockup-shell
- [ ] If gate fails → `2026-05-09.md.draft` written, page falls back gracefully (does not crash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)