### PR TITLE
fix(hn-ai-trend): extend retry ceiling to cover post-sleep wake (#403)

### DIFF
--- a/scripts/hn-ai-trend.mjs
+++ b/scripts/hn-ai-trend.mjs
@@ -69,15 +69,15 @@ function isAITopic(item) {
   return AI_PATTERNS.some(p => p.test(text));
 }
 
-async function fetchJSON(url, attempt = 1, maxAttempts = 5) {
+async function fetchJSON(url, attempt = 1, maxAttempts = 8) {
   try {
     const r = await fetch(url);
     if (!r.ok) throw new Error(`HTTP ${r.status}`);
     return await r.json();
   } catch (e) {
     if (attempt < maxAttempts) {
-      // exponential backoff with jitter: ~1s, 2s, 4s, 8s (cumulative ~15s)
-      const delay = 1000 * Math.pow(2, attempt - 1) + Math.floor(Math.random() * 250);
+      // exponential backoff with jitter capped at 30s; cumulative ~127s covers post-sleep wake (issue #403)
+      const delay = Math.min(30000, 1000 * Math.pow(2, attempt - 1)) + Math.floor(Math.random() * 250);
       console.error(`[hn-ai-trend] fetch failed (${e.message}); retry ${attempt}/${maxAttempts - 1} in ${delay}ms`);
       await new Promise(res => setTimeout(res, delay));
       return fetchJSON(url, attempt + 1, maxAttempts);


### PR DESCRIPTION
## Summary
- `maxAttempts` 5 → 8 in `scripts/hn-ai-trend.mjs:fetchJSON`
- Per-retry delay capped at 30s
- Cumulative retry window ~91s (vs ~15s before) — covers macOS post-sleep network association

Closes #403.

## Why
Today's 09:00 launchd run logged 4 retries within ~15s then FATAL exit=1, even though the HN Firebase endpoint was healthy at that moment. Same script run minutes later succeeds. Hypothesis (in #403): post-sleep DNS/Wi-Fi association window > current retry budget. Extending the budget is the lowest-effort fix.

## Falsifier
- Pass: tomorrow 2026-05-09 09:00 cron writes `memory/state/hn-ai-trend/2026-05-09.json` without manual intervention.
- Fail: still FATAL exit=1 → hypothesis wrong, escalate to network-layer probe (option B in #403).

## Verification
- `node --check scripts/hn-ai-trend.mjs` passed
- Logic-only diff (3+/3-), behaviour identical when network is up.

🤖 Filed by Kuro (open-cycle 03bbc29a)

