### PR TITLE
fix(hn-ai-trend): extend retry window 15s→63s for post-sleep launchd (#403)

### DIFF
--- a/scripts/hn-ai-trend.mjs
+++ b/scripts/hn-ai-trend.mjs
@@ -69,15 +69,18 @@ function isAITopic(item) {
   return AI_PATTERNS.some(p => p.test(text));
 }
 
-async function fetchJSON(url, attempt = 1, maxAttempts = 5) {
+async function fetchJSON(url, attempt = 1, maxAttempts = 7) {
   try {
     const r = await fetch(url);
     if (!r.ok) throw new Error(`HTTP ${r.status}`);
     return await r.json();
   } catch (e) {
     if (attempt < maxAttempts) {
-      // exponential backoff with jitter: ~1s, 2s, 4s, 8s (cumulative ~15s)
-      const delay = 1000 * Math.pow(2, attempt - 1) + Math.floor(Math.random() * 250);
+      // exponential backoff with jitter, capped at 32s/step:
+      // ~1s, 2s, 4s, 8s, 16s, 32s → cumulative ~63s (was ~15s at maxAttempts=5).
+      // Window must be ≥60s to survive macOS post-sleep DNS/Wi-Fi warmup at the
+      // 09:00 launchd wake (issue #403). Cap prevents runaway delay if extended later.
+      const delay = Math.min(32000, 1000 * Math.pow(2, attempt - 1)) + Math.floor(Math.random() * 250);
       console.error(`[hn-ai-trend] fetch failed (${e.message}); retry ${attempt}/${maxAttempts - 1} in ${delay}ms`);
       await new Promise(res => setTimeout(res, delay));
       return fetchJSON(url, attempt + 1, maxAttempts);


### PR DESCRIPTION
## Summary
Closes #403 (fix path A — extend retry ceiling).

- Retry budget grows from `~15s` (5 attempts) → `~63s` (7 attempts), capped at 32s/step
- Window now exceeds the 30-60s macOS post-sleep Wi-Fi/DNS warmup that was eating the 09:00 launchd run

## Why this fix
Endpoint healthy at 23:23 same day (manual `curl` 200 OK, 401ms). Issue is local — Mac wakes at 09:00, all 5 retries finish before network is associated, FATAL exit, no `memory/state/hn-ai-trend/<DATE>.json` written → silent daily-feed gap.

Sequence math: `1+2+4+8+16+32 = 63s` (verified, see commit).

## Falsifier
Per issue #403: next 09:00 launchd run produces `memory/state/hn-ai-trend/<DATE>.json` by 09:30 without manual rerun. If FATAL persists → hypothesis wrong, escalate to fix path B (explicit network-ready probe).

## Test plan
- [ ] Merge before next 09:00 run
- [ ] Inspect `memory/logs/hn-trend-launchd.log` after 09:00 next morning
- [ ] Confirm `memory/state/hn-ai-trend/<tomorrow>.json` exists by 09:30
- [ ] If still FATAL: reopen #403, switch to network-probe approach

🤖 Filed by Kuro (cycle 03bbc29a, scheduler task #403)