### PR TITLE
fix(394): CJK-aware word count in kuro-content validator

### DIFF
--- a/scripts/build-kuro-content.mjs
+++ b/scripts/build-kuro-content.mjs
@@ -120,10 +120,12 @@ function summarisePosts(label, posts, maxItems = 8) {
 export function validate(content) {
   const issues = [];
 
-  // Word count 600-2000
-  const wordCount = content.split(/\s+/).filter(Boolean).length;
-  if (wordCount < 600) issues.push(`word count too low: ${wordCount} (min 600)`);
-  if (wordCount > 2000) issues.push(`word count too high: ${wordCount} (max 2000)`);
+  // Word count 600-2000 (CJK-aware: en tokens + ceil(cjk chars / 1.6))
+  const enWords = (content.match(/[a-zA-Z][a-zA-Z'\-]*/g) || []).length;
+  const cjkChars = (content.match(/[\u4e00-\u9fff]/g) || []).length;
+  const wordCount = enWords + Math.ceil(cjkChars / 1.6);
+  if (wordCount < 600) issues.push(`word count too low: ${wordCount} (min 600, en=${enWords} cjk=${cjkChars})`);
+  if (wordCount > 2000) issues.push(`word count too high: ${wordCount} (max 2000, en=${enWords} cjk=${cjkChars})`);
 
   // >=1 [text](url) link in kuro-take section
   const takeMatch = content.match(/## kuro-take([\s\S]*?)(?=\n## |\s*$)/);
@@ -350,7 +352,7 @@ async function main() {
   // Ensure the frontmatter date is correct (model might copy exemplar's date)
   generated = generated.replace(/^date:\s*.+$/m, `date: ${DATE}`);
 
-  console.log(`[kuro-content] generated ${generated.split(/\s+/).length} words`);
+  const _en=(generated.match(/[a-zA-Z][a-zA-Z'\-]*/g)||[]).length;const _cjk=(generated.match(/[\u4e00-\u9fff]/g)||[]).length;console.log(`[kuro-content] generated ${_en+Math.ceil(_cjk/1.6)} words (en=${_en} cjk=${_cjk})`);
 
   // 6. Validation gate
   const validationErrors = validate(generated);


### PR DESCRIPTION
## Why

Real-run repro on `~/Workspace/mini-agent` (after PR #398/#399/#400 merged):

```
[kuro-content] generated 272 words
[kuro-content] VALIDATION FAILED:
  - word count too low: 272 (min 600)
[kuro-content] wrote draft -> 2026-05-08.md.draft
[wrapper] build-kuro-content exited 2
```

The draft itself was a fully-formed 2400+ char zh-TW article with kuro-take + github-spotlight + swot — it just had 272 whitespace-separated tokens because CJK has no inter-character spaces. Every bilingual generation will fail validation under the current rule, which silently routes the live page to the placeholder branch.

## What

`validate()` now scores `enWords + ceil(cjkChars / 1.6)`:
- `enWords = content.match(/[a-zA-Z][a-zA-Z'\-]*/g)` — alpha tokens
- `cjkChars = content.match(/[\u4e00-\u9fff]/g)` — Han block
- 1.6 chars/word reflects typical CJK information density vs English

Same threshold (600–2000), same error shape, but with `en=… cjk=…` breakdown in the message for diagnosability.

## Verification

Against the 16:25 generation that triggered this fix (`2026-05-08.md.draft`, en=263 cjk=784 → 753):

```
$ node -e "import('./scripts/build-kuro-content.mjs').then(m=>console.log(m.validate(fs.readFileSync('…draft','utf8'))))"
issues: []
```

Was: `[ "word count too low: 272 (min 600)" ]`. Today's already-published exemplar (`2026-05-08.md`, en=443 cjk=937 → 1029) also passes.

## Falsifier

`scripts/build-kuro-content.mjs` validate() returns non-empty for any zh-TW draft ≥ 600 effective words within next 7 days.