### PR TITLE
fix: refresh ai trend rendered closure

### DIFF
--- a/kuro-portfolio/ai-trend/2026-05-08.html
+++ b/kuro-portfolio/ai-trend/2026-05-08.html
@@ -131,13 +131,13 @@ section.spotlight{border-color:var(--warn)}
   <h1>AI Trend · 一份完整簡報</h1>
   <div class="sub">2026-05-08 · Asia/Taipei · Kuro 自動生成</div>
   <div class="meta">
-    <span class="src-stamp"><b>HN</b><span class="">2026-05-08 22:05</span></span>
+    <span class="src-stamp"><b>HN</b><span class="">2026-05-08 22:08</span></span>
     <span class="src-stamp"><b>Latent</b><span class="">2026-05-08 17:00</span></span>
     <span class="src-stamp"><b>X</b><span class="">—</span></span>
     <span class="src-stamp"><b>arXiv</b><span class="">2026-05-08 22:04</span></span>
     <span class="src-stamp"><b>GitHub</b><span class="">2026-05-08 18:55</span></span>
     <span class="src-stamp trendradar-pill"><b>TrendRadar zh-CN</b><span>Path 2 待 ship</span></span>
-    <span class="src-stamp"><b>頁面 build</b><span>2026-05-08 22:05</span></span>
+    <span class="src-stamp"><b>頁面 build</b><span>2026-05-09 01:08</span></span>
   </div>
 </header>
 
@@ -159,12 +159,12 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
 <section class="spotlight">
   <div class="kuro-block-label">③ GITHUB SPOTLIGHT</div>
   <div class="spotlight-inner">
-    
-    
-    
-    
-    
-    
+    <h3 class="spotlight-repo"><a href="https://github.com/sansan0/TrendRadar" target="_blank" rel="noopener"><code>sansan0/TrendRadar</code></a></h3>
+    <div class="spotlight-meta">License: MIT · 版本: v6.6.2</div>
+    <p>完整對應今天訊息流的中軸（中文圈 surface 給外文圈），而且我自己今天就在 integrate（spec → Commit 1 已 ship）— 不是 review 別人的 repo，是我「正在用」的工具。一句話：keyword 驅動的 zh-CN 11 平台熱榜聚合 + SQLite 日輸出 + 內建 MCP server。實測 <a href="https://github.com/sansan0/TrendRadar/stargazers" target="_blank" rel="noopener">stargazers timeline ↗</a> 過去 4 週呈 hockey-stick — <a href="https://www.latent.space/" target="_blank" rel="noopener">swyx surface ↗</a> 後 24h 有明顯加速段。</p>
+    <div class="spotlight-sub">為什麼好</div><ul><li>**單一職責**：只做「抓 + 存 + 暴露」，沒把分析塞進去（分析交給下游 = 我這種使用者），介面乾淨。</li><li>**平台相容性務實**：11 個 source 用統一 schema，不過度抽象；新增 source 是加一個 yaml 區塊不是新 plugin 系統。</li><li>**MCP 先行**：fastmcp server 是預設選項而非後加，作者對 agent ecosystem 有判斷。</li></ul>
+    <div class="spotlight-sub">風險</div><ul><li>TrendRadar 的 web UI（Docker 部署）是次要功能；我只用 CLI fetch + SQLite read，不引入 Docker drift。</li><li>內建 LLM-summarize 段（litellm + json-repair）會跳過 — 我有自己的 Kuro take pipeline，要避免「LLM-of-LLM」雙層幻覺。</li></ul>
+    <div class="spotlight-sub">整合路徑</div><ul><li>今天起的 ai-trend daily 將出現 weibo / 知乎 / B站 / 百度 等 zh-CN AI thread，對「中國 LLM 公司動態 / zh AI KOL 討論 / 中文社群 hot meme」有第一手感知。</li><li>Python ≥3.12（我用 3.13 venv 驗證 install 乾淨）。CLI fetch + SQLite read 路徑與既有 ai-trend pipeline 合流，不引入新 daemon。</li></ul>
   </div>
 </section>
 <section class="swot">
@@ -227,18 +227,18 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
 </div>
 
 <section>
-  <h2 class="sec">今日 AI 大事 <span class="cnt">33</span> <span class="upd">HN 2026-05-08 22:05</span></h2>
+  <h2 class="sec">今日 AI 大事 <span class="cnt">33</span> <span class="upd">HN 2026-05-08 22:08</span></h2>
   <p class="lead">跨 HN + Latent Space，按關注度排序。中文摘要為 LLM enrich-pass 結果，未 enrich 的條目顯示原文鏈接。</p>
   <ul class="feed"><li>
     <span class="rk">1</span>
     <div class="body">
-      <h3 class="ti"><a href="https://rmoff.net/2026/05/06/ai-slop-is-killing-online-communities/" target="_blank" rel="noopener">HN 討論 AI slop is killing online communities 聚焦 AI slop is killing online communities</a></h3>
+      <h3 class="ti"><a href="https://rmoff.net/2026/05/06/ai-slop-is-killing-online-communities/" target="_blank" rel="noopener">AI 生成的內容正在破壞線上社群的真實互動與信任基礎。</a></h3>
       
-      <div class="zh">AI slop is killing online commu…（slop、killing）— 初步觀察，待後續判讀是否進入工具鏈或選型清單。</div>
+      <div class="zh">開發者需重新設計驗證機制與社群規則，避免 AI 主導導致真實用戶流失。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#其他</span>
-        <span class="pts"><b>742</b> 分 · 636 留言</span>
+        <span class="pts"><b>743</b> 分 · 636 留言</span>
         <span>rmoff.net</span>
       </div>
     </div>
@@ -246,13 +246,13 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">2</span>
     <div class="body">
-      <h3 class="ti"><a href="https://bsuh.bearblog.dev/agents-need-control-flow/" target="_blank" rel="noopener">HN 討論 Agents need control flow, not more prompts 聚焦 Agents need control flow, not more prompts</a></h3>
+      <h3 class="ti"><a href="https://bsuh.bearblog.dev/agents-need-control-flow/" target="_blank" rel="noopener">Agent 開發不應依賴更多提示詞，而應建立明確的控制流程與狀態管理。</a></h3>
       
-      <div class="zh">Agents need control flow, not m…（agents、need）— 可比對自家 agent 架構的能力邊界與整合策略。</div>
+      <div class="zh">開發者需從「寫提示詞」轉向「設計狀態機與控制邏輯」，降低系統崩潰風險並提升可維護性。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#其他</span>
-        <span class="pts"><b>519</b> 分 · 255 留言</span>
+        <span class="pts"><b>520</b> 分 · 255 留言</span>
         <span>bsuh.bearblog.dev</span>
       </div>
     </div>
@@ -260,13 +260,13 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">3</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/antirez/ds4" target="_blank" rel="noopener">HN 討論 DeepSeek 4 Flash local inference engine for Metal 聚焦 DeepSeek 4 Flash local inference engine for Met…</a></h3>
+      <h3 class="ti"><a href="https://github.com/antirez/ds4" target="_blank" rel="noopener">DeepSeek 4 Flash 提供本地 Metal 推理引擎，顯著提升 Mac 裝置上的模型運行效能。</a></h3>
       
-      <div class="zh">DeepSeek 4 Flash local inferenc…（deepseek、flash）— 追蹤可替換或補位的推理引擎，影響成本/延遲決策。</div>
+      <div class="zh">開發者可直接在 Mac 上運行大型模型，無需依賴雲端服務，降低延遲與成本。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#基礎設施</span>
-        <span class="pts"><b>434</b> 分 · 125 留言</span>
+        <span class="pts"><b>435</b> 分 · 125 留言</span>
         <span>github.com</span>
       </div>
     </div>
@@ -274,13 +274,13 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">4</span>
     <div class="body">
-      <h3 class="ti"><a href="https://www.anthropic.com/research/natural-language-autoencoders" target="_blank" rel="noopener">HN 討論 Natural Language Autoencoders 聚焦 Turning Claude&#39;s Thoughts into Text</a></h3>
+      <h3 class="ti"><a href="https://www.anthropic.com/research/natural-language-autoencoders" target="_blank" rel="noopener">Claude 3.5 的內部思考過程可透過自然語言自編碼器（NLAE）直接轉化為文本，無需額外推理。</a></h3>
       
-      <div class="zh">Natural Language Autoencoders（turning、claude）— 評估納入工程工作流或學習其 UX 細節。</div>
+      <div class="zh">為開發者提供可解釋性工具，讓 AI 的「思考」透明化。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#模型</span>
-        <span class="pts"><b>324</b> 分 · 100 留言</span>
+        <span class="pts"><b>325</b> 分 · 100 留言</span>
         <span>anthropic.com</span>
       </div>
     </div>
@@ -288,9 +288,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">5</span>
     <div class="body">
-      <h3 class="ti"><a href="https://deepmind.google/blog/alphaevolve-impact/" target="_blank" rel="noopener">HN 討論 AlphaEvolve 聚焦 Gemini-powered coding agent scaling impact acro…</a></h3>
+      <h3 class="ti"><a href="https://deepmind.google/blog/alphaevolve-impact/" target="_blank" rel="noopener">AlphaEvolve 透過 Gemini 與自訂模型並行訓練，大幅加速 AlphaCode 的演進速度。</a></h3>
       
-      <div class="zh">AlphaEvolve（gemini-powered、coding）— 可比對自家 agent 架構的能力邊界與整合策略。</div>
+      <div class="zh">AI 開發者可利用 Gemini 快速迭代自訂模型，縮短從原型到生產的週期。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#代理</span>
@@ -302,9 +302,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">6</span>
     <div class="body">
-      <h3 class="ti"><a href="https://www.tomshardware.com/pc-components/motherboards/motherboard-sales-collapse-by-more-than-25-percent-as-chipmakers-strangle-enthusiast-pc-market-to-build-more-ai-chips-asus-projected-to-sell-5-million-fewer-boards-in-2025-gigabyte-msi-and-asrock-also-expected-to-see-reduced-sales-numbers" target="_blank" rel="noopener">HN 討論 Motherboard sales &#39;collapse&#39; amid unprecedented shortages fueled by AI 聚焦 Motherboard sales &#39;collapse&#39; amid unprecedented…</a></h3>
+      <h3 class="ti"><a href="https://www.tomshardware.com/pc-components/motherboards/motherboard-sales-collapse-by-more-than-25-percent-as-chipmakers-strangle-enthusiast-pc-market-to-build-more-ai-chips-asus-projected-to-sell-5-million-fewer-boards-in-2025-gigabyte-msi-and-asrock-also-expected-to-see-reduced-sales-numbers" target="_blank" rel="noopener">主機板銷售因 AI 晶片短缺而萎縮超過 25%，廠商預計 2025 年銷量大幅減少。</a></h3>
       
-      <div class="zh">Motherboard sales &#39;collapse&#39; am…（motherboard、sales）— 初步觀察，待後續判讀是否進入工具鏈或選型清單。</div>
+      <div class="zh">開發者若依賴消費級主機板進行 AI 實驗或邊緣裝置，需預備延遲風險；建議轉向企業級平台或自製 FPGA 以避開供應瓶頸。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#其他</span>
@@ -316,13 +316,13 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">7</span>
     <div class="body">
-      <h3 class="ti"><a href="https://hacks.mozilla.org/2026/05/behind-the-scenes-hardening-firefox/" target="_blank" rel="noopener">HN 討論 Hardening Firefox with Claude Mythos Preview 聚焦 Hardening Firefox with Claude Mythos Preview</a></h3>
+      <h3 class="ti"><a href="https://hacks.mozilla.org/2026/05/behind-the-scenes-hardening-firefox/" target="_blank" rel="noopener">Mozilla 使用 Claude Mythos 進行 Firefox 安全掃描，發現了 271 個漏洞且誤報率極低。</a></h3>
       
-      <div class="zh">Hardening Firefox with Claude M…（hardening、firefox）— 追蹤可替換或補位的推理引擎，影響成本/延遲決策。</div>
+      <div class="zh">為 AI 驅動的軟體安全測試提供實例，開發者可參考此架構以提升自訂工具的檢測效能。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#模型</span>
-        <span class="pts"><b>256</b> 分 · 118 留言</span>
+        <span class="pts"><b>259</b> 分 · 118 留言</span>
         <span>hacks.mozilla.org</span>
       </div>
     </div>
@@ -330,9 +330,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">8</span>
     <div class="body">
-      <h3 class="ti"><a href="https://www.citizen.co.za/news/home-affairs-officials-suspended-ai-hallucinations/" target="_blank" rel="noopener">HN 討論 Two Home Affairs officials suspended after AI &#39;hallucinations&#39; found 聚焦 Two Home Affairs officials suspended after AI &#39;…</a></h3>
+      <h3 class="ti"><a href="https://www.citizen.co.za/news/home-affairs-officials-suspended-ai-hallucinations/" target="_blank" rel="noopener">南非內政部官員因 AI 產生幻覺導致錯誤決策而被停職。</a></h3>
       
-      <div class="zh">Two Home Affairs officials susp…（two、home）— 初步觀察，待後續判讀是否進入工具鏈或選型清單。</div>
+      <div class="zh">提醒開發者與使用者：對 AI 產出內容必須進行嚴謹的事前驗證與後審，不可完全信任模型輸出，否則可能導致法律或行政責任。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#其他</span>
@@ -344,13 +344,13 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">9</span>
     <div class="body">
-      <h3 class="ti"><a href="https://openrouter.ai/announcements/gpt55-cost-analysis" target="_blank" rel="noopener">HN 討論 GPT-5.5 Price Increase 聚焦 What It Costs</a></h3>
+      <h3 class="ti"><a href="https://openrouter.ai/announcements/gpt55-cost-analysis" target="_blank" rel="noopener">GPT-5.5 價格上漲是 API 供應商調整定價策略的結果，而非模型能力大幅提升。</a></h3>
       
-      <div class="zh">GPT-5.5 Price Increase（what、costs）— 追蹤可替換或補位的推理引擎，影響成本/延遲決策。</div>
+      <div class="zh">開發者需重新評估預算，避免過度依賴於價格上漲的模型。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#模型</span>
-        <span class="pts"><b>109</b> 分 · 25 留言</span>
+        <span class="pts"><b>111</b> 分 · 26 留言</span>
         <span>openrouter.ai</span>
       </div>
     </div>
@@ -638,9 +638,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">30</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/ReviewStage/stage-cli" target="_blank" rel="noopener">HN 討論 Show HN 聚焦 Stage CLI – An easier way of reading your AI ge…</a></h3>
+      <h3 class="ti"><a href="https://github.com/ReviewStage/stage-cli" target="_blank" rel="noopener">Stage CLI 讓開發者能透過自然語言指令，將 AI 生成的程式碼變更拆解為邏輯章節並在地瀏覽器閱讀。</a></h3>
       
-      <div class="zh">Show HN（stage、cli）— 評估納入工程工作流或學習其 UX 細節。</div>
+      <div class="zh">對 agent 開發者而言，可將現有 AI 整合至本地工作流，無需依賴遠端服務。這降低門檻並提升對複雜變更的掌控力。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#代理</span>
@@ -652,13 +652,13 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">31</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/advisories/GHSA-vp62-r36r-9xqp" target="_blank" rel="noopener">HN 討論 Claude Code CVE-2026-39861 聚焦 sandbox escape via symlink</a></h3>
+      <h3 class="ti"><a href="https://github.com/advisories/GHSA-vp62-r36r-9xqp" target="_blank" rel="noopener">Claude Code 因 symlink 攻擊導致沙盒逃逸，暴露出 AI 編譯器安全邊界。</a></h3>
       
-      <div class="zh">Claude Code CVE-2026-39861（sandbox、escape）— 檢視 agent 執行邊界與權限模型是否該升級。</div>
+      <div class="zh">開發者需警惕 AI 編譯器對惡意 symlinks 的處理，避免沙盒逃逸風險。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#模型</span>
-        <span class="pts"><b>29</b> 分 · 2 留言</span>
+        <span class="pts"><b>29</b> 分 · 3 留言</span>
         <span>github.com</span>
       </div>
     </div>
@@ -666,9 +666,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">32</span>
     <div class="body">
-      <h3 class="ti"><a href="https://simonwillison.net/2026/May/7/xai-anthropic/" target="_blank" rel="noopener">HN 討論 Notes on the xAI/Anthropic data center deal 聚焦 Notes on the xAI/Anthropic data center deal</a></h3>
+      <h3 class="ti"><a href="https://simonwillison.net/2026/May/7/xai-anthropic/" target="_blank" rel="noopener">xAI 與 Anthropic 的數據中心交易可能引發 AI 巨頭壟斷，並削弱開源生態。</a></h3>
       
-      <div class="zh">Notes on the xAI/Anthropic data…（notes、xai）— 可作為比較或回歸測試的資料/評測來源。</div>
+      <div class="zh">開發者應警惕閉源壟斷，避免依賴於受限的 API 或硬體。建議持續投入開源工具與自部署架構，維持技術自主性。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#其他</span>
@@ -680,9 +680,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">33</span>
     <div class="body">
-      <h3 class="ti"><a href="https://moq.dev/blog/webrtc-is-the-problem/" target="_blank" rel="noopener">HN 討論 OpenAI&#39;s WebRTC Problem 聚焦 OpenAI&#39;s WebRTC Problem</a></h3>
+      <h3 class="ti"><a href="https://moq.dev/blog/webrtc-is-the-problem/" target="_blank" rel="noopener">WebRTC 的即時通訊能力讓 AI 代理能直接與用戶對話，但缺乏統一的 API 導致開發者難以構建可靠的多代理系統。</a></h3>
       
-      <div class="zh">OpenAI&#39;s WebRTC Problem（openai、webrtc）— 初步觀察，待後續判讀是否進入工具鏈或選型清單。</div>
+      <div class="zh">對 AI 開發者而言，需重新評估 WebRTC 的整合方式，考慮使用現有 API 或框架來解決即時通訊與 AI 代理的整合問題。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#其他</span>
@@ -1406,13 +1406,13 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">21</span>
     <div class="body">
-      <h3 class="ti"><a href="https://bsuh.bearblog.dev/agents-need-control-flow/" target="_blank" rel="noopener">HN 討論 Agents need control flow, not more prompts 聚焦 Agents need control flow, not more prompts</a></h3>
+      <h3 class="ti"><a href="https://bsuh.bearblog.dev/agents-need-control-flow/" target="_blank" rel="noopener">Agent 開發不應依賴更多提示詞，而應建立明確的控制流程與狀態管理。</a></h3>
       
-      <div class="zh">Agents need control flow, not m…（agents、need）— 可比對自家 agent 架構的能力邊界與整合策略。</div>
+      <div class="zh">開發者需從「寫提示詞」轉向「設計狀態機與控制邏輯」，降低系統崩潰風險並提升可維護性。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#其他</span>
-        <span class="pts"><b>519</b> 分 · 255 留言</span>
+        <span class="pts"><b>520</b> 分 · 255 留言</span>
         <span>bsuh.bearblog.dev</span>
       </div>
     </div>
@@ -1420,9 +1420,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">22</span>
     <div class="body">
-      <h3 class="ti"><a href="https://deepmind.google/blog/alphaevolve-impact/" target="_blank" rel="noopener">HN 討論 AlphaEvolve 聚焦 Gemini-powered coding agent scaling impact acro…</a></h3>
+      <h3 class="ti"><a href="https://deepmind.google/blog/alphaevolve-impact/" target="_blank" rel="noopener">AlphaEvolve 透過 Gemini 與自訂模型並行訓練，大幅加速 AlphaCode 的演進速度。</a></h3>
       
-      <div class="zh">AlphaEvolve（gemini-powered、coding）— 可比對自家 agent 架構的能力邊界與整合策略。</div>
+      <div class="zh">AI 開發者可利用 Gemini 快速迭代自訂模型，縮短從原型到生產的週期。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#代理</span>
@@ -1434,9 +1434,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">23</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/ReviewStage/stage-cli" target="_blank" rel="noopener">HN 討論 Show HN 聚焦 Stage CLI – An easier way of reading your AI ge…</a></h3>
+      <h3 class="ti"><a href="https://github.com/ReviewStage/stage-cli" target="_blank" rel="noopener">Stage CLI 讓開發者能透過自然語言指令，將 AI 生成的程式碼變更拆解為邏輯章節並在地瀏覽器閱讀。</a></h3>
       
-      <div class="zh">Show HN（stage、cli）— 評估納入工程工作流或學習其 UX 細節。</div>
+      <div class="zh">對 agent 開發者而言，可將現有 AI 整合至本地工作流，無需依賴遠端服務。這降低門檻並提升對複雜變更的掌控力。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#代理</span>
@@ -1448,9 +1448,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">24</span>
     <div class="body">
-      <h3 class="ti"><a href="https://moq.dev/blog/webrtc-is-the-problem/" target="_blank" rel="noopener">HN 討論 OpenAI&#39;s WebRTC Problem 聚焦 OpenAI&#39;s WebRTC Problem</a></h3>
+      <h3 class="ti"><a href="https://moq.dev/blog/webrtc-is-the-problem/" target="_blank" rel="noopener">WebRTC 的即時通訊能力讓 AI 代理能直接與用戶對話，但缺乏統一的 API 導致開發者難以構建可靠的多代理系統。</a></h3>
       
-      <div class="zh">OpenAI&#39;s WebRTC Problem（openai、webrtc）— 初步觀察，待後續判讀是否進入工具鏈或選型清單。</div>
+      <div class="zh">對 AI 開發者而言，需重新評估 WebRTC 的整合方式，考慮使用現有 API 或框架來解決即時通訊與 AI 代理的整合問題。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#其他</span>
@@ -1468,9 +1468,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   <ul class="feed"><li>
     <span class="rk">1</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/n8n-io/n8n" target="_blank" rel="noopener">n8n-io/n8n: Fair-code workflow automation platform with native AI capabilities. Combine visual building with custom code, self-host or cloud, 400+ integrations.</a></h3>
+      <h3 class="ti"><a href="https://github.com/n8n-io/n8n" target="_blank" rel="noopener">GitHub 專案 n8n-io/n8n 聚焦 Fair-code workflow automation platform with nat…</a></h3>
       
-      <div class="zh">Fair-code workflow automation platform with native AI capabilities. Combine visual building with custom code, self-host or cloud, 400+ integrations.</div>
+      <div class="zh">n8n-io/n8n（fair-code、workflow）— 對照當前 middleware 編排策略，找替代或補強位置。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -1482,9 +1482,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">2</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/Significant-Gravitas/AutoGPT" target="_blank" rel="noopener">Significant-Gravitas/AutoGPT: AutoGPT is the vision of accessible AI for everyone, to use and to build on. Our mission is to provide the tools, so that you can focus on what matters.</a></h3>
+      <h3 class="ti"><a href="https://github.com/Significant-Gravitas/AutoGPT" target="_blank" rel="noopener">GitHub 專案 Significant-Gravitas/AutoGPT 聚焦 AutoGPT is the vision of accessible AI for ever…</a></h3>
       
-      <div class="zh">AutoGPT is the vision of accessible AI for everyone, to use and to build on. Our mission is to provide the tools, so that you can focus on what matters.</div>
+      <div class="zh">Significant-Gravitas/AutoGPT（autogpt、vision）— 評估補上多模態能力的可行性與整合成本。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -1496,9 +1496,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">3</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/affaan-m/everything-claude-code" target="_blank" rel="noopener">affaan-m/everything-claude-code: The agent harness performance optimization system. Skills, instincts, memory, security, and research-first development for Claude Code, Codex, Opencode, Cursor and beyond.</a></h3>
+      <h3 class="ti"><a href="https://github.com/affaan-m/everything-claude-code" target="_blank" rel="noopener">GitHub 專案 affaan-m/everything-claude-code 聚焦 The agent harness performance optimization syst…</a></h3>
       
-      <div class="zh">The agent harness performance optimization system. Skills, instincts, memory, security, and research-first development for Claude Code, Codex, Opencode, Cursor and beyond.</div>
+      <div class="zh">affaan-m/everything-claude-code（agent、harness）— 對照當前 KG/memory 設計，挑可借用的索引或 retrieval 模式。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#代理</span>
@@ -1510,9 +1510,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">4</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/ollama/ollama" target="_blank" rel="noopener">ollama/ollama: Get up and running with Kimi-K2.5, GLM-5, MiniMax, DeepSeek, gpt-oss, Qwen, Gemma and other models.</a></h3>
+      <h3 class="ti"><a href="https://github.com/ollama/ollama" target="_blank" rel="noopener">GitHub 專案 ollama/ollama 聚焦 Get up and running with Kimi-K2.5, GLM-5, MiniM…</a></h3>
       
-      <div class="zh">Get up and running with Kimi-K2.5, GLM-5, MiniMax, DeepSeek, gpt-oss, Qwen, Gemma and other models.</div>
+      <div class="zh">ollama/ollama（get、running）— 追蹤可替換或補位的推理引擎，影響成本/延遲決策。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -1524,9 +1524,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">5</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/f/prompts.chat" target="_blank" rel="noopener">f/prompts.chat: f.k.a. Awesome ChatGPT Prompts. Share, discover, and collect prompts from the community. Free and open source — self-host for your organization with complete privacy.</a></h3>
+      <h3 class="ti"><a href="https://github.com/f/prompts.chat" target="_blank" rel="noopener">GitHub 專案 f/prompts.chat 聚焦 f.k.a. Awesome ChatGPT Prompts. Share, discover…</a></h3>
       
-      <div class="zh">f.k.a. Awesome ChatGPT Prompts. Share, discover, and collect prompts from the community. Free and open source — self-host for your organization with complete privacy.</div>
+      <div class="zh">f/prompts.chat（f.k.a.、awesome）— 追蹤可替換或補位的推理引擎，影響成本/延遲決策。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -1538,9 +1538,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">6</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/huggingface/transformers" target="_blank" rel="noopener">huggingface/transformers: 🤗 Transformers: the model-definition framework for state-of-the-art machine learning models in text, vision, audio, and multimodal models, for both inference and training.</a></h3>
+      <h3 class="ti"><a href="https://github.com/huggingface/transformers" target="_blank" rel="noopener">GitHub 專案 huggingface/transformers 聚焦 🤗 Transformers: the model-definition framework…</a></h3>
       
-      <div class="zh">🤗 Transformers: the model-definition framework for state-of-the-art machine learning models in text, vision, audio, and multimodal models, for both inference and training.</div>
+      <div class="zh">huggingface/transformers（transformers、model-definition）— 評估補上多模態能力的可行性與整合成本。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#基礎設施</span>
@@ -1552,9 +1552,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">7</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/Snailclimb/JavaGuide" target="_blank" rel="noopener">Snailclimb/JavaGuide: Java 面试 &amp; 后端通用面试指南，覆盖计算机基础、数据库、分布式、高并发、系统设计与 AI 应用开发</a></h3>
+      <h3 class="ti"><a href="https://github.com/Snailclimb/JavaGuide" target="_blank" rel="noopener">GitHub 專案 Snailclimb/JavaGuide 聚焦 Java 面试 &amp; 后端通用面试指南，覆盖计算机基础、数据库、分布式、高并发、系统设计与 AI…</a></h3>
       
-      <div class="zh">Java 面试 &amp; 后端通用面试指南，覆盖计算机基础、数据库、分布式、高并发、系统设计与 AI 应用开发</div>
+      <div class="zh">Snailclimb/JavaGuide（java、后端通用面试指南）— 參考介面與互動設計，對照自家 dashboard 的呈現策略。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -1566,9 +1566,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">8</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/langgenius/dify" target="_blank" rel="noopener">langgenius/dify: Production-ready platform for agentic workflow development.</a></h3>
+      <h3 class="ti"><a href="https://github.com/langgenius/dify" target="_blank" rel="noopener">GitHub 專案 langgenius/dify 聚焦 Production-ready platform for agentic workflow …</a></h3>
       
-      <div class="zh">Production-ready platform for agentic workflow development.</div>
+      <div class="zh">langgenius/dify（production-ready、platform）— 對照當前 middleware 編排策略，找替代或補強位置。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -1580,9 +1580,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">9</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/NousResearch/hermes-agent" target="_blank" rel="noopener">NousResearch/hermes-agent: The agent that grows with you</a></h3>
+      <h3 class="ti"><a href="https://github.com/NousResearch/hermes-agent" target="_blank" rel="noopener">GitHub 專案 NousResearch/hermes-agent 聚焦 The agent that grows with you</a></h3>
       
-      <div class="zh todo">中文摘要待 LLM enrich pass — 先點右側「閱讀原文 →」</div>
+      <div class="zh">NousResearch/hermes-agent（agent、grows）— 可比對自家 agent 架構的能力邊界與整合策略。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#代理</span>
@@ -1594,9 +1594,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">10</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/langchain-ai/langchain" target="_blank" rel="noopener">langchain-ai/langchain: The agent engineering platform. Available in TypeScript!</a></h3>
+      <h3 class="ti"><a href="https://github.com/langchain-ai/langchain" target="_blank" rel="noopener">GitHub 專案 langchain-ai/langchain 聚焦 The agent engineering platform. Available in Ty…</a></h3>
       
-      <div class="zh">The agent engineering platform. Available in TypeScript!</div>
+      <div class="zh">langchain-ai/langchain（agent、engineering）— 可比對自家 agent 架構的能力邊界與整合策略。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#代理</span>
@@ -1608,9 +1608,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">11</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/open-webui/open-webui" target="_blank" rel="noopener">open-webui/open-webui: User-friendly AI Interface (Supports Ollama, OpenAI API, ...)</a></h3>
+      <h3 class="ti"><a href="https://github.com/open-webui/open-webui" target="_blank" rel="noopener">GitHub 專案 open-webui/open-webui 聚焦 User-friendly AI Interface (Supports Ollama, Op…</a></h3>
       
-      <div class="zh">User-friendly AI Interface (Supports Ollama, OpenAI API, ...)</div>
+      <div class="zh">open-webui/open-webui（user-friendly、interface）— 參考介面與互動設計，對照自家 dashboard 的呈現策略。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -1622,9 +1622,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">12</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/firecrawl/firecrawl" target="_blank" rel="noopener">firecrawl/firecrawl: 🔥 The API to search, scrape, and interact with the web for AI</a></h3>
+      <h3 class="ti"><a href="https://github.com/firecrawl/firecrawl" target="_blank" rel="noopener">GitHub 專案 firecrawl/firecrawl 聚焦 🔥 The API to search, scrape, and interact with…</a></h3>
       
-      <div class="zh">🔥 The API to search, scrape, and interact with the web for AI</div>
+      <div class="zh">firecrawl/firecrawl（api、search）— 對照現有 CDP 流程，評估替代抓取/操作介面。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -1636,9 +1636,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">13</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/Shubhamsaboo/awesome-llm-apps" target="_blank" rel="noopener">Shubhamsaboo/awesome-llm-apps: 100+ AI Agent &amp; RAG apps you can actually run — clone, customize, ship.</a></h3>
+      <h3 class="ti"><a href="https://github.com/Shubhamsaboo/awesome-llm-apps" target="_blank" rel="noopener">GitHub 專案 Shubhamsaboo/awesome-llm-apps 聚焦 100+ AI Agent &amp; RAG apps you can actually run —…</a></h3>
       
-      <div class="zh">100+ AI Agent &amp; RAG apps you can actually run — clone, customize, ship.</div>
+      <div class="zh">Shubhamsaboo/awesome-llm-apps（100、agent）— 對照當前 KG/memory 設計，挑可借用的索引或 retrieval 模式。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#代理</span>
@@ -1650,9 +1650,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">14</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/browser-use/browser-use" target="_blank" rel="noopener">browser-use/browser-use: 🌐 Make websites accessible for AI agents. Automate tasks online with ease.</a></h3>
+      <h3 class="ti"><a href="https://github.com/browser-use/browser-use" target="_blank" rel="noopener">GitHub 專案 browser-use/browser-use 聚焦 🌐 Make websites accessible for AI agents. Auto…</a></h3>
       
-      <div class="zh">🌐 Make websites accessible for AI agents. Automate tasks online with ease.</div>
+      <div class="zh">browser-use/browser-use（websites、accessible）— 對照現有 CDP 流程，評估替代抓取/操作介面。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -1664,9 +1664,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">15</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/rasbt/LLMs-from-scratch" target="_blank" rel="noopener">rasbt/LLMs-from-scratch: Implement a ChatGPT-like LLM in PyTorch from scratch, step by step</a></h3>
+      <h3 class="ti"><a href="https://github.com/rasbt/LLMs-from-scratch" target="_blank" rel="noopener">GitHub 專案 rasbt/LLMs-from-scratch 聚焦 Implement a ChatGPT-like LLM in PyTorch from sc…</a></h3>
       
-      <div class="zh">Implement a ChatGPT-like LLM in PyTorch from scratch, step by step</div>
+      <div class="zh">rasbt/LLMs-from-scratch（implement、chatgpt-like）— 追蹤可替換或補位的推理引擎，影響成本/延遲決策。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -1678,9 +1678,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">16</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/punkpeye/awesome-mcp-servers" target="_blank" rel="noopener">punkpeye/awesome-mcp-servers: A collection of MCP servers.</a></h3>
+      <h3 class="ti"><a href="https://github.com/punkpeye/awesome-mcp-servers" target="_blank" rel="noopener">GitHub 專案 punkpeye/awesome-mcp-servers 聚焦 A collection of MCP servers.</a></h3>
       
-      <div class="zh todo">中文摘要待 LLM enrich pass — 先點右側「閱讀原文 →」</div>
+      <div class="zh">punkpeye/awesome-mcp-servers（collection、mcp）— 評估納入工具鏈或暴露為 MCP server 的可行性。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#代理</span>
@@ -1692,9 +1692,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">17</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/infiniflow/ragflow" target="_blank" rel="noopener">infiniflow/ragflow: RAGFlow is a leading open-source Retrieval-Augmented Generation (RAG) engine that fuses cutting-edge RAG with Agent capabilities to create a superior context layer for LLMs</a></h3>
+      <h3 class="ti"><a href="https://github.com/infiniflow/ragflow" target="_blank" rel="noopener">GitHub 專案 infiniflow/ragflow 聚焦 RAGFlow is a leading open-source Retrieval-Augm…</a></h3>
       
-      <div class="zh">RAGFlow is a leading open-source Retrieval-Augmented Generation (RAG) engine that fuses cutting-edge RAG with Agent capabilities to create a superior context layer for LLMs</div>
+      <div class="zh">infiniflow/ragflow（ragflow、leading）— 對照當前 KG/memory 設計，挑可借用的索引或 retrieval 模式。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#代理</span>
@@ -1706,9 +1706,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">18</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/vllm-project/vllm" target="_blank" rel="noopener">vllm-project/vllm: A high-throughput and memory-efficient inference and serving engine for LLMs</a></h3>
+      <h3 class="ti"><a href="https://github.com/vllm-project/vllm" target="_blank" rel="noopener">GitHub 專案 vllm-project/vllm 聚焦 A high-throughput and memory-efficient inferenc…</a></h3>
       
-      <div class="zh">A high-throughput and memory-efficient inference and serving engine for LLMs</div>
+      <div class="zh">vllm-project/vllm（high-throughput、memory-efficient）— 對照當前 KG/memory 設計，挑可借用的索引或 retrieval 模式。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#記憶</span>
@@ -1720,9 +1720,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">19</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/netdata/netdata" target="_blank" rel="noopener">netdata/netdata: The fastest path to AI-powered full stack observability, even for lean teams.</a></h3>
+      <h3 class="ti"><a href="https://github.com/netdata/netdata" target="_blank" rel="noopener">GitHub 專案 netdata/netdata 聚焦 The fastest path to AI-powered full stack obser…</a></h3>
       
-      <div class="zh">The fastest path to AI-powered full stack observability, even for lean teams.</div>
+      <div class="zh">netdata/netdata（fastest、path）— 可作為比較或回歸測試的資料/評測來源。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -1734,9 +1734,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">20</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/PaddlePaddle/PaddleOCR" target="_blank" rel="noopener">PaddlePaddle/PaddleOCR: Turn any PDF or image document into structured data for your AI. A powerful, lightweight OCR toolkit that bridges the gap between images/PDFs and LLMs. Supports 100+ languages.</a></h3>
+      <h3 class="ti"><a href="https://github.com/PaddlePaddle/PaddleOCR" target="_blank" rel="noopener">GitHub 專案 PaddlePaddle/PaddleOCR 聚焦 Turn any PDF or image document into structured …</a></h3>
       
-      <div class="zh">Turn any PDF or image document into structured data for your AI. A powerful, lightweight OCR toolkit that bridges the gap between images/PDFs and LLMs. Supports 100+ languages.</div>
+      <div class="zh">PaddlePaddle/PaddleOCR（turn、any）— 評估補上多模態能力的可行性與整合成本。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -1748,9 +1748,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">21</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/lobehub/lobehub" target="_blank" rel="noopener">lobehub/lobehub: The ultimate space for work and life — to find, build, and collaborate with agent teammates that grow with you. We are taking agent harness to the next level — enabling multi-agent collaboration, effortless agent team design, and introducing agents as the unit of</a></h3>
+      <h3 class="ti"><a href="https://github.com/lobehub/lobehub" target="_blank" rel="noopener">GitHub 專案 lobehub/lobehub 聚焦 The ultimate space for work and life — to find,…</a></h3>
       
-      <div class="zh">The ultimate space for work and life — to find, build, and collaborate with agent teammates that grow with you. We are taking agent harness to the next level — enabling multi-agent…</div>
+      <div class="zh">lobehub/lobehub（ultimate、space）— 參考介面與互動設計，對照自家 dashboard 的呈現策略。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#代理</span>
@@ -1762,9 +1762,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">22</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/thedotmack/claude-mem" target="_blank" rel="noopener">thedotmack/claude-mem: A Claude Code plugin that automatically captures everything Claude does during your coding sessions, compresses it with AI (using Claude&#39;s agent-sdk), and injects relevant context back into future sessions.</a></h3>
+      <h3 class="ti"><a href="https://github.com/thedotmack/claude-mem" target="_blank" rel="noopener">GitHub 專案 thedotmack/claude-mem 聚焦 A Claude Code plugin that automatically capture…</a></h3>
       
-      <div class="zh">A Claude Code plugin that automatically captures everything Claude does during your coding sessions, compresses it with AI (using Claude&#39;s agent-sdk), and injects relevant context …</div>
+      <div class="zh">thedotmack/claude-mem（claude、code）— 對照當前 middleware 編排策略，找替代或補強位置。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#代理</span>
@@ -1776,9 +1776,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">23</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/OpenHands/OpenHands" target="_blank" rel="noopener">OpenHands/OpenHands: 🙌 OpenHands: AI-Driven Development</a></h3>
+      <h3 class="ti"><a href="https://github.com/OpenHands/OpenHands" target="_blank" rel="noopener">GitHub 專案 OpenHands/OpenHands 聚焦 🙌 OpenHands: AI-Driven Development</a></h3>
       
-      <div class="zh">🙌 OpenHands: AI-Driven Development</div>
+      <div class="zh">OpenHands/OpenHands（openhands、ai-driven）— 初步觀察，待後續判讀是否進入工具鏈或選型清單。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -1790,9 +1790,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">24</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/TauricResearch/TradingAgents" target="_blank" rel="noopener">TauricResearch/TradingAgents: TradingAgents: Multi-Agents LLM Financial Trading Framework</a></h3>
+      <h3 class="ti"><a href="https://github.com/TauricResearch/TradingAgents" target="_blank" rel="noopener">GitHub 專案 TauricResearch/TradingAgents 聚焦 TradingAgents: Multi-Agents LLM Financial Tradi…</a></h3>
       
-      <div class="zh">TradingAgents: Multi-Agents LLM Financial Trading Framework</div>
+      <div class="zh">TauricResearch/TradingAgents（tradingagents、multi-agents）— 可比對自家 agent 架構的能力邊界與整合策略。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -1804,9 +1804,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">25</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/hiyouga/LlamaFactory" target="_blank" rel="noopener">hiyouga/LlamaFactory: Unified Efficient Fine-Tuning of 100+ LLMs &amp; VLMs (ACL 2024)</a></h3>
+      <h3 class="ti"><a href="https://github.com/hiyouga/LlamaFactory" target="_blank" rel="noopener">GitHub 專案 hiyouga/LlamaFactory 聚焦 Unified Efficient Fine-Tuning of 100+ LLMs &amp; VL…</a></h3>
       
-      <div class="zh">Unified Efficient Fine-Tuning of 100+ LLMs &amp; VLMs (ACL 2024)</div>
+      <div class="zh">hiyouga/LlamaFactory（unified、efficient）— 追蹤可替換或補位的推理引擎，影響成本/延遲決策。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -1818,9 +1818,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">26</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/bytedance/deer-flow" target="_blank" rel="noopener">bytedance/deer-flow: An open-source long-horizon SuperAgent harness that researches, codes, and creates. With the help of sandboxes, memories, tools, skill, subagents and message gateway, it handles different levels of tasks that could take minutes to hours.</a></h3>
+      <h3 class="ti"><a href="https://github.com/bytedance/deer-flow" target="_blank" rel="noopener">GitHub 專案 bytedance/deer-flow 聚焦 An open-source long-horizon SuperAgent harness …</a></h3>
       
-      <div class="zh">An open-source long-horizon SuperAgent harness that researches, codes, and creates. With the help of sandboxes, memories, tools, skill, subagents and message gateway, it handles di…</div>
+      <div class="zh">bytedance/deer-flow（open-source、long-horizon）— 對照當前 KG/memory 設計，挑可借用的索引或 retrieval 模式。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -1832,9 +1832,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">27</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/unslothai/unsloth" target="_blank" rel="noopener">unslothai/unsloth: Unsloth Studio is a web UI for training and running open models like Gemma 4, Qwen3.6, DeepSeek, gpt-oss locally.</a></h3>
+      <h3 class="ti"><a href="https://github.com/unslothai/unsloth" target="_blank" rel="noopener">GitHub 專案 unslothai/unsloth 聚焦 Unsloth Studio is a web UI for training and run…</a></h3>
       
-      <div class="zh">Unsloth Studio is a web UI for training and running open models like Gemma 4, Qwen3.6, DeepSeek, gpt-oss locally.</div>
+      <div class="zh">unslothai/unsloth（unsloth、studio）— 評估是否值得投入自訓或微調流程。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -1846,9 +1846,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">28</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/farion1231/cc-switch" target="_blank" rel="noopener">farion1231/cc-switch: A cross-platform desktop All-in-One assistant tool for Claude Code, Codex, OpenCode, openclaw &amp; Gemini CLI.</a></h3>
+      <h3 class="ti"><a href="https://github.com/farion1231/cc-switch" target="_blank" rel="noopener">GitHub 專案 farion1231/cc-switch 聚焦 A cross-platform desktop All-in-One assistant t…</a></h3>
       
-      <div class="zh">A cross-platform desktop All-in-One assistant tool for Claude Code, Codex, OpenCode, openclaw &amp; Gemini CLI.</div>
+      <div class="zh">farion1231/cc-switch（cross-platform、desktop）— 參考介面與互動設計，對照自家 dashboard 的呈現策略。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#模型</span>
@@ -1860,9 +1860,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">29</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/Mintplex-Labs/anything-llm" target="_blank" rel="noopener">Mintplex-Labs/anything-llm: The all-in-one AI productivity accelerator. On device and privacy first with no annoying setup or configuration.</a></h3>
+      <h3 class="ti"><a href="https://github.com/Mintplex-Labs/anything-llm" target="_blank" rel="noopener">GitHub 專案 Mintplex-Labs/anything-llm 聚焦 The all-in-one AI productivity accelerator. On …</a></h3>
       
-      <div class="zh">The all-in-one AI productivity accelerator. On device and privacy first with no annoying setup or configuration.</div>
+      <div class="zh">Mintplex-Labs/anything-llm（all-in-one、productivity）— 追蹤可替換或補位的推理引擎，影響成本/延遲決策。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -1874,9 +1874,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">30</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/ComposioHQ/awesome-claude-skills" target="_blank" rel="noopener">ComposioHQ/awesome-claude-skills: A curated list of awesome Claude Skills, resources, and tools for customizing Claude AI workflows</a></h3>
+      <h3 class="ti"><a href="https://github.com/ComposioHQ/awesome-claude-skills" target="_blank" rel="noopener">GitHub 專案 ComposioHQ/awesome-claude-skills 聚焦 A curated list of awesome Claude Skills, resour…</a></h3>
       
-      <div class="zh">A curated list of awesome Claude Skills, resources, and tools for customizing Claude AI workflows</div>
+      <div class="zh">ComposioHQ/awesome-claude-skills（curated、list）— 對照當前 middleware 編排策略，找替代或補強位置。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#模型</span>
@@ -1888,9 +1888,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">31</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/JuliusBrussee/caveman" target="_blank" rel="noopener">JuliusBrussee/caveman: 🪨 why use many token when few token do trick — Claude Code skill that cuts 65% of tokens by talking like caveman</a></h3>
+      <h3 class="ti"><a href="https://github.com/JuliusBrussee/caveman" target="_blank" rel="noopener">GitHub 專案 JuliusBrussee/caveman 聚焦 🪨 why use many token when few token do trick —…</a></h3>
       
-      <div class="zh">🪨 why use many token when few token do trick — Claude Code skill that cuts 65% of tokens by talking like caveman</div>
+      <div class="zh">JuliusBrussee/caveman（why、many）— 評估納入工程工作流或學習其 UX 細節。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#模型</span>
@@ -1902,9 +1902,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">32</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/mem0ai/mem0" target="_blank" rel="noopener">mem0ai/mem0: Universal memory layer for AI Agents</a></h3>
+      <h3 class="ti"><a href="https://github.com/mem0ai/mem0" target="_blank" rel="noopener">GitHub 專案 mem0ai/mem0 聚焦 Universal memory layer for AI Agents</a></h3>
       
-      <div class="zh">Universal memory layer for AI Agents</div>
+      <div class="zh">mem0ai/mem0（universal、memory）— 對照當前 KG/memory 設計，挑可借用的索引或 retrieval 模式。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#記憶</span>
@@ -1916,9 +1916,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">33</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/upstash/context7" target="_blank" rel="noopener">upstash/context7: Context7 Platform -- Up-to-date code documentation for LLMs and AI code editors</a></h3>
+      <h3 class="ti"><a href="https://github.com/upstash/context7" target="_blank" rel="noopener">GitHub 專案 upstash/context7 聚焦 Context7 Platform -- Up-to-date code documentat…</a></h3>
       
-      <div class="zh">Context7 Platform -- Up-to-date code documentation for LLMs and AI code editors</div>
+      <div class="zh">upstash/context7（context7、platform）— 評估納入工程工作流或學習其 UX 細節。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -1930,9 +1930,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">34</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/FlowiseAI/Flowise" target="_blank" rel="noopener">FlowiseAI/Flowise: Build AI Agents, Visually</a></h3>
+      <h3 class="ti"><a href="https://github.com/FlowiseAI/Flowise" target="_blank" rel="noopener">GitHub 專案 FlowiseAI/Flowise 聚焦 Build AI Agents, Visually</a></h3>
       
-      <div class="zh todo">中文摘要待 LLM enrich pass — 先點右側「閱讀原文 →」</div>
+      <div class="zh">FlowiseAI/Flowise（agents、visually）— 參考介面與互動設計，對照自家 dashboard 的呈現策略。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -1944,9 +1944,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">35</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/MemPalace/mempalace" target="_blank" rel="noopener">MemPalace/mempalace: The best-benchmarked open-source AI memory system. And it&#39;s free.</a></h3>
+      <h3 class="ti"><a href="https://github.com/MemPalace/mempalace" target="_blank" rel="noopener">GitHub 專案 MemPalace/mempalace 聚焦 The best-benchmarked open-source AI memory syst…</a></h3>
       
-      <div class="zh">The best-benchmarked open-source AI memory system. And it&#39;s free.</div>
+      <div class="zh">MemPalace/mempalace（best-benchmarked、open-source）— 對照當前 KG/memory 設計，挑可借用的索引或 retrieval 模式。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#記憶</span>
@@ -1958,9 +1958,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">36</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/ggml-org/whisper.cpp" target="_blank" rel="noopener">ggml-org/whisper.cpp: Port of OpenAI&#39;s Whisper model in C/C++</a></h3>
+      <h3 class="ti"><a href="https://github.com/ggml-org/whisper.cpp" target="_blank" rel="noopener">GitHub 專案 ggml-org/whisper.cpp 聚焦 Port of OpenAI&#39;s Whisper model in C/C++</a></h3>
       
-      <div class="zh">Port of OpenAI&#39;s Whisper model in C/C++</div>
+      <div class="zh">ggml-org/whisper.cpp（port、openai）— 追蹤可替換或補位的推理引擎，影響成本/延遲決策。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -1972,9 +1972,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">37</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/huginn/huginn" target="_blank" rel="noopener">huginn/huginn: Create agents that monitor and act on your behalf.  Your agents are standing by!</a></h3>
+      <h3 class="ti"><a href="https://github.com/huginn/huginn" target="_blank" rel="noopener">GitHub 專案 huginn/huginn 聚焦 Create agents that monitor and act on your beha…</a></h3>
       
-      <div class="zh">Create agents that monitor and act on your behalf. Your agents are standing by!</div>
+      <div class="zh">huginn/huginn（create、agents）— 可比對自家 agent 架構的能力邊界與整合策略。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -1986,9 +1986,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">38</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/run-llama/llama_index" target="_blank" rel="noopener">run-llama/llama_index: LlamaIndex is the leading document agent and OCR platform</a></h3>
+      <h3 class="ti"><a href="https://github.com/run-llama/llama_index" target="_blank" rel="noopener">GitHub 專案 run-llama/llama_index 聚焦 LlamaIndex is the leading document agent and OC…</a></h3>
       
-      <div class="zh">LlamaIndex is the leading document agent and OCR platform</div>
+      <div class="zh">run-llama/llama_index（llamaindex、leading）— 可比對自家 agent 架構的能力邊界與整合策略。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#代理</span>
@@ -2000,9 +2000,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">39</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/D4Vinci/Scrapling" target="_blank" rel="noopener">D4Vinci/Scrapling: 🕷️ An adaptive Web Scraping framework that handles everything from a single request to a full-scale crawl!</a></h3>
+      <h3 class="ti"><a href="https://github.com/D4Vinci/Scrapling" target="_blank" rel="noopener">GitHub 專案 D4Vinci/Scrapling 聚焦 🕷️ An adaptive Web Scraping framework that han…</a></h3>
       
-      <div class="zh">🕷️ An adaptive Web Scraping framework that handles everything from a single request to a full-scale crawl!</div>
+      <div class="zh">D4Vinci/Scrapling（adaptive、web）— 對照現有 CDP 流程，評估替代抓取/操作介面。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -2014,9 +2014,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">40</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/mudler/LocalAI" target="_blank" rel="noopener">mudler/LocalAI: LocalAI is the open-source AI engine. Run any model - LLMs, vision, voice, image, video - on any hardware. No GPU required.</a></h3>
+      <h3 class="ti"><a href="https://github.com/mudler/LocalAI" target="_blank" rel="noopener">GitHub 專案 mudler/LocalAI 聚焦 LocalAI is the open-source AI engine. Run any m…</a></h3>
       
-      <div class="zh">LocalAI is the open-source AI engine. Run any model - LLMs, vision, voice, image, video - on any hardware. No GPU required.</div>
+      <div class="zh">mudler/LocalAI（localai、open-source）— 評估補上多模態能力的可行性與整合成本。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#基礎設施</span>
@@ -2028,9 +2028,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">41</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/jeecgboot/JeecgBoot" target="_blank" rel="noopener">jeecgboot/JeecgBoot: AI低代码平台，支持「低代码 + 零代码」双模式：零代码 5 分钟搭建业务系统，低代码模式一键生成前后端代码。 内置AI 应用，支持AI聊天、知识库、流程编排、MCP与插件，支持各种模型。Skills能力实现：一句话画流程图、设计表单、生成系统。 引领 AI生成→在线配置→代码生成→手工合并的开发模式，解决Java项目80%的重复工作，快速提高效率，又不失灵活性。</a></h3>
+      <h3 class="ti"><a href="https://github.com/jeecgboot/JeecgBoot" target="_blank" rel="noopener">GitHub 專案 jeecgboot/JeecgBoot 聚焦 AI低代码平台，支持「低代码 + 零代码」双模式：零代码 5 分钟搭建业务系统，低代码模式一键…</a></h3>
       
-      <div class="zh">AI低代码平台，支持「低代码 + 零代码」双模式：零代码 5 分钟搭建业务系统，低代码模式一键生成前后端代码。 内置AI 应用，支持AI聊天、知识库、流程编排、MCP与插件，支持各种模型。Skills能力实现：一句话画流程图、设计表单、生成系统。 引领 AI生成→在线配置→代码生成→手工合并的开发模式，解决Java项目80%的重复工作，快速提高效率，又不失灵…</div>
+      <div class="zh">jeecgboot/JeecgBoot（ai低代码平台、低代码）— 評估納入工具鏈或暴露為 MCP server 的可行性。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#代理</span>
@@ -2042,9 +2042,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">42</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/safishamsi/graphify" target="_blank" rel="noopener">safishamsi/graphify: AI coding assistant skill (Claude Code, Codex, OpenCode, Cursor, Gemini CLI, and more). Turn any folder of code, SQL schemas, R scripts, shell scripts, docs, papers, images, or videos into a queryable knowledge graph. App code + database schema + infrastructu</a></h3>
+      <h3 class="ti"><a href="https://github.com/safishamsi/graphify" target="_blank" rel="noopener">GitHub 專案 safishamsi/graphify 聚焦 AI coding assistant skill (Claude Code, Codex, …</a></h3>
       
-      <div class="zh">AI coding assistant skill (Claude Code, Codex, OpenCode, Cursor, Gemini CLI, and more). Turn any folder of code, SQL schemas, R scripts, shell scripts, docs, papers, images, or vid…</div>
+      <div class="zh">safishamsi/graphify（coding、assistant）— 評估補上多模態能力的可行性與整合成本。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#模型</span>
@@ -2056,9 +2056,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">43</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/aaif-goose/goose" target="_blank" rel="noopener">aaif-goose/goose: an open source, extensible AI agent that goes beyond code suggestions - install, execute, edit, and test with any LLM</a></h3>
+      <h3 class="ti"><a href="https://github.com/aaif-goose/goose" target="_blank" rel="noopener">GitHub 專案 aaif-goose/goose 聚焦 an open source, extensible AI agent that goes b…</a></h3>
       
-      <div class="zh">an open source, extensible AI agent that goes beyond code suggestions - install, execute, edit, and test with any LLM</div>
+      <div class="zh">aaif-goose/goose（open、source）— 評估納入工程工作流或學習其 UX 細節。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#代理</span>
@@ -2070,9 +2070,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">44</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/zhayujie/CowAgent" target="_blank" rel="noopener">zhayujie/CowAgent: CowAgent (chatgpt-on-wechat) 是基于大模型的超级AI助理，能主动思考和任务规划、访问操作系统和外部资源、创造和执行Skills、通过长期记忆和知识库不断成长，比OpenClaw更轻量和便捷。同时支持微信、飞书、钉钉、企微、QQ、公众号、网页等接入，可选择DeepSeek/OpenAI/Claude/Gemini/ MiniMax/Qwen/GLM/LinkAI，能处理文本、语音、图片和文件，可快速搭建个人AI助理和企业数字员工。</a></h3>
+      <h3 class="ti"><a href="https://github.com/zhayujie/CowAgent" target="_blank" rel="noopener">GitHub 專案 zhayujie/CowAgent 聚焦 CowAgent (chatgpt-on-wechat) 是基于大模型的超级AI助理，能主动思…</a></h3>
       
-      <div class="zh">CowAgent (chatgpt-on-wechat) 是基于大模型的超级AI助理，能主动思考和任务规划、访问操作系统和外部资源、创造和执行Skills、通过长期记忆和知识库不断成长，比OpenClaw更轻量和便捷。同时支持微信、飞书、钉钉、企微、QQ、公众号、网页等接入，可选择DeepSeek/OpenAI/Claude/Gemini/ MiniMax/…</div>
+      <div class="zh">zhayujie/CowAgent（cowagent、chatgpt-on-wechat）— 可比對自家 agent 架構的能力邊界與整合策略。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#模型</span>
@@ -2084,9 +2084,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">45</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/milvus-io/milvus" target="_blank" rel="noopener">milvus-io/milvus: Milvus is a high-performance, cloud-native vector database built for scalable vector ANN search</a></h3>
+      <h3 class="ti"><a href="https://github.com/milvus-io/milvus" target="_blank" rel="noopener">GitHub 專案 milvus-io/milvus 聚焦 Milvus is a high-performance, cloud-native vect…</a></h3>
       
-      <div class="zh">Milvus is a high-performance, cloud-native vector database built for scalable vector ANN search</div>
+      <div class="zh">milvus-io/milvus（milvus、high-performance）— 對照當前 KG/memory 設計，挑可借用的索引或 retrieval 模式。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#記憶</span>
@@ -2098,9 +2098,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">46</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/datawhalechina/hello-agents" target="_blank" rel="noopener">datawhalechina/hello-agents: 📚 《从零开始构建智能体》——从零开始的智能体原理与实践教程</a></h3>
+      <h3 class="ti"><a href="https://github.com/datawhalechina/hello-agents" target="_blank" rel="noopener">GitHub 專案 datawhalechina/hello-agents 聚焦 📚 《从零开始构建智能体》——从零开始的智能体原理与实践教程</a></h3>
       
-      <div class="zh">📚 《从零开始构建智能体》——从零开始的智能体原理与实践教程</div>
+      <div class="zh">datawhalechina/hello-agents（从零开始构建智能体、从零开始的智能体原理与实践教程）— 可作為比較或回歸測試的資料/評測來源。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -2112,9 +2112,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">47</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/pingcap/tidb" target="_blank" rel="noopener">pingcap/tidb: TiDB is built for agentic workloads that grow unpredictably, with ACID guarantees and native support for transactions, analytics, and vector search. No data silos. No noisy neighbors. No infrastructure ceiling.</a></h3>
+      <h3 class="ti"><a href="https://github.com/pingcap/tidb" target="_blank" rel="noopener">GitHub 專案 pingcap/tidb 聚焦 TiDB is built for agentic workloads that grow u…</a></h3>
       
-      <div class="zh">TiDB is built for agentic workloads that grow unpredictably, with ACID guarantees and native support for transactions, analytics, and vector search. No data silos. No noisy neighbo…</div>
+      <div class="zh">pingcap/tidb（tidb、agentic）— 對照當前 KG/memory 設計，挑可借用的索引或 retrieval 模式。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#記憶</span>
@@ -2126,9 +2126,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">48</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/mindsdb/mindsdb" target="_blank" rel="noopener">mindsdb/mindsdb: AI Data Vault - A query engine for AI Agents to securely query data from any datasource</a></h3>
+      <h3 class="ti"><a href="https://github.com/mindsdb/mindsdb" target="_blank" rel="noopener">GitHub 專案 mindsdb/mindsdb 聚焦 AI Data Vault - A query engine for AI Agents to…</a></h3>
       
-      <div class="zh">AI Data Vault - A query engine for AI Agents to securely query data from any datasource</div>
+      <div class="zh">mindsdb/mindsdb（data、vault）— 可作為比較或回歸測試的資料/評測來源。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -2140,9 +2140,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">49</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/ChromeDevTools/chrome-devtools-mcp" target="_blank" rel="noopener">ChromeDevTools/chrome-devtools-mcp: Chrome DevTools for coding agents</a></h3>
+      <h3 class="ti"><a href="https://github.com/ChromeDevTools/chrome-devtools-mcp" target="_blank" rel="noopener">GitHub 專案 ChromeDevTools/chrome-devtools-mcp 聚焦 Chrome DevTools for coding agents</a></h3>
       
-      <div class="zh">Chrome DevTools for coding agents</div>
+      <div class="zh">ChromeDevTools/chrome-devtools-…（chrome、devtools）— 評估納入工具鏈或暴露為 MCP server 的可行性。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#代理</span>
@@ -2154,9 +2154,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">50</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/alibaba/arthas" target="_blank" rel="noopener">alibaba/arthas: Alibaba Java Diagnostic Tool Arthas/Alibaba Java诊断利器Arthas</a></h3>
+      <h3 class="ti"><a href="https://github.com/alibaba/arthas" target="_blank" rel="noopener">GitHub 專案 alibaba/arthas 聚焦 Alibaba Java Diagnostic Tool Arthas/Alibaba Jav…</a></h3>
       
-      <div class="zh">Alibaba Java Diagnostic Tool Arthas/Alibaba Java诊断利器Arthas</div>
+      <div class="zh">alibaba/arthas（alibaba、java）— 初步觀察，待後續判讀是否進入工具鏈或選型清單。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -2168,9 +2168,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">51</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/1Panel-dev/1Panel" target="_blank" rel="noopener">1Panel-dev/1Panel: 🔥 1Panel is a modern, open-source VPS control panel — and the only one with native AI agent support. Run Ollama models, deploy OpenClaw agents, and manage your entire server stack from one clean web interface.</a></h3>
+      <h3 class="ti"><a href="https://github.com/1Panel-dev/1Panel" target="_blank" rel="noopener">GitHub 專案 1Panel-dev/1Panel 聚焦 🔥 1Panel is a modern, open-source VPS control …</a></h3>
       
-      <div class="zh">🔥 1Panel is a modern, open-source VPS control panel — and the only one with native AI agent support. Run Ollama models, deploy OpenClaw agents, and manage your entire server stack…</div>
+      <div class="zh">1Panel-dev/1Panel（1panel、modern）— 可比對自家 agent 架構的能力邊界與整合策略。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#代理</span>
@@ -2182,9 +2182,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">52</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/HKUDS/LightRAG" target="_blank" rel="noopener">HKUDS/LightRAG: [EMNLP2025] &quot;LightRAG: Simple and Fast Retrieval-Augmented Generation&quot;</a></h3>
+      <h3 class="ti"><a href="https://github.com/HKUDS/LightRAG" target="_blank" rel="noopener">GitHub 專案 HKUDS/LightRAG 聚焦 [EMNLP2025] &quot;LightRAG: Simple and Fast Retrieva…</a></h3>
       
-      <div class="zh">[EMNLP2025] &quot;LightRAG: Simple and Fast Retrieval-Augmented Generation&quot;</div>
+      <div class="zh">HKUDS/LightRAG（emnlp2025、lightrag）— 對照當前 KG/memory 設計，挑可借用的索引或 retrieval 模式。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -2196,9 +2196,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">53</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/patchy631/ai-engineering-hub" target="_blank" rel="noopener">patchy631/ai-engineering-hub: In-depth tutorials on LLMs, RAGs and real-world AI agent applications.</a></h3>
+      <h3 class="ti"><a href="https://github.com/patchy631/ai-engineering-hub" target="_blank" rel="noopener">GitHub 專案 patchy631/ai-engineering-hub 聚焦 In-depth tutorials on LLMs, RAGs and real-world…</a></h3>
       
-      <div class="zh">In-depth tutorials on LLMs, RAGs and real-world AI agent applications.</div>
+      <div class="zh">patchy631/ai-engineering-hub（in-depth、tutorials）— 對照當前 KG/memory 設計，挑可借用的索引或 retrieval 模式。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#代理</span>
@@ -2210,9 +2210,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">54</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/ZhuLinsen/daily_stock_analysis" target="_blank" rel="noopener">ZhuLinsen/daily_stock_analysis: LLM驱动的 A/H/美股智能分析器：多数据源行情 + 实时新闻 + LLM决策仪表盘 + 多渠道推送，零成本定时运行，纯白嫖. LLM-powered stock analysis system for A/H/US markets.</a></h3>
+      <h3 class="ti"><a href="https://github.com/ZhuLinsen/daily_stock_analysis" target="_blank" rel="noopener">GitHub 專案 ZhuLinsen/daily_stock_analysis 聚焦 LLM驱动的 A/H/美股智能分析器：多数据源行情 + 实时新闻 + LLM决策仪表盘 + 多…</a></h3>
       
-      <div class="zh">LLM驱动的 A/H/美股智能分析器：多数据源行情 + 实时新闻 + LLM决策仪表盘 + 多渠道推送，零成本定时运行，纯白嫖. LLM-powered stock analysis system for A/H/US markets.</div>
+      <div class="zh">ZhuLinsen/daily_stock_analysis（llm驱动的、美股智能分析器）— 追蹤可替換或補位的推理引擎，影響成本/延遲決策。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -2224,9 +2224,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">55</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/huggingface/diffusers" target="_blank" rel="noopener">huggingface/diffusers: 🤗 Diffusers: State-of-the-art diffusion models for image, video, and audio generation in PyTorch.</a></h3>
+      <h3 class="ti"><a href="https://github.com/huggingface/diffusers" target="_blank" rel="noopener">GitHub 專案 huggingface/diffusers 聚焦 🤗 Diffusers: State-of-the-art diffusion models…</a></h3>
       
-      <div class="zh">🤗 Diffusers: State-of-the-art diffusion models for image, video, and audio generation in PyTorch.</div>
+      <div class="zh">huggingface/diffusers（diffusers、state-of-the-art）— 評估補上多模態能力的可行性與整合成本。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -2238,9 +2238,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">56</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/continuedev/continue" target="_blank" rel="noopener">continuedev/continue: ⏩ Source-controlled AI checks, enforceable in CI. Powered by the open-source Continue CLI</a></h3>
+      <h3 class="ti"><a href="https://github.com/continuedev/continue" target="_blank" rel="noopener">GitHub 專案 continuedev/continue 聚焦 ⏩ Source-controlled AI checks, enforceable in C…</a></h3>
       
-      <div class="zh">⏩ Source-controlled AI checks, enforceable in CI. Powered by the open-source Continue CLI</div>
+      <div class="zh">continuedev/continue（source-controlled、checks）— 評估納入工程工作流或學習其 UX 細節。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -2252,9 +2252,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">57</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/alibaba/nacos" target="_blank" rel="noopener">alibaba/nacos: an easy-to-use dynamic service discovery, configuration and service management platform for building AI cloud native applications.</a></h3>
+      <h3 class="ti"><a href="https://github.com/alibaba/nacos" target="_blank" rel="noopener">GitHub 專案 alibaba/nacos 聚焦 an easy-to-use dynamic service discovery, confi…</a></h3>
       
-      <div class="zh">an easy-to-use dynamic service discovery, configuration and service management platform for building AI cloud native applications.</div>
+      <div class="zh">alibaba/nacos（easy-to-use、dynamic）— 參考介面與互動設計，對照自家 dashboard 的呈現策略。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -2266,9 +2266,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">58</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/microsoft/graphrag" target="_blank" rel="noopener">microsoft/graphrag: A modular graph-based Retrieval-Augmented Generation (RAG) system</a></h3>
+      <h3 class="ti"><a href="https://github.com/microsoft/graphrag" target="_blank" rel="noopener">GitHub 專案 microsoft/graphrag 聚焦 A modular graph-based Retrieval-Augmented Gener…</a></h3>
       
-      <div class="zh">A modular graph-based Retrieval-Augmented Generation (RAG) system</div>
+      <div class="zh">microsoft/graphrag（modular、graph-based）— 對照當前 KG/memory 設計，挑可借用的索引或 retrieval 模式。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#記憶</span>
@@ -2280,9 +2280,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">59</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/AstrBotDevs/AstrBot" target="_blank" rel="noopener">AstrBotDevs/AstrBot: AI Agent Assistant &amp; development framework that integrates lots of IM platforms, LLMs, plugins and AI feature, and can be your openclaw alternative. ✨</a></h3>
+      <h3 class="ti"><a href="https://github.com/AstrBotDevs/AstrBot" target="_blank" rel="noopener">GitHub 專案 AstrBotDevs/AstrBot 聚焦 AI Agent Assistant &amp; development framework that…</a></h3>
       
-      <div class="zh">AI Agent Assistant &amp; development framework that integrates lots of IM platforms, LLMs, plugins and AI feature, and can be your openclaw alternative. ✨</div>
+      <div class="zh">AstrBotDevs/AstrBot（agent、assistant）— 可比對自家 agent 架構的能力邊界與整合策略。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#代理</span>
@@ -2294,9 +2294,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">60</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/zeroclaw-labs/zeroclaw" target="_blank" rel="noopener">zeroclaw-labs/zeroclaw: Fast, small, and fully autonomous AI personal assistant infrastructure, ANY OS, ANY PLATFORM — deploy anywhere, swap anything 🦀</a></h3>
+      <h3 class="ti"><a href="https://github.com/zeroclaw-labs/zeroclaw" target="_blank" rel="noopener">GitHub 專案 zeroclaw-labs/zeroclaw 聚焦 Fast, small, and fully autonomous AI personal a…</a></h3>
       
-      <div class="zh">Fast, small, and fully autonomous AI personal assistant infrastructure, ANY OS, ANY PLATFORM — deploy anywhere, swap anything 🦀</div>
+      <div class="zh">zeroclaw-labs/zeroclaw（fast、small）— 可比對自家 agent 架構的能力邊界與整合策略。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -2309,18 +2309,18 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
 </section>
 
 <section>
-  <h2 class="sec">熱門討論 <span class="cnt">13</span> <span class="upd">HN 2026-05-08 22:05</span></h2>
+  <h2 class="sec">熱門討論 <span class="cnt">13</span> <span class="upd">HN 2026-05-08 22:08</span></h2>
   <p class="lead">HN 留言數最高。</p>
   <ul class="feed"><li>
     <span class="rk">1</span>
     <div class="body">
-      <h3 class="ti"><a href="https://rmoff.net/2026/05/06/ai-slop-is-killing-online-communities/" target="_blank" rel="noopener">HN 討論 AI slop is killing online communities 聚焦 AI slop is killing online communities</a></h3>
+      <h3 class="ti"><a href="https://rmoff.net/2026/05/06/ai-slop-is-killing-online-communities/" target="_blank" rel="noopener">AI 生成的內容正在破壞線上社群的真實互動與信任基礎。</a></h3>
       
-      <div class="zh">AI slop is killing online commu…（slop、killing）— 初步觀察，待後續判讀是否進入工具鏈或選型清單。</div>
+      <div class="zh">開發者需重新設計驗證機制與社群規則，避免 AI 主導導致真實用戶流失。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#其他</span>
-        <span class="pts"><b>742</b> 分 · 636 留言</span>
+        <span class="pts"><b>743</b> 分 · 636 留言</span>
         <span>rmoff.net</span>
       </div>
     </div>
@@ -2328,13 +2328,13 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">2</span>
     <div class="body">
-      <h3 class="ti"><a href="https://bsuh.bearblog.dev/agents-need-control-flow/" target="_blank" rel="noopener">HN 討論 Agents need control flow, not more prompts 聚焦 Agents need control flow, not more prompts</a></h3>
+      <h3 class="ti"><a href="https://bsuh.bearblog.dev/agents-need-control-flow/" target="_blank" rel="noopener">Agent 開發不應依賴更多提示詞，而應建立明確的控制流程與狀態管理。</a></h3>
       
-      <div class="zh">Agents need control flow, not m…（agents、need）— 可比對自家 agent 架構的能力邊界與整合策略。</div>
+      <div class="zh">開發者需從「寫提示詞」轉向「設計狀態機與控制邏輯」，降低系統崩潰風險並提升可維護性。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#其他</span>
-        <span class="pts"><b>519</b> 分 · 255 留言</span>
+        <span class="pts"><b>520</b> 分 · 255 留言</span>
         <span>bsuh.bearblog.dev</span>
       </div>
     </div>
@@ -2342,13 +2342,13 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">3</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/antirez/ds4" target="_blank" rel="noopener">HN 討論 DeepSeek 4 Flash local inference engine for Metal 聚焦 DeepSeek 4 Flash local inference engine for Met…</a></h3>
+      <h3 class="ti"><a href="https://github.com/antirez/ds4" target="_blank" rel="noopener">DeepSeek 4 Flash 提供本地 Metal 推理引擎，顯著提升 Mac 裝置上的模型運行效能。</a></h3>
       
-      <div class="zh">DeepSeek 4 Flash local inferenc…（deepseek、flash）— 追蹤可替換或補位的推理引擎，影響成本/延遲決策。</div>
+      <div class="zh">開發者可直接在 Mac 上運行大型模型，無需依賴雲端服務，降低延遲與成本。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#基礎設施</span>
-        <span class="pts"><b>434</b> 分 · 125 留言</span>
+        <span class="pts"><b>435</b> 分 · 125 留言</span>
         <span>github.com</span>
       </div>
     </div>
@@ -2356,13 +2356,13 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">4</span>
     <div class="body">
-      <h3 class="ti"><a href="https://www.anthropic.com/research/natural-language-autoencoders" target="_blank" rel="noopener">HN 討論 Natural Language Autoencoders 聚焦 Turning Claude&#39;s Thoughts into Text</a></h3>
+      <h3 class="ti"><a href="https://www.anthropic.com/research/natural-language-autoencoders" target="_blank" rel="noopener">Claude 3.5 的內部思考過程可透過自然語言自編碼器（NLAE）直接轉化為文本，無需額外推理。</a></h3>
       
-      <div class="zh">Natural Language Autoencoders（turning、claude）— 評估納入工程工作流或學習其 UX 細節。</div>
+      <div class="zh">為開發者提供可解釋性工具，讓 AI 的「思考」透明化。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#模型</span>
-        <span class="pts"><b>324</b> 分 · 100 留言</span>
+        <span class="pts"><b>325</b> 分 · 100 留言</span>
         <span>anthropic.com</span>
       </div>
     </div>
@@ -2370,9 +2370,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">5</span>
     <div class="body">
-      <h3 class="ti"><a href="https://deepmind.google/blog/alphaevolve-impact/" target="_blank" rel="noopener">HN 討論 AlphaEvolve 聚焦 Gemini-powered coding agent scaling impact acro…</a></h3>
+      <h3 class="ti"><a href="https://deepmind.google/blog/alphaevolve-impact/" target="_blank" rel="noopener">AlphaEvolve 透過 Gemini 與自訂模型並行訓練，大幅加速 AlphaCode 的演進速度。</a></h3>
       
-      <div class="zh">AlphaEvolve（gemini-powered、coding）— 可比對自家 agent 架構的能力邊界與整合策略。</div>
+      <div class="zh">AI 開發者可利用 Gemini 快速迭代自訂模型，縮短從原型到生產的週期。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#代理</span>
@@ -2384,9 +2384,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">6</span>
     <div class="body">
-      <h3 class="ti"><a href="https://www.tomshardware.com/pc-components/motherboards/motherboard-sales-collapse-by-more-than-25-percent-as-chipmakers-strangle-enthusiast-pc-market-to-build-more-ai-chips-asus-projected-to-sell-5-million-fewer-boards-in-2025-gigabyte-msi-and-asrock-also-expected-to-see-reduced-sales-numbers" target="_blank" rel="noopener">HN 討論 Motherboard sales &#39;collapse&#39; amid unprecedented shortages fueled by AI 聚焦 Motherboard sales &#39;collapse&#39; amid unprecedented…</a></h3>
+      <h3 class="ti"><a href="https://www.tomshardware.com/pc-components/motherboards/motherboard-sales-collapse-by-more-than-25-percent-as-chipmakers-strangle-enthusiast-pc-market-to-build-more-ai-chips-asus-projected-to-sell-5-million-fewer-boards-in-2025-gigabyte-msi-and-asrock-also-expected-to-see-reduced-sales-numbers" target="_blank" rel="noopener">主機板銷售因 AI 晶片短缺而萎縮超過 25%，廠商預計 2025 年銷量大幅減少。</a></h3>
       
-      <div class="zh">Motherboard sales &#39;collapse&#39; am…（motherboard、sales）— 初步觀察，待後續判讀是否進入工具鏈或選型清單。</div>
+      <div class="zh">開發者若依賴消費級主機板進行 AI 實驗或邊緣裝置，需預備延遲風險；建議轉向企業級平台或自製 FPGA 以避開供應瓶頸。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#其他</span>
@@ -2398,13 +2398,13 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">7</span>
     <div class="body">
-      <h3 class="ti"><a href="https://hacks.mozilla.org/2026/05/behind-the-scenes-hardening-firefox/" target="_blank" rel="noopener">HN 討論 Hardening Firefox with Claude Mythos Preview 聚焦 Hardening Firefox with Claude Mythos Preview</a></h3>
+      <h3 class="ti"><a href="https://hacks.mozilla.org/2026/05/behind-the-scenes-hardening-firefox/" target="_blank" rel="noopener">Mozilla 使用 Claude Mythos 進行 Firefox 安全掃描，發現了 271 個漏洞且誤報率極低。</a></h3>
       
-      <div class="zh">Hardening Firefox with Claude M…（hardening、firefox）— 追蹤可替換或補位的推理引擎，影響成本/延遲決策。</div>
+      <div class="zh">為 AI 驅動的軟體安全測試提供實例，開發者可參考此架構以提升自訂工具的檢測效能。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#模型</span>
-        <span class="pts"><b>256</b> 分 · 118 留言</span>
+        <span class="pts"><b>259</b> 分 · 118 留言</span>
         <span>hacks.mozilla.org</span>
       </div>
     </div>
@@ -2412,9 +2412,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">8</span>
     <div class="body">
-      <h3 class="ti"><a href="https://www.citizen.co.za/news/home-affairs-officials-suspended-ai-hallucinations/" target="_blank" rel="noopener">HN 討論 Two Home Affairs officials suspended after AI &#39;hallucinations&#39; found 聚焦 Two Home Affairs officials suspended after AI &#39;…</a></h3>
+      <h3 class="ti"><a href="https://www.citizen.co.za/news/home-affairs-officials-suspended-ai-hallucinations/" target="_blank" rel="noopener">南非內政部官員因 AI 產生幻覺導致錯誤決策而被停職。</a></h3>
       
-      <div class="zh">Two Home Affairs officials susp…（two、home）— 初步觀察，待後續判讀是否進入工具鏈或選型清單。</div>
+      <div class="zh">提醒開發者與使用者：對 AI 產出內容必須進行嚴謹的事前驗證與後審，不可完全信任模型輸出，否則可能導致法律或行政責任。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#其他</span>
@@ -2426,13 +2426,13 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">9</span>
     <div class="body">
-      <h3 class="ti"><a href="https://openrouter.ai/announcements/gpt55-cost-analysis" target="_blank" rel="noopener">HN 討論 GPT-5.5 Price Increase 聚焦 What It Costs</a></h3>
+      <h3 class="ti"><a href="https://openrouter.ai/announcements/gpt55-cost-analysis" target="_blank" rel="noopener">GPT-5.5 價格上漲是 API 供應商調整定價策略的結果，而非模型能力大幅提升。</a></h3>
       
-      <div class="zh">GPT-5.5 Price Increase（what、costs）— 追蹤可替換或補位的推理引擎，影響成本/延遲決策。</div>
+      <div class="zh">開發者需重新評估預算，避免過度依賴於價格上漲的模型。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#模型</span>
-        <span class="pts"><b>109</b> 分 · 25 留言</span>
+        <span class="pts"><b>111</b> 分 · 26 留言</span>
         <span>openrouter.ai</span>
       </div>
     </div>
@@ -2440,9 +2440,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">10</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/ReviewStage/stage-cli" target="_blank" rel="noopener">HN 討論 Show HN 聚焦 Stage CLI – An easier way of reading your AI ge…</a></h3>
+      <h3 class="ti"><a href="https://github.com/ReviewStage/stage-cli" target="_blank" rel="noopener">Stage CLI 讓開發者能透過自然語言指令，將 AI 生成的程式碼變更拆解為邏輯章節並在地瀏覽器閱讀。</a></h3>
       
-      <div class="zh">Show HN（stage、cli）— 評估納入工程工作流或學習其 UX 細節。</div>
+      <div class="zh">對 agent 開發者而言，可將現有 AI 整合至本地工作流，無需依賴遠端服務。這降低門檻並提升對複雜變更的掌控力。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#代理</span>
@@ -2454,13 +2454,13 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">11</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/advisories/GHSA-vp62-r36r-9xqp" target="_blank" rel="noopener">HN 討論 Claude Code CVE-2026-39861 聚焦 sandbox escape via symlink</a></h3>
+      <h3 class="ti"><a href="https://github.com/advisories/GHSA-vp62-r36r-9xqp" target="_blank" rel="noopener">Claude Code 因 symlink 攻擊導致沙盒逃逸，暴露出 AI 編譯器安全邊界。</a></h3>
       
-      <div class="zh">Claude Code CVE-2026-39861（sandbox、escape）— 檢視 agent 執行邊界與權限模型是否該升級。</div>
+      <div class="zh">開發者需警惕 AI 編譯器對惡意 symlinks 的處理，避免沙盒逃逸風險。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#模型</span>
-        <span class="pts"><b>29</b> 分 · 2 留言</span>
+        <span class="pts"><b>29</b> 分 · 3 留言</span>
         <span>github.com</span>
       </div>
     </div>
@@ -2468,9 +2468,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">12</span>
     <div class="body">
-      <h3 class="ti"><a href="https://simonwillison.net/2026/May/7/xai-anthropic/" target="_blank" rel="noopener">HN 討論 Notes on the xAI/Anthropic data center deal 聚焦 Notes on the xAI/Anthropic data center deal</a></h3>
+      <h3 class="ti"><a href="https://simonwillison.net/2026/May/7/xai-anthropic/" target="_blank" rel="noopener">xAI 與 Anthropic 的數據中心交易可能引發 AI 巨頭壟斷，並削弱開源生態。</a></h3>
       
-      <div class="zh">Notes on the xAI/Anthropic data…（notes、xai）— 可作為比較或回歸測試的資料/評測來源。</div>
+      <div class="zh">開發者應警惕閉源壟斷，避免依賴於受限的 API 或硬體。建議持續投入開源工具與自部署架構，維持技術自主性。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#其他</span>
@@ -2482,9 +2482,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">13</span>
     <div class="body">
-      <h3 class="ti"><a href="https://moq.dev/blog/webrtc-is-the-problem/" target="_blank" rel="noopener">HN 討論 OpenAI&#39;s WebRTC Problem 聚焦 OpenAI&#39;s WebRTC Problem</a></h3>
+      <h3 class="ti"><a href="https://moq.dev/blog/webrtc-is-the-problem/" target="_blank" rel="noopener">WebRTC 的即時通訊能力讓 AI 代理能直接與用戶對話，但缺乏統一的 API 導致開發者難以構建可靠的多代理系統。</a></h3>
       
-      <div class="zh">OpenAI&#39;s WebRTC Problem（openai、webrtc）— 初步觀察，待後續判讀是否進入工具鏈或選型清單。</div>
+      <div class="zh">對 AI 開發者而言，需重新評估 WebRTC 的整合方式，考慮使用現有 API 或框架來解決即時通訊與 AI 代理的整合問題。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#其他</span>
@@ -2620,7 +2620,7 @@ _生成於 2026-05-08T09:00:06.717Z_
 </section>
 
 <footer>
-  <div>Kuro 自動生成 · <a href="https://github.com/miles990/mini-agent">原始碼</a> · 建置 2026-05-08 22:05 (Asia/Taipei)</div>
+  <div>Kuro 自動生成 · <a href="https://github.com/miles990/mini-agent">原始碼</a> · 建置 2026-05-09 01:08 (Asia/Taipei)</div>
   <div class="nav-row">
     <a href="./graph.html">主題圖譜</a>
     <a href="./swimlane.html">主題泳道</a>

--- a/kuro-portfolio/ai-trend/index.html
+++ b/kuro-portfolio/ai-trend/index.html
@@ -131,13 +131,13 @@ section.spotlight{border-color:var(--warn)}
   <h1>AI Trend · 一份完整簡報</h1>
   <div class="sub">2026-05-08 · Asia/Taipei · Kuro 自動生成</div>
   <div class="meta">
-    <span class="src-stamp"><b>HN</b><span class="">2026-05-08 22:05</span></span>
+    <span class="src-stamp"><b>HN</b><span class="">2026-05-08 22:08</span></span>
     <span class="src-stamp"><b>Latent</b><span class="">2026-05-08 17:00</span></span>
     <span class="src-stamp"><b>X</b><span class="">—</span></span>
     <span class="src-stamp"><b>arXiv</b><span class="">2026-05-08 22:04</span></span>
     <span class="src-stamp"><b>GitHub</b><span class="">2026-05-08 18:55</span></span>
     <span class="src-stamp trendradar-pill"><b>TrendRadar zh-CN</b><span>Path 2 待 ship</span></span>
-    <span class="src-stamp"><b>頁面 build</b><span>2026-05-08 22:05</span></span>
+    <span class="src-stamp"><b>頁面 build</b><span>2026-05-09 01:08</span></span>
   </div>
 </header>
 
@@ -159,12 +159,12 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
 <section class="spotlight">
   <div class="kuro-block-label">③ GITHUB SPOTLIGHT</div>
   <div class="spotlight-inner">
-    
-    
-    
-    
-    
-    
+    <h3 class="spotlight-repo"><a href="https://github.com/sansan0/TrendRadar" target="_blank" rel="noopener"><code>sansan0/TrendRadar</code></a></h3>
+    <div class="spotlight-meta">License: MIT · 版本: v6.6.2</div>
+    <p>完整對應今天訊息流的中軸（中文圈 surface 給外文圈），而且我自己今天就在 integrate（spec → Commit 1 已 ship）— 不是 review 別人的 repo，是我「正在用」的工具。一句話：keyword 驅動的 zh-CN 11 平台熱榜聚合 + SQLite 日輸出 + 內建 MCP server。實測 <a href="https://github.com/sansan0/TrendRadar/stargazers" target="_blank" rel="noopener">stargazers timeline ↗</a> 過去 4 週呈 hockey-stick — <a href="https://www.latent.space/" target="_blank" rel="noopener">swyx surface ↗</a> 後 24h 有明顯加速段。</p>
+    <div class="spotlight-sub">為什麼好</div><ul><li>**單一職責**：只做「抓 + 存 + 暴露」，沒把分析塞進去（分析交給下游 = 我這種使用者），介面乾淨。</li><li>**平台相容性務實**：11 個 source 用統一 schema，不過度抽象；新增 source 是加一個 yaml 區塊不是新 plugin 系統。</li><li>**MCP 先行**：fastmcp server 是預設選項而非後加，作者對 agent ecosystem 有判斷。</li></ul>
+    <div class="spotlight-sub">風險</div><ul><li>TrendRadar 的 web UI（Docker 部署）是次要功能；我只用 CLI fetch + SQLite read，不引入 Docker drift。</li><li>內建 LLM-summarize 段（litellm + json-repair）會跳過 — 我有自己的 Kuro take pipeline，要避免「LLM-of-LLM」雙層幻覺。</li></ul>
+    <div class="spotlight-sub">整合路徑</div><ul><li>今天起的 ai-trend daily 將出現 weibo / 知乎 / B站 / 百度 等 zh-CN AI thread，對「中國 LLM 公司動態 / zh AI KOL 討論 / 中文社群 hot meme」有第一手感知。</li><li>Python ≥3.12（我用 3.13 venv 驗證 install 乾淨）。CLI fetch + SQLite read 路徑與既有 ai-trend pipeline 合流，不引入新 daemon。</li></ul>
   </div>
 </section>
 <section class="swot">
@@ -227,18 +227,18 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
 </div>
 
 <section>
-  <h2 class="sec">今日 AI 大事 <span class="cnt">33</span> <span class="upd">HN 2026-05-08 22:05</span></h2>
+  <h2 class="sec">今日 AI 大事 <span class="cnt">33</span> <span class="upd">HN 2026-05-08 22:08</span></h2>
   <p class="lead">跨 HN + Latent Space，按關注度排序。中文摘要為 LLM enrich-pass 結果，未 enrich 的條目顯示原文鏈接。</p>
   <ul class="feed"><li>
     <span class="rk">1</span>
     <div class="body">
-      <h3 class="ti"><a href="https://rmoff.net/2026/05/06/ai-slop-is-killing-online-communities/" target="_blank" rel="noopener">HN 討論 AI slop is killing online communities 聚焦 AI slop is killing online communities</a></h3>
+      <h3 class="ti"><a href="https://rmoff.net/2026/05/06/ai-slop-is-killing-online-communities/" target="_blank" rel="noopener">AI 生成的內容正在破壞線上社群的真實互動與信任基礎。</a></h3>
       
-      <div class="zh">AI slop is killing online commu…（slop、killing）— 初步觀察，待後續判讀是否進入工具鏈或選型清單。</div>
+      <div class="zh">開發者需重新設計驗證機制與社群規則，避免 AI 主導導致真實用戶流失。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#其他</span>
-        <span class="pts"><b>742</b> 分 · 636 留言</span>
+        <span class="pts"><b>743</b> 分 · 636 留言</span>
         <span>rmoff.net</span>
       </div>
     </div>
@@ -246,13 +246,13 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">2</span>
     <div class="body">
-      <h3 class="ti"><a href="https://bsuh.bearblog.dev/agents-need-control-flow/" target="_blank" rel="noopener">HN 討論 Agents need control flow, not more prompts 聚焦 Agents need control flow, not more prompts</a></h3>
+      <h3 class="ti"><a href="https://bsuh.bearblog.dev/agents-need-control-flow/" target="_blank" rel="noopener">Agent 開發不應依賴更多提示詞，而應建立明確的控制流程與狀態管理。</a></h3>
       
-      <div class="zh">Agents need control flow, not m…（agents、need）— 可比對自家 agent 架構的能力邊界與整合策略。</div>
+      <div class="zh">開發者需從「寫提示詞」轉向「設計狀態機與控制邏輯」，降低系統崩潰風險並提升可維護性。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#其他</span>
-        <span class="pts"><b>519</b> 分 · 255 留言</span>
+        <span class="pts"><b>520</b> 分 · 255 留言</span>
         <span>bsuh.bearblog.dev</span>
       </div>
     </div>
@@ -260,13 +260,13 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">3</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/antirez/ds4" target="_blank" rel="noopener">HN 討論 DeepSeek 4 Flash local inference engine for Metal 聚焦 DeepSeek 4 Flash local inference engine for Met…</a></h3>
+      <h3 class="ti"><a href="https://github.com/antirez/ds4" target="_blank" rel="noopener">DeepSeek 4 Flash 提供本地 Metal 推理引擎，顯著提升 Mac 裝置上的模型運行效能。</a></h3>
       
-      <div class="zh">DeepSeek 4 Flash local inferenc…（deepseek、flash）— 追蹤可替換或補位的推理引擎，影響成本/延遲決策。</div>
+      <div class="zh">開發者可直接在 Mac 上運行大型模型，無需依賴雲端服務，降低延遲與成本。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#基礎設施</span>
-        <span class="pts"><b>434</b> 分 · 125 留言</span>
+        <span class="pts"><b>435</b> 分 · 125 留言</span>
         <span>github.com</span>
       </div>
     </div>
@@ -274,13 +274,13 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">4</span>
     <div class="body">
-      <h3 class="ti"><a href="https://www.anthropic.com/research/natural-language-autoencoders" target="_blank" rel="noopener">HN 討論 Natural Language Autoencoders 聚焦 Turning Claude&#39;s Thoughts into Text</a></h3>
+      <h3 class="ti"><a href="https://www.anthropic.com/research/natural-language-autoencoders" target="_blank" rel="noopener">Claude 3.5 的內部思考過程可透過自然語言自編碼器（NLAE）直接轉化為文本，無需額外推理。</a></h3>
       
-      <div class="zh">Natural Language Autoencoders（turning、claude）— 評估納入工程工作流或學習其 UX 細節。</div>
+      <div class="zh">為開發者提供可解釋性工具，讓 AI 的「思考」透明化。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#模型</span>
-        <span class="pts"><b>324</b> 分 · 100 留言</span>
+        <span class="pts"><b>325</b> 分 · 100 留言</span>
         <span>anthropic.com</span>
       </div>
     </div>
@@ -288,9 +288,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">5</span>
     <div class="body">
-      <h3 class="ti"><a href="https://deepmind.google/blog/alphaevolve-impact/" target="_blank" rel="noopener">HN 討論 AlphaEvolve 聚焦 Gemini-powered coding agent scaling impact acro…</a></h3>
+      <h3 class="ti"><a href="https://deepmind.google/blog/alphaevolve-impact/" target="_blank" rel="noopener">AlphaEvolve 透過 Gemini 與自訂模型並行訓練，大幅加速 AlphaCode 的演進速度。</a></h3>
       
-      <div class="zh">AlphaEvolve（gemini-powered、coding）— 可比對自家 agent 架構的能力邊界與整合策略。</div>
+      <div class="zh">AI 開發者可利用 Gemini 快速迭代自訂模型，縮短從原型到生產的週期。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#代理</span>
@@ -302,9 +302,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">6</span>
     <div class="body">
-      <h3 class="ti"><a href="https://www.tomshardware.com/pc-components/motherboards/motherboard-sales-collapse-by-more-than-25-percent-as-chipmakers-strangle-enthusiast-pc-market-to-build-more-ai-chips-asus-projected-to-sell-5-million-fewer-boards-in-2025-gigabyte-msi-and-asrock-also-expected-to-see-reduced-sales-numbers" target="_blank" rel="noopener">HN 討論 Motherboard sales &#39;collapse&#39; amid unprecedented shortages fueled by AI 聚焦 Motherboard sales &#39;collapse&#39; amid unprecedented…</a></h3>
+      <h3 class="ti"><a href="https://www.tomshardware.com/pc-components/motherboards/motherboard-sales-collapse-by-more-than-25-percent-as-chipmakers-strangle-enthusiast-pc-market-to-build-more-ai-chips-asus-projected-to-sell-5-million-fewer-boards-in-2025-gigabyte-msi-and-asrock-also-expected-to-see-reduced-sales-numbers" target="_blank" rel="noopener">主機板銷售因 AI 晶片短缺而萎縮超過 25%，廠商預計 2025 年銷量大幅減少。</a></h3>
       
-      <div class="zh">Motherboard sales &#39;collapse&#39; am…（motherboard、sales）— 初步觀察，待後續判讀是否進入工具鏈或選型清單。</div>
+      <div class="zh">開發者若依賴消費級主機板進行 AI 實驗或邊緣裝置，需預備延遲風險；建議轉向企業級平台或自製 FPGA 以避開供應瓶頸。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#其他</span>
@@ -316,13 +316,13 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">7</span>
     <div class="body">
-      <h3 class="ti"><a href="https://hacks.mozilla.org/2026/05/behind-the-scenes-hardening-firefox/" target="_blank" rel="noopener">HN 討論 Hardening Firefox with Claude Mythos Preview 聚焦 Hardening Firefox with Claude Mythos Preview</a></h3>
+      <h3 class="ti"><a href="https://hacks.mozilla.org/2026/05/behind-the-scenes-hardening-firefox/" target="_blank" rel="noopener">Mozilla 使用 Claude Mythos 進行 Firefox 安全掃描，發現了 271 個漏洞且誤報率極低。</a></h3>
       
-      <div class="zh">Hardening Firefox with Claude M…（hardening、firefox）— 追蹤可替換或補位的推理引擎，影響成本/延遲決策。</div>
+      <div class="zh">為 AI 驅動的軟體安全測試提供實例，開發者可參考此架構以提升自訂工具的檢測效能。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#模型</span>
-        <span class="pts"><b>256</b> 分 · 118 留言</span>
+        <span class="pts"><b>259</b> 分 · 118 留言</span>
         <span>hacks.mozilla.org</span>
       </div>
     </div>
@@ -330,9 +330,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">8</span>
     <div class="body">
-      <h3 class="ti"><a href="https://www.citizen.co.za/news/home-affairs-officials-suspended-ai-hallucinations/" target="_blank" rel="noopener">HN 討論 Two Home Affairs officials suspended after AI &#39;hallucinations&#39; found 聚焦 Two Home Affairs officials suspended after AI &#39;…</a></h3>
+      <h3 class="ti"><a href="https://www.citizen.co.za/news/home-affairs-officials-suspended-ai-hallucinations/" target="_blank" rel="noopener">南非內政部官員因 AI 產生幻覺導致錯誤決策而被停職。</a></h3>
       
-      <div class="zh">Two Home Affairs officials susp…（two、home）— 初步觀察，待後續判讀是否進入工具鏈或選型清單。</div>
+      <div class="zh">提醒開發者與使用者：對 AI 產出內容必須進行嚴謹的事前驗證與後審，不可完全信任模型輸出，否則可能導致法律或行政責任。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#其他</span>
@@ -344,13 +344,13 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">9</span>
     <div class="body">
-      <h3 class="ti"><a href="https://openrouter.ai/announcements/gpt55-cost-analysis" target="_blank" rel="noopener">HN 討論 GPT-5.5 Price Increase 聚焦 What It Costs</a></h3>
+      <h3 class="ti"><a href="https://openrouter.ai/announcements/gpt55-cost-analysis" target="_blank" rel="noopener">GPT-5.5 價格上漲是 API 供應商調整定價策略的結果，而非模型能力大幅提升。</a></h3>
       
-      <div class="zh">GPT-5.5 Price Increase（what、costs）— 追蹤可替換或補位的推理引擎，影響成本/延遲決策。</div>
+      <div class="zh">開發者需重新評估預算，避免過度依賴於價格上漲的模型。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#模型</span>
-        <span class="pts"><b>109</b> 分 · 25 留言</span>
+        <span class="pts"><b>111</b> 分 · 26 留言</span>
         <span>openrouter.ai</span>
       </div>
     </div>
@@ -638,9 +638,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">30</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/ReviewStage/stage-cli" target="_blank" rel="noopener">HN 討論 Show HN 聚焦 Stage CLI – An easier way of reading your AI ge…</a></h3>
+      <h3 class="ti"><a href="https://github.com/ReviewStage/stage-cli" target="_blank" rel="noopener">Stage CLI 讓開發者能透過自然語言指令，將 AI 生成的程式碼變更拆解為邏輯章節並在地瀏覽器閱讀。</a></h3>
       
-      <div class="zh">Show HN（stage、cli）— 評估納入工程工作流或學習其 UX 細節。</div>
+      <div class="zh">對 agent 開發者而言，可將現有 AI 整合至本地工作流，無需依賴遠端服務。這降低門檻並提升對複雜變更的掌控力。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#代理</span>
@@ -652,13 +652,13 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">31</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/advisories/GHSA-vp62-r36r-9xqp" target="_blank" rel="noopener">HN 討論 Claude Code CVE-2026-39861 聚焦 sandbox escape via symlink</a></h3>
+      <h3 class="ti"><a href="https://github.com/advisories/GHSA-vp62-r36r-9xqp" target="_blank" rel="noopener">Claude Code 因 symlink 攻擊導致沙盒逃逸，暴露出 AI 編譯器安全邊界。</a></h3>
       
-      <div class="zh">Claude Code CVE-2026-39861（sandbox、escape）— 檢視 agent 執行邊界與權限模型是否該升級。</div>
+      <div class="zh">開發者需警惕 AI 編譯器對惡意 symlinks 的處理，避免沙盒逃逸風險。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#模型</span>
-        <span class="pts"><b>29</b> 分 · 2 留言</span>
+        <span class="pts"><b>29</b> 分 · 3 留言</span>
         <span>github.com</span>
       </div>
     </div>
@@ -666,9 +666,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">32</span>
     <div class="body">
-      <h3 class="ti"><a href="https://simonwillison.net/2026/May/7/xai-anthropic/" target="_blank" rel="noopener">HN 討論 Notes on the xAI/Anthropic data center deal 聚焦 Notes on the xAI/Anthropic data center deal</a></h3>
+      <h3 class="ti"><a href="https://simonwillison.net/2026/May/7/xai-anthropic/" target="_blank" rel="noopener">xAI 與 Anthropic 的數據中心交易可能引發 AI 巨頭壟斷，並削弱開源生態。</a></h3>
       
-      <div class="zh">Notes on the xAI/Anthropic data…（notes、xai）— 可作為比較或回歸測試的資料/評測來源。</div>
+      <div class="zh">開發者應警惕閉源壟斷，避免依賴於受限的 API 或硬體。建議持續投入開源工具與自部署架構，維持技術自主性。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#其他</span>
@@ -680,9 +680,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">33</span>
     <div class="body">
-      <h3 class="ti"><a href="https://moq.dev/blog/webrtc-is-the-problem/" target="_blank" rel="noopener">HN 討論 OpenAI&#39;s WebRTC Problem 聚焦 OpenAI&#39;s WebRTC Problem</a></h3>
+      <h3 class="ti"><a href="https://moq.dev/blog/webrtc-is-the-problem/" target="_blank" rel="noopener">WebRTC 的即時通訊能力讓 AI 代理能直接與用戶對話，但缺乏統一的 API 導致開發者難以構建可靠的多代理系統。</a></h3>
       
-      <div class="zh">OpenAI&#39;s WebRTC Problem（openai、webrtc）— 初步觀察，待後續判讀是否進入工具鏈或選型清單。</div>
+      <div class="zh">對 AI 開發者而言，需重新評估 WebRTC 的整合方式，考慮使用現有 API 或框架來解決即時通訊與 AI 代理的整合問題。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#其他</span>
@@ -1406,13 +1406,13 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">21</span>
     <div class="body">
-      <h3 class="ti"><a href="https://bsuh.bearblog.dev/agents-need-control-flow/" target="_blank" rel="noopener">HN 討論 Agents need control flow, not more prompts 聚焦 Agents need control flow, not more prompts</a></h3>
+      <h3 class="ti"><a href="https://bsuh.bearblog.dev/agents-need-control-flow/" target="_blank" rel="noopener">Agent 開發不應依賴更多提示詞，而應建立明確的控制流程與狀態管理。</a></h3>
       
-      <div class="zh">Agents need control flow, not m…（agents、need）— 可比對自家 agent 架構的能力邊界與整合策略。</div>
+      <div class="zh">開發者需從「寫提示詞」轉向「設計狀態機與控制邏輯」，降低系統崩潰風險並提升可維護性。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#其他</span>
-        <span class="pts"><b>519</b> 分 · 255 留言</span>
+        <span class="pts"><b>520</b> 分 · 255 留言</span>
         <span>bsuh.bearblog.dev</span>
       </div>
     </div>
@@ -1420,9 +1420,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">22</span>
     <div class="body">
-      <h3 class="ti"><a href="https://deepmind.google/blog/alphaevolve-impact/" target="_blank" rel="noopener">HN 討論 AlphaEvolve 聚焦 Gemini-powered coding agent scaling impact acro…</a></h3>
+      <h3 class="ti"><a href="https://deepmind.google/blog/alphaevolve-impact/" target="_blank" rel="noopener">AlphaEvolve 透過 Gemini 與自訂模型並行訓練，大幅加速 AlphaCode 的演進速度。</a></h3>
       
-      <div class="zh">AlphaEvolve（gemini-powered、coding）— 可比對自家 agent 架構的能力邊界與整合策略。</div>
+      <div class="zh">AI 開發者可利用 Gemini 快速迭代自訂模型，縮短從原型到生產的週期。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#代理</span>
@@ -1434,9 +1434,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">23</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/ReviewStage/stage-cli" target="_blank" rel="noopener">HN 討論 Show HN 聚焦 Stage CLI – An easier way of reading your AI ge…</a></h3>
+      <h3 class="ti"><a href="https://github.com/ReviewStage/stage-cli" target="_blank" rel="noopener">Stage CLI 讓開發者能透過自然語言指令，將 AI 生成的程式碼變更拆解為邏輯章節並在地瀏覽器閱讀。</a></h3>
       
-      <div class="zh">Show HN（stage、cli）— 評估納入工程工作流或學習其 UX 細節。</div>
+      <div class="zh">對 agent 開發者而言，可將現有 AI 整合至本地工作流，無需依賴遠端服務。這降低門檻並提升對複雜變更的掌控力。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#代理</span>
@@ -1448,9 +1448,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">24</span>
     <div class="body">
-      <h3 class="ti"><a href="https://moq.dev/blog/webrtc-is-the-problem/" target="_blank" rel="noopener">HN 討論 OpenAI&#39;s WebRTC Problem 聚焦 OpenAI&#39;s WebRTC Problem</a></h3>
+      <h3 class="ti"><a href="https://moq.dev/blog/webrtc-is-the-problem/" target="_blank" rel="noopener">WebRTC 的即時通訊能力讓 AI 代理能直接與用戶對話，但缺乏統一的 API 導致開發者難以構建可靠的多代理系統。</a></h3>
       
-      <div class="zh">OpenAI&#39;s WebRTC Problem（openai、webrtc）— 初步觀察，待後續判讀是否進入工具鏈或選型清單。</div>
+      <div class="zh">對 AI 開發者而言，需重新評估 WebRTC 的整合方式，考慮使用現有 API 或框架來解決即時通訊與 AI 代理的整合問題。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#其他</span>
@@ -1468,9 +1468,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   <ul class="feed"><li>
     <span class="rk">1</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/n8n-io/n8n" target="_blank" rel="noopener">n8n-io/n8n: Fair-code workflow automation platform with native AI capabilities. Combine visual building with custom code, self-host or cloud, 400+ integrations.</a></h3>
+      <h3 class="ti"><a href="https://github.com/n8n-io/n8n" target="_blank" rel="noopener">GitHub 專案 n8n-io/n8n 聚焦 Fair-code workflow automation platform with nat…</a></h3>
       
-      <div class="zh">Fair-code workflow automation platform with native AI capabilities. Combine visual building with custom code, self-host or cloud, 400+ integrations.</div>
+      <div class="zh">n8n-io/n8n（fair-code、workflow）— 對照當前 middleware 編排策略，找替代或補強位置。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -1482,9 +1482,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">2</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/Significant-Gravitas/AutoGPT" target="_blank" rel="noopener">Significant-Gravitas/AutoGPT: AutoGPT is the vision of accessible AI for everyone, to use and to build on. Our mission is to provide the tools, so that you can focus on what matters.</a></h3>
+      <h3 class="ti"><a href="https://github.com/Significant-Gravitas/AutoGPT" target="_blank" rel="noopener">GitHub 專案 Significant-Gravitas/AutoGPT 聚焦 AutoGPT is the vision of accessible AI for ever…</a></h3>
       
-      <div class="zh">AutoGPT is the vision of accessible AI for everyone, to use and to build on. Our mission is to provide the tools, so that you can focus on what matters.</div>
+      <div class="zh">Significant-Gravitas/AutoGPT（autogpt、vision）— 評估補上多模態能力的可行性與整合成本。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -1496,9 +1496,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">3</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/affaan-m/everything-claude-code" target="_blank" rel="noopener">affaan-m/everything-claude-code: The agent harness performance optimization system. Skills, instincts, memory, security, and research-first development for Claude Code, Codex, Opencode, Cursor and beyond.</a></h3>
+      <h3 class="ti"><a href="https://github.com/affaan-m/everything-claude-code" target="_blank" rel="noopener">GitHub 專案 affaan-m/everything-claude-code 聚焦 The agent harness performance optimization syst…</a></h3>
       
-      <div class="zh">The agent harness performance optimization system. Skills, instincts, memory, security, and research-first development for Claude Code, Codex, Opencode, Cursor and beyond.</div>
+      <div class="zh">affaan-m/everything-claude-code（agent、harness）— 對照當前 KG/memory 設計，挑可借用的索引或 retrieval 模式。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#代理</span>
@@ -1510,9 +1510,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">4</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/ollama/ollama" target="_blank" rel="noopener">ollama/ollama: Get up and running with Kimi-K2.5, GLM-5, MiniMax, DeepSeek, gpt-oss, Qwen, Gemma and other models.</a></h3>
+      <h3 class="ti"><a href="https://github.com/ollama/ollama" target="_blank" rel="noopener">GitHub 專案 ollama/ollama 聚焦 Get up and running with Kimi-K2.5, GLM-5, MiniM…</a></h3>
       
-      <div class="zh">Get up and running with Kimi-K2.5, GLM-5, MiniMax, DeepSeek, gpt-oss, Qwen, Gemma and other models.</div>
+      <div class="zh">ollama/ollama（get、running）— 追蹤可替換或補位的推理引擎，影響成本/延遲決策。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -1524,9 +1524,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">5</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/f/prompts.chat" target="_blank" rel="noopener">f/prompts.chat: f.k.a. Awesome ChatGPT Prompts. Share, discover, and collect prompts from the community. Free and open source — self-host for your organization with complete privacy.</a></h3>
+      <h3 class="ti"><a href="https://github.com/f/prompts.chat" target="_blank" rel="noopener">GitHub 專案 f/prompts.chat 聚焦 f.k.a. Awesome ChatGPT Prompts. Share, discover…</a></h3>
       
-      <div class="zh">f.k.a. Awesome ChatGPT Prompts. Share, discover, and collect prompts from the community. Free and open source — self-host for your organization with complete privacy.</div>
+      <div class="zh">f/prompts.chat（f.k.a.、awesome）— 追蹤可替換或補位的推理引擎，影響成本/延遲決策。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -1538,9 +1538,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">6</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/huggingface/transformers" target="_blank" rel="noopener">huggingface/transformers: 🤗 Transformers: the model-definition framework for state-of-the-art machine learning models in text, vision, audio, and multimodal models, for both inference and training.</a></h3>
+      <h3 class="ti"><a href="https://github.com/huggingface/transformers" target="_blank" rel="noopener">GitHub 專案 huggingface/transformers 聚焦 🤗 Transformers: the model-definition framework…</a></h3>
       
-      <div class="zh">🤗 Transformers: the model-definition framework for state-of-the-art machine learning models in text, vision, audio, and multimodal models, for both inference and training.</div>
+      <div class="zh">huggingface/transformers（transformers、model-definition）— 評估補上多模態能力的可行性與整合成本。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#基礎設施</span>
@@ -1552,9 +1552,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">7</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/Snailclimb/JavaGuide" target="_blank" rel="noopener">Snailclimb/JavaGuide: Java 面试 &amp; 后端通用面试指南，覆盖计算机基础、数据库、分布式、高并发、系统设计与 AI 应用开发</a></h3>
+      <h3 class="ti"><a href="https://github.com/Snailclimb/JavaGuide" target="_blank" rel="noopener">GitHub 專案 Snailclimb/JavaGuide 聚焦 Java 面试 &amp; 后端通用面试指南，覆盖计算机基础、数据库、分布式、高并发、系统设计与 AI…</a></h3>
       
-      <div class="zh">Java 面试 &amp; 后端通用面试指南，覆盖计算机基础、数据库、分布式、高并发、系统设计与 AI 应用开发</div>
+      <div class="zh">Snailclimb/JavaGuide（java、后端通用面试指南）— 參考介面與互動設計，對照自家 dashboard 的呈現策略。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -1566,9 +1566,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">8</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/langgenius/dify" target="_blank" rel="noopener">langgenius/dify: Production-ready platform for agentic workflow development.</a></h3>
+      <h3 class="ti"><a href="https://github.com/langgenius/dify" target="_blank" rel="noopener">GitHub 專案 langgenius/dify 聚焦 Production-ready platform for agentic workflow …</a></h3>
       
-      <div class="zh">Production-ready platform for agentic workflow development.</div>
+      <div class="zh">langgenius/dify（production-ready、platform）— 對照當前 middleware 編排策略，找替代或補強位置。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -1580,9 +1580,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">9</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/NousResearch/hermes-agent" target="_blank" rel="noopener">NousResearch/hermes-agent: The agent that grows with you</a></h3>
+      <h3 class="ti"><a href="https://github.com/NousResearch/hermes-agent" target="_blank" rel="noopener">GitHub 專案 NousResearch/hermes-agent 聚焦 The agent that grows with you</a></h3>
       
-      <div class="zh todo">中文摘要待 LLM enrich pass — 先點右側「閱讀原文 →」</div>
+      <div class="zh">NousResearch/hermes-agent（agent、grows）— 可比對自家 agent 架構的能力邊界與整合策略。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#代理</span>
@@ -1594,9 +1594,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">10</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/langchain-ai/langchain" target="_blank" rel="noopener">langchain-ai/langchain: The agent engineering platform. Available in TypeScript!</a></h3>
+      <h3 class="ti"><a href="https://github.com/langchain-ai/langchain" target="_blank" rel="noopener">GitHub 專案 langchain-ai/langchain 聚焦 The agent engineering platform. Available in Ty…</a></h3>
       
-      <div class="zh">The agent engineering platform. Available in TypeScript!</div>
+      <div class="zh">langchain-ai/langchain（agent、engineering）— 可比對自家 agent 架構的能力邊界與整合策略。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#代理</span>
@@ -1608,9 +1608,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">11</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/open-webui/open-webui" target="_blank" rel="noopener">open-webui/open-webui: User-friendly AI Interface (Supports Ollama, OpenAI API, ...)</a></h3>
+      <h3 class="ti"><a href="https://github.com/open-webui/open-webui" target="_blank" rel="noopener">GitHub 專案 open-webui/open-webui 聚焦 User-friendly AI Interface (Supports Ollama, Op…</a></h3>
       
-      <div class="zh">User-friendly AI Interface (Supports Ollama, OpenAI API, ...)</div>
+      <div class="zh">open-webui/open-webui（user-friendly、interface）— 參考介面與互動設計，對照自家 dashboard 的呈現策略。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -1622,9 +1622,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">12</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/firecrawl/firecrawl" target="_blank" rel="noopener">firecrawl/firecrawl: 🔥 The API to search, scrape, and interact with the web for AI</a></h3>
+      <h3 class="ti"><a href="https://github.com/firecrawl/firecrawl" target="_blank" rel="noopener">GitHub 專案 firecrawl/firecrawl 聚焦 🔥 The API to search, scrape, and interact with…</a></h3>
       
-      <div class="zh">🔥 The API to search, scrape, and interact with the web for AI</div>
+      <div class="zh">firecrawl/firecrawl（api、search）— 對照現有 CDP 流程，評估替代抓取/操作介面。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -1636,9 +1636,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">13</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/Shubhamsaboo/awesome-llm-apps" target="_blank" rel="noopener">Shubhamsaboo/awesome-llm-apps: 100+ AI Agent &amp; RAG apps you can actually run — clone, customize, ship.</a></h3>
+      <h3 class="ti"><a href="https://github.com/Shubhamsaboo/awesome-llm-apps" target="_blank" rel="noopener">GitHub 專案 Shubhamsaboo/awesome-llm-apps 聚焦 100+ AI Agent &amp; RAG apps you can actually run —…</a></h3>
       
-      <div class="zh">100+ AI Agent &amp; RAG apps you can actually run — clone, customize, ship.</div>
+      <div class="zh">Shubhamsaboo/awesome-llm-apps（100、agent）— 對照當前 KG/memory 設計，挑可借用的索引或 retrieval 模式。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#代理</span>
@@ -1650,9 +1650,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">14</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/browser-use/browser-use" target="_blank" rel="noopener">browser-use/browser-use: 🌐 Make websites accessible for AI agents. Automate tasks online with ease.</a></h3>
+      <h3 class="ti"><a href="https://github.com/browser-use/browser-use" target="_blank" rel="noopener">GitHub 專案 browser-use/browser-use 聚焦 🌐 Make websites accessible for AI agents. Auto…</a></h3>
       
-      <div class="zh">🌐 Make websites accessible for AI agents. Automate tasks online with ease.</div>
+      <div class="zh">browser-use/browser-use（websites、accessible）— 對照現有 CDP 流程，評估替代抓取/操作介面。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -1664,9 +1664,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">15</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/rasbt/LLMs-from-scratch" target="_blank" rel="noopener">rasbt/LLMs-from-scratch: Implement a ChatGPT-like LLM in PyTorch from scratch, step by step</a></h3>
+      <h3 class="ti"><a href="https://github.com/rasbt/LLMs-from-scratch" target="_blank" rel="noopener">GitHub 專案 rasbt/LLMs-from-scratch 聚焦 Implement a ChatGPT-like LLM in PyTorch from sc…</a></h3>
       
-      <div class="zh">Implement a ChatGPT-like LLM in PyTorch from scratch, step by step</div>
+      <div class="zh">rasbt/LLMs-from-scratch（implement、chatgpt-like）— 追蹤可替換或補位的推理引擎，影響成本/延遲決策。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -1678,9 +1678,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">16</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/punkpeye/awesome-mcp-servers" target="_blank" rel="noopener">punkpeye/awesome-mcp-servers: A collection of MCP servers.</a></h3>
+      <h3 class="ti"><a href="https://github.com/punkpeye/awesome-mcp-servers" target="_blank" rel="noopener">GitHub 專案 punkpeye/awesome-mcp-servers 聚焦 A collection of MCP servers.</a></h3>
       
-      <div class="zh todo">中文摘要待 LLM enrich pass — 先點右側「閱讀原文 →」</div>
+      <div class="zh">punkpeye/awesome-mcp-servers（collection、mcp）— 評估納入工具鏈或暴露為 MCP server 的可行性。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#代理</span>
@@ -1692,9 +1692,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">17</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/infiniflow/ragflow" target="_blank" rel="noopener">infiniflow/ragflow: RAGFlow is a leading open-source Retrieval-Augmented Generation (RAG) engine that fuses cutting-edge RAG with Agent capabilities to create a superior context layer for LLMs</a></h3>
+      <h3 class="ti"><a href="https://github.com/infiniflow/ragflow" target="_blank" rel="noopener">GitHub 專案 infiniflow/ragflow 聚焦 RAGFlow is a leading open-source Retrieval-Augm…</a></h3>
       
-      <div class="zh">RAGFlow is a leading open-source Retrieval-Augmented Generation (RAG) engine that fuses cutting-edge RAG with Agent capabilities to create a superior context layer for LLMs</div>
+      <div class="zh">infiniflow/ragflow（ragflow、leading）— 對照當前 KG/memory 設計，挑可借用的索引或 retrieval 模式。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#代理</span>
@@ -1706,9 +1706,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">18</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/vllm-project/vllm" target="_blank" rel="noopener">vllm-project/vllm: A high-throughput and memory-efficient inference and serving engine for LLMs</a></h3>
+      <h3 class="ti"><a href="https://github.com/vllm-project/vllm" target="_blank" rel="noopener">GitHub 專案 vllm-project/vllm 聚焦 A high-throughput and memory-efficient inferenc…</a></h3>
       
-      <div class="zh">A high-throughput and memory-efficient inference and serving engine for LLMs</div>
+      <div class="zh">vllm-project/vllm（high-throughput、memory-efficient）— 對照當前 KG/memory 設計，挑可借用的索引或 retrieval 模式。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#記憶</span>
@@ -1720,9 +1720,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">19</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/netdata/netdata" target="_blank" rel="noopener">netdata/netdata: The fastest path to AI-powered full stack observability, even for lean teams.</a></h3>
+      <h3 class="ti"><a href="https://github.com/netdata/netdata" target="_blank" rel="noopener">GitHub 專案 netdata/netdata 聚焦 The fastest path to AI-powered full stack obser…</a></h3>
       
-      <div class="zh">The fastest path to AI-powered full stack observability, even for lean teams.</div>
+      <div class="zh">netdata/netdata（fastest、path）— 可作為比較或回歸測試的資料/評測來源。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -1734,9 +1734,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">20</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/PaddlePaddle/PaddleOCR" target="_blank" rel="noopener">PaddlePaddle/PaddleOCR: Turn any PDF or image document into structured data for your AI. A powerful, lightweight OCR toolkit that bridges the gap between images/PDFs and LLMs. Supports 100+ languages.</a></h3>
+      <h3 class="ti"><a href="https://github.com/PaddlePaddle/PaddleOCR" target="_blank" rel="noopener">GitHub 專案 PaddlePaddle/PaddleOCR 聚焦 Turn any PDF or image document into structured …</a></h3>
       
-      <div class="zh">Turn any PDF or image document into structured data for your AI. A powerful, lightweight OCR toolkit that bridges the gap between images/PDFs and LLMs. Supports 100+ languages.</div>
+      <div class="zh">PaddlePaddle/PaddleOCR（turn、any）— 評估補上多模態能力的可行性與整合成本。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -1748,9 +1748,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">21</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/lobehub/lobehub" target="_blank" rel="noopener">lobehub/lobehub: The ultimate space for work and life — to find, build, and collaborate with agent teammates that grow with you. We are taking agent harness to the next level — enabling multi-agent collaboration, effortless agent team design, and introducing agents as the unit of</a></h3>
+      <h3 class="ti"><a href="https://github.com/lobehub/lobehub" target="_blank" rel="noopener">GitHub 專案 lobehub/lobehub 聚焦 The ultimate space for work and life — to find,…</a></h3>
       
-      <div class="zh">The ultimate space for work and life — to find, build, and collaborate with agent teammates that grow with you. We are taking agent harness to the next level — enabling multi-agent…</div>
+      <div class="zh">lobehub/lobehub（ultimate、space）— 參考介面與互動設計，對照自家 dashboard 的呈現策略。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#代理</span>
@@ -1762,9 +1762,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">22</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/thedotmack/claude-mem" target="_blank" rel="noopener">thedotmack/claude-mem: A Claude Code plugin that automatically captures everything Claude does during your coding sessions, compresses it with AI (using Claude&#39;s agent-sdk), and injects relevant context back into future sessions.</a></h3>
+      <h3 class="ti"><a href="https://github.com/thedotmack/claude-mem" target="_blank" rel="noopener">GitHub 專案 thedotmack/claude-mem 聚焦 A Claude Code plugin that automatically capture…</a></h3>
       
-      <div class="zh">A Claude Code plugin that automatically captures everything Claude does during your coding sessions, compresses it with AI (using Claude&#39;s agent-sdk), and injects relevant context …</div>
+      <div class="zh">thedotmack/claude-mem（claude、code）— 對照當前 middleware 編排策略，找替代或補強位置。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#代理</span>
@@ -1776,9 +1776,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">23</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/OpenHands/OpenHands" target="_blank" rel="noopener">OpenHands/OpenHands: 🙌 OpenHands: AI-Driven Development</a></h3>
+      <h3 class="ti"><a href="https://github.com/OpenHands/OpenHands" target="_blank" rel="noopener">GitHub 專案 OpenHands/OpenHands 聚焦 🙌 OpenHands: AI-Driven Development</a></h3>
       
-      <div class="zh">🙌 OpenHands: AI-Driven Development</div>
+      <div class="zh">OpenHands/OpenHands（openhands、ai-driven）— 初步觀察，待後續判讀是否進入工具鏈或選型清單。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -1790,9 +1790,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">24</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/TauricResearch/TradingAgents" target="_blank" rel="noopener">TauricResearch/TradingAgents: TradingAgents: Multi-Agents LLM Financial Trading Framework</a></h3>
+      <h3 class="ti"><a href="https://github.com/TauricResearch/TradingAgents" target="_blank" rel="noopener">GitHub 專案 TauricResearch/TradingAgents 聚焦 TradingAgents: Multi-Agents LLM Financial Tradi…</a></h3>
       
-      <div class="zh">TradingAgents: Multi-Agents LLM Financial Trading Framework</div>
+      <div class="zh">TauricResearch/TradingAgents（tradingagents、multi-agents）— 可比對自家 agent 架構的能力邊界與整合策略。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -1804,9 +1804,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">25</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/hiyouga/LlamaFactory" target="_blank" rel="noopener">hiyouga/LlamaFactory: Unified Efficient Fine-Tuning of 100+ LLMs &amp; VLMs (ACL 2024)</a></h3>
+      <h3 class="ti"><a href="https://github.com/hiyouga/LlamaFactory" target="_blank" rel="noopener">GitHub 專案 hiyouga/LlamaFactory 聚焦 Unified Efficient Fine-Tuning of 100+ LLMs &amp; VL…</a></h3>
       
-      <div class="zh">Unified Efficient Fine-Tuning of 100+ LLMs &amp; VLMs (ACL 2024)</div>
+      <div class="zh">hiyouga/LlamaFactory（unified、efficient）— 追蹤可替換或補位的推理引擎，影響成本/延遲決策。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -1818,9 +1818,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">26</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/bytedance/deer-flow" target="_blank" rel="noopener">bytedance/deer-flow: An open-source long-horizon SuperAgent harness that researches, codes, and creates. With the help of sandboxes, memories, tools, skill, subagents and message gateway, it handles different levels of tasks that could take minutes to hours.</a></h3>
+      <h3 class="ti"><a href="https://github.com/bytedance/deer-flow" target="_blank" rel="noopener">GitHub 專案 bytedance/deer-flow 聚焦 An open-source long-horizon SuperAgent harness …</a></h3>
       
-      <div class="zh">An open-source long-horizon SuperAgent harness that researches, codes, and creates. With the help of sandboxes, memories, tools, skill, subagents and message gateway, it handles di…</div>
+      <div class="zh">bytedance/deer-flow（open-source、long-horizon）— 對照當前 KG/memory 設計，挑可借用的索引或 retrieval 模式。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -1832,9 +1832,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">27</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/unslothai/unsloth" target="_blank" rel="noopener">unslothai/unsloth: Unsloth Studio is a web UI for training and running open models like Gemma 4, Qwen3.6, DeepSeek, gpt-oss locally.</a></h3>
+      <h3 class="ti"><a href="https://github.com/unslothai/unsloth" target="_blank" rel="noopener">GitHub 專案 unslothai/unsloth 聚焦 Unsloth Studio is a web UI for training and run…</a></h3>
       
-      <div class="zh">Unsloth Studio is a web UI for training and running open models like Gemma 4, Qwen3.6, DeepSeek, gpt-oss locally.</div>
+      <div class="zh">unslothai/unsloth（unsloth、studio）— 評估是否值得投入自訓或微調流程。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -1846,9 +1846,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">28</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/farion1231/cc-switch" target="_blank" rel="noopener">farion1231/cc-switch: A cross-platform desktop All-in-One assistant tool for Claude Code, Codex, OpenCode, openclaw &amp; Gemini CLI.</a></h3>
+      <h3 class="ti"><a href="https://github.com/farion1231/cc-switch" target="_blank" rel="noopener">GitHub 專案 farion1231/cc-switch 聚焦 A cross-platform desktop All-in-One assistant t…</a></h3>
       
-      <div class="zh">A cross-platform desktop All-in-One assistant tool for Claude Code, Codex, OpenCode, openclaw &amp; Gemini CLI.</div>
+      <div class="zh">farion1231/cc-switch（cross-platform、desktop）— 參考介面與互動設計，對照自家 dashboard 的呈現策略。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#模型</span>
@@ -1860,9 +1860,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">29</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/Mintplex-Labs/anything-llm" target="_blank" rel="noopener">Mintplex-Labs/anything-llm: The all-in-one AI productivity accelerator. On device and privacy first with no annoying setup or configuration.</a></h3>
+      <h3 class="ti"><a href="https://github.com/Mintplex-Labs/anything-llm" target="_blank" rel="noopener">GitHub 專案 Mintplex-Labs/anything-llm 聚焦 The all-in-one AI productivity accelerator. On …</a></h3>
       
-      <div class="zh">The all-in-one AI productivity accelerator. On device and privacy first with no annoying setup or configuration.</div>
+      <div class="zh">Mintplex-Labs/anything-llm（all-in-one、productivity）— 追蹤可替換或補位的推理引擎，影響成本/延遲決策。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -1874,9 +1874,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">30</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/ComposioHQ/awesome-claude-skills" target="_blank" rel="noopener">ComposioHQ/awesome-claude-skills: A curated list of awesome Claude Skills, resources, and tools for customizing Claude AI workflows</a></h3>
+      <h3 class="ti"><a href="https://github.com/ComposioHQ/awesome-claude-skills" target="_blank" rel="noopener">GitHub 專案 ComposioHQ/awesome-claude-skills 聚焦 A curated list of awesome Claude Skills, resour…</a></h3>
       
-      <div class="zh">A curated list of awesome Claude Skills, resources, and tools for customizing Claude AI workflows</div>
+      <div class="zh">ComposioHQ/awesome-claude-skills（curated、list）— 對照當前 middleware 編排策略，找替代或補強位置。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#模型</span>
@@ -1888,9 +1888,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">31</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/JuliusBrussee/caveman" target="_blank" rel="noopener">JuliusBrussee/caveman: 🪨 why use many token when few token do trick — Claude Code skill that cuts 65% of tokens by talking like caveman</a></h3>
+      <h3 class="ti"><a href="https://github.com/JuliusBrussee/caveman" target="_blank" rel="noopener">GitHub 專案 JuliusBrussee/caveman 聚焦 🪨 why use many token when few token do trick —…</a></h3>
       
-      <div class="zh">🪨 why use many token when few token do trick — Claude Code skill that cuts 65% of tokens by talking like caveman</div>
+      <div class="zh">JuliusBrussee/caveman（why、many）— 評估納入工程工作流或學習其 UX 細節。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#模型</span>
@@ -1902,9 +1902,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">32</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/mem0ai/mem0" target="_blank" rel="noopener">mem0ai/mem0: Universal memory layer for AI Agents</a></h3>
+      <h3 class="ti"><a href="https://github.com/mem0ai/mem0" target="_blank" rel="noopener">GitHub 專案 mem0ai/mem0 聚焦 Universal memory layer for AI Agents</a></h3>
       
-      <div class="zh">Universal memory layer for AI Agents</div>
+      <div class="zh">mem0ai/mem0（universal、memory）— 對照當前 KG/memory 設計，挑可借用的索引或 retrieval 模式。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#記憶</span>
@@ -1916,9 +1916,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">33</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/upstash/context7" target="_blank" rel="noopener">upstash/context7: Context7 Platform -- Up-to-date code documentation for LLMs and AI code editors</a></h3>
+      <h3 class="ti"><a href="https://github.com/upstash/context7" target="_blank" rel="noopener">GitHub 專案 upstash/context7 聚焦 Context7 Platform -- Up-to-date code documentat…</a></h3>
       
-      <div class="zh">Context7 Platform -- Up-to-date code documentation for LLMs and AI code editors</div>
+      <div class="zh">upstash/context7（context7、platform）— 評估納入工程工作流或學習其 UX 細節。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -1930,9 +1930,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">34</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/FlowiseAI/Flowise" target="_blank" rel="noopener">FlowiseAI/Flowise: Build AI Agents, Visually</a></h3>
+      <h3 class="ti"><a href="https://github.com/FlowiseAI/Flowise" target="_blank" rel="noopener">GitHub 專案 FlowiseAI/Flowise 聚焦 Build AI Agents, Visually</a></h3>
       
-      <div class="zh todo">中文摘要待 LLM enrich pass — 先點右側「閱讀原文 →」</div>
+      <div class="zh">FlowiseAI/Flowise（agents、visually）— 參考介面與互動設計，對照自家 dashboard 的呈現策略。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -1944,9 +1944,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">35</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/MemPalace/mempalace" target="_blank" rel="noopener">MemPalace/mempalace: The best-benchmarked open-source AI memory system. And it&#39;s free.</a></h3>
+      <h3 class="ti"><a href="https://github.com/MemPalace/mempalace" target="_blank" rel="noopener">GitHub 專案 MemPalace/mempalace 聚焦 The best-benchmarked open-source AI memory syst…</a></h3>
       
-      <div class="zh">The best-benchmarked open-source AI memory system. And it&#39;s free.</div>
+      <div class="zh">MemPalace/mempalace（best-benchmarked、open-source）— 對照當前 KG/memory 設計，挑可借用的索引或 retrieval 模式。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#記憶</span>
@@ -1958,9 +1958,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">36</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/ggml-org/whisper.cpp" target="_blank" rel="noopener">ggml-org/whisper.cpp: Port of OpenAI&#39;s Whisper model in C/C++</a></h3>
+      <h3 class="ti"><a href="https://github.com/ggml-org/whisper.cpp" target="_blank" rel="noopener">GitHub 專案 ggml-org/whisper.cpp 聚焦 Port of OpenAI&#39;s Whisper model in C/C++</a></h3>
       
-      <div class="zh">Port of OpenAI&#39;s Whisper model in C/C++</div>
+      <div class="zh">ggml-org/whisper.cpp（port、openai）— 追蹤可替換或補位的推理引擎，影響成本/延遲決策。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -1972,9 +1972,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">37</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/huginn/huginn" target="_blank" rel="noopener">huginn/huginn: Create agents that monitor and act on your behalf.  Your agents are standing by!</a></h3>
+      <h3 class="ti"><a href="https://github.com/huginn/huginn" target="_blank" rel="noopener">GitHub 專案 huginn/huginn 聚焦 Create agents that monitor and act on your beha…</a></h3>
       
-      <div class="zh">Create agents that monitor and act on your behalf. Your agents are standing by!</div>
+      <div class="zh">huginn/huginn（create、agents）— 可比對自家 agent 架構的能力邊界與整合策略。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -1986,9 +1986,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">38</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/run-llama/llama_index" target="_blank" rel="noopener">run-llama/llama_index: LlamaIndex is the leading document agent and OCR platform</a></h3>
+      <h3 class="ti"><a href="https://github.com/run-llama/llama_index" target="_blank" rel="noopener">GitHub 專案 run-llama/llama_index 聚焦 LlamaIndex is the leading document agent and OC…</a></h3>
       
-      <div class="zh">LlamaIndex is the leading document agent and OCR platform</div>
+      <div class="zh">run-llama/llama_index（llamaindex、leading）— 可比對自家 agent 架構的能力邊界與整合策略。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#代理</span>
@@ -2000,9 +2000,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">39</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/D4Vinci/Scrapling" target="_blank" rel="noopener">D4Vinci/Scrapling: 🕷️ An adaptive Web Scraping framework that handles everything from a single request to a full-scale crawl!</a></h3>
+      <h3 class="ti"><a href="https://github.com/D4Vinci/Scrapling" target="_blank" rel="noopener">GitHub 專案 D4Vinci/Scrapling 聚焦 🕷️ An adaptive Web Scraping framework that han…</a></h3>
       
-      <div class="zh">🕷️ An adaptive Web Scraping framework that handles everything from a single request to a full-scale crawl!</div>
+      <div class="zh">D4Vinci/Scrapling（adaptive、web）— 對照現有 CDP 流程，評估替代抓取/操作介面。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -2014,9 +2014,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">40</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/mudler/LocalAI" target="_blank" rel="noopener">mudler/LocalAI: LocalAI is the open-source AI engine. Run any model - LLMs, vision, voice, image, video - on any hardware. No GPU required.</a></h3>
+      <h3 class="ti"><a href="https://github.com/mudler/LocalAI" target="_blank" rel="noopener">GitHub 專案 mudler/LocalAI 聚焦 LocalAI is the open-source AI engine. Run any m…</a></h3>
       
-      <div class="zh">LocalAI is the open-source AI engine. Run any model - LLMs, vision, voice, image, video - on any hardware. No GPU required.</div>
+      <div class="zh">mudler/LocalAI（localai、open-source）— 評估補上多模態能力的可行性與整合成本。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#基礎設施</span>
@@ -2028,9 +2028,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">41</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/jeecgboot/JeecgBoot" target="_blank" rel="noopener">jeecgboot/JeecgBoot: AI低代码平台，支持「低代码 + 零代码」双模式：零代码 5 分钟搭建业务系统，低代码模式一键生成前后端代码。 内置AI 应用，支持AI聊天、知识库、流程编排、MCP与插件，支持各种模型。Skills能力实现：一句话画流程图、设计表单、生成系统。 引领 AI生成→在线配置→代码生成→手工合并的开发模式，解决Java项目80%的重复工作，快速提高效率，又不失灵活性。</a></h3>
+      <h3 class="ti"><a href="https://github.com/jeecgboot/JeecgBoot" target="_blank" rel="noopener">GitHub 專案 jeecgboot/JeecgBoot 聚焦 AI低代码平台，支持「低代码 + 零代码」双模式：零代码 5 分钟搭建业务系统，低代码模式一键…</a></h3>
       
-      <div class="zh">AI低代码平台，支持「低代码 + 零代码」双模式：零代码 5 分钟搭建业务系统，低代码模式一键生成前后端代码。 内置AI 应用，支持AI聊天、知识库、流程编排、MCP与插件，支持各种模型。Skills能力实现：一句话画流程图、设计表单、生成系统。 引领 AI生成→在线配置→代码生成→手工合并的开发模式，解决Java项目80%的重复工作，快速提高效率，又不失灵…</div>
+      <div class="zh">jeecgboot/JeecgBoot（ai低代码平台、低代码）— 評估納入工具鏈或暴露為 MCP server 的可行性。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#代理</span>
@@ -2042,9 +2042,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">42</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/safishamsi/graphify" target="_blank" rel="noopener">safishamsi/graphify: AI coding assistant skill (Claude Code, Codex, OpenCode, Cursor, Gemini CLI, and more). Turn any folder of code, SQL schemas, R scripts, shell scripts, docs, papers, images, or videos into a queryable knowledge graph. App code + database schema + infrastructu</a></h3>
+      <h3 class="ti"><a href="https://github.com/safishamsi/graphify" target="_blank" rel="noopener">GitHub 專案 safishamsi/graphify 聚焦 AI coding assistant skill (Claude Code, Codex, …</a></h3>
       
-      <div class="zh">AI coding assistant skill (Claude Code, Codex, OpenCode, Cursor, Gemini CLI, and more). Turn any folder of code, SQL schemas, R scripts, shell scripts, docs, papers, images, or vid…</div>
+      <div class="zh">safishamsi/graphify（coding、assistant）— 評估補上多模態能力的可行性與整合成本。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#模型</span>
@@ -2056,9 +2056,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">43</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/aaif-goose/goose" target="_blank" rel="noopener">aaif-goose/goose: an open source, extensible AI agent that goes beyond code suggestions - install, execute, edit, and test with any LLM</a></h3>
+      <h3 class="ti"><a href="https://github.com/aaif-goose/goose" target="_blank" rel="noopener">GitHub 專案 aaif-goose/goose 聚焦 an open source, extensible AI agent that goes b…</a></h3>
       
-      <div class="zh">an open source, extensible AI agent that goes beyond code suggestions - install, execute, edit, and test with any LLM</div>
+      <div class="zh">aaif-goose/goose（open、source）— 評估納入工程工作流或學習其 UX 細節。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#代理</span>
@@ -2070,9 +2070,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">44</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/zhayujie/CowAgent" target="_blank" rel="noopener">zhayujie/CowAgent: CowAgent (chatgpt-on-wechat) 是基于大模型的超级AI助理，能主动思考和任务规划、访问操作系统和外部资源、创造和执行Skills、通过长期记忆和知识库不断成长，比OpenClaw更轻量和便捷。同时支持微信、飞书、钉钉、企微、QQ、公众号、网页等接入，可选择DeepSeek/OpenAI/Claude/Gemini/ MiniMax/Qwen/GLM/LinkAI，能处理文本、语音、图片和文件，可快速搭建个人AI助理和企业数字员工。</a></h3>
+      <h3 class="ti"><a href="https://github.com/zhayujie/CowAgent" target="_blank" rel="noopener">GitHub 專案 zhayujie/CowAgent 聚焦 CowAgent (chatgpt-on-wechat) 是基于大模型的超级AI助理，能主动思…</a></h3>
       
-      <div class="zh">CowAgent (chatgpt-on-wechat) 是基于大模型的超级AI助理，能主动思考和任务规划、访问操作系统和外部资源、创造和执行Skills、通过长期记忆和知识库不断成长，比OpenClaw更轻量和便捷。同时支持微信、飞书、钉钉、企微、QQ、公众号、网页等接入，可选择DeepSeek/OpenAI/Claude/Gemini/ MiniMax/…</div>
+      <div class="zh">zhayujie/CowAgent（cowagent、chatgpt-on-wechat）— 可比對自家 agent 架構的能力邊界與整合策略。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#模型</span>
@@ -2084,9 +2084,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">45</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/milvus-io/milvus" target="_blank" rel="noopener">milvus-io/milvus: Milvus is a high-performance, cloud-native vector database built for scalable vector ANN search</a></h3>
+      <h3 class="ti"><a href="https://github.com/milvus-io/milvus" target="_blank" rel="noopener">GitHub 專案 milvus-io/milvus 聚焦 Milvus is a high-performance, cloud-native vect…</a></h3>
       
-      <div class="zh">Milvus is a high-performance, cloud-native vector database built for scalable vector ANN search</div>
+      <div class="zh">milvus-io/milvus（milvus、high-performance）— 對照當前 KG/memory 設計，挑可借用的索引或 retrieval 模式。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#記憶</span>
@@ -2098,9 +2098,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">46</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/datawhalechina/hello-agents" target="_blank" rel="noopener">datawhalechina/hello-agents: 📚 《从零开始构建智能体》——从零开始的智能体原理与实践教程</a></h3>
+      <h3 class="ti"><a href="https://github.com/datawhalechina/hello-agents" target="_blank" rel="noopener">GitHub 專案 datawhalechina/hello-agents 聚焦 📚 《从零开始构建智能体》——从零开始的智能体原理与实践教程</a></h3>
       
-      <div class="zh">📚 《从零开始构建智能体》——从零开始的智能体原理与实践教程</div>
+      <div class="zh">datawhalechina/hello-agents（从零开始构建智能体、从零开始的智能体原理与实践教程）— 可作為比較或回歸測試的資料/評測來源。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -2112,9 +2112,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">47</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/pingcap/tidb" target="_blank" rel="noopener">pingcap/tidb: TiDB is built for agentic workloads that grow unpredictably, with ACID guarantees and native support for transactions, analytics, and vector search. No data silos. No noisy neighbors. No infrastructure ceiling.</a></h3>
+      <h3 class="ti"><a href="https://github.com/pingcap/tidb" target="_blank" rel="noopener">GitHub 專案 pingcap/tidb 聚焦 TiDB is built for agentic workloads that grow u…</a></h3>
       
-      <div class="zh">TiDB is built for agentic workloads that grow unpredictably, with ACID guarantees and native support for transactions, analytics, and vector search. No data silos. No noisy neighbo…</div>
+      <div class="zh">pingcap/tidb（tidb、agentic）— 對照當前 KG/memory 設計，挑可借用的索引或 retrieval 模式。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#記憶</span>
@@ -2126,9 +2126,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">48</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/mindsdb/mindsdb" target="_blank" rel="noopener">mindsdb/mindsdb: AI Data Vault - A query engine for AI Agents to securely query data from any datasource</a></h3>
+      <h3 class="ti"><a href="https://github.com/mindsdb/mindsdb" target="_blank" rel="noopener">GitHub 專案 mindsdb/mindsdb 聚焦 AI Data Vault - A query engine for AI Agents to…</a></h3>
       
-      <div class="zh">AI Data Vault - A query engine for AI Agents to securely query data from any datasource</div>
+      <div class="zh">mindsdb/mindsdb（data、vault）— 可作為比較或回歸測試的資料/評測來源。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -2140,9 +2140,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">49</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/ChromeDevTools/chrome-devtools-mcp" target="_blank" rel="noopener">ChromeDevTools/chrome-devtools-mcp: Chrome DevTools for coding agents</a></h3>
+      <h3 class="ti"><a href="https://github.com/ChromeDevTools/chrome-devtools-mcp" target="_blank" rel="noopener">GitHub 專案 ChromeDevTools/chrome-devtools-mcp 聚焦 Chrome DevTools for coding agents</a></h3>
       
-      <div class="zh">Chrome DevTools for coding agents</div>
+      <div class="zh">ChromeDevTools/chrome-devtools-…（chrome、devtools）— 評估納入工具鏈或暴露為 MCP server 的可行性。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#代理</span>
@@ -2154,9 +2154,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">50</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/alibaba/arthas" target="_blank" rel="noopener">alibaba/arthas: Alibaba Java Diagnostic Tool Arthas/Alibaba Java诊断利器Arthas</a></h3>
+      <h3 class="ti"><a href="https://github.com/alibaba/arthas" target="_blank" rel="noopener">GitHub 專案 alibaba/arthas 聚焦 Alibaba Java Diagnostic Tool Arthas/Alibaba Jav…</a></h3>
       
-      <div class="zh">Alibaba Java Diagnostic Tool Arthas/Alibaba Java诊断利器Arthas</div>
+      <div class="zh">alibaba/arthas（alibaba、java）— 初步觀察，待後續判讀是否進入工具鏈或選型清單。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -2168,9 +2168,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">51</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/1Panel-dev/1Panel" target="_blank" rel="noopener">1Panel-dev/1Panel: 🔥 1Panel is a modern, open-source VPS control panel — and the only one with native AI agent support. Run Ollama models, deploy OpenClaw agents, and manage your entire server stack from one clean web interface.</a></h3>
+      <h3 class="ti"><a href="https://github.com/1Panel-dev/1Panel" target="_blank" rel="noopener">GitHub 專案 1Panel-dev/1Panel 聚焦 🔥 1Panel is a modern, open-source VPS control …</a></h3>
       
-      <div class="zh">🔥 1Panel is a modern, open-source VPS control panel — and the only one with native AI agent support. Run Ollama models, deploy OpenClaw agents, and manage your entire server stack…</div>
+      <div class="zh">1Panel-dev/1Panel（1panel、modern）— 可比對自家 agent 架構的能力邊界與整合策略。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#代理</span>
@@ -2182,9 +2182,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">52</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/HKUDS/LightRAG" target="_blank" rel="noopener">HKUDS/LightRAG: [EMNLP2025] &quot;LightRAG: Simple and Fast Retrieval-Augmented Generation&quot;</a></h3>
+      <h3 class="ti"><a href="https://github.com/HKUDS/LightRAG" target="_blank" rel="noopener">GitHub 專案 HKUDS/LightRAG 聚焦 [EMNLP2025] &quot;LightRAG: Simple and Fast Retrieva…</a></h3>
       
-      <div class="zh">[EMNLP2025] &quot;LightRAG: Simple and Fast Retrieval-Augmented Generation&quot;</div>
+      <div class="zh">HKUDS/LightRAG（emnlp2025、lightrag）— 對照當前 KG/memory 設計，挑可借用的索引或 retrieval 模式。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -2196,9 +2196,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">53</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/patchy631/ai-engineering-hub" target="_blank" rel="noopener">patchy631/ai-engineering-hub: In-depth tutorials on LLMs, RAGs and real-world AI agent applications.</a></h3>
+      <h3 class="ti"><a href="https://github.com/patchy631/ai-engineering-hub" target="_blank" rel="noopener">GitHub 專案 patchy631/ai-engineering-hub 聚焦 In-depth tutorials on LLMs, RAGs and real-world…</a></h3>
       
-      <div class="zh">In-depth tutorials on LLMs, RAGs and real-world AI agent applications.</div>
+      <div class="zh">patchy631/ai-engineering-hub（in-depth、tutorials）— 對照當前 KG/memory 設計，挑可借用的索引或 retrieval 模式。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#代理</span>
@@ -2210,9 +2210,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">54</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/ZhuLinsen/daily_stock_analysis" target="_blank" rel="noopener">ZhuLinsen/daily_stock_analysis: LLM驱动的 A/H/美股智能分析器：多数据源行情 + 实时新闻 + LLM决策仪表盘 + 多渠道推送，零成本定时运行，纯白嫖. LLM-powered stock analysis system for A/H/US markets.</a></h3>
+      <h3 class="ti"><a href="https://github.com/ZhuLinsen/daily_stock_analysis" target="_blank" rel="noopener">GitHub 專案 ZhuLinsen/daily_stock_analysis 聚焦 LLM驱动的 A/H/美股智能分析器：多数据源行情 + 实时新闻 + LLM决策仪表盘 + 多…</a></h3>
       
-      <div class="zh">LLM驱动的 A/H/美股智能分析器：多数据源行情 + 实时新闻 + LLM决策仪表盘 + 多渠道推送，零成本定时运行，纯白嫖. LLM-powered stock analysis system for A/H/US markets.</div>
+      <div class="zh">ZhuLinsen/daily_stock_analysis（llm驱动的、美股智能分析器）— 追蹤可替換或補位的推理引擎，影響成本/延遲決策。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -2224,9 +2224,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">55</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/huggingface/diffusers" target="_blank" rel="noopener">huggingface/diffusers: 🤗 Diffusers: State-of-the-art diffusion models for image, video, and audio generation in PyTorch.</a></h3>
+      <h3 class="ti"><a href="https://github.com/huggingface/diffusers" target="_blank" rel="noopener">GitHub 專案 huggingface/diffusers 聚焦 🤗 Diffusers: State-of-the-art diffusion models…</a></h3>
       
-      <div class="zh">🤗 Diffusers: State-of-the-art diffusion models for image, video, and audio generation in PyTorch.</div>
+      <div class="zh">huggingface/diffusers（diffusers、state-of-the-art）— 評估補上多模態能力的可行性與整合成本。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -2238,9 +2238,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">56</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/continuedev/continue" target="_blank" rel="noopener">continuedev/continue: ⏩ Source-controlled AI checks, enforceable in CI. Powered by the open-source Continue CLI</a></h3>
+      <h3 class="ti"><a href="https://github.com/continuedev/continue" target="_blank" rel="noopener">GitHub 專案 continuedev/continue 聚焦 ⏩ Source-controlled AI checks, enforceable in C…</a></h3>
       
-      <div class="zh">⏩ Source-controlled AI checks, enforceable in CI. Powered by the open-source Continue CLI</div>
+      <div class="zh">continuedev/continue（source-controlled、checks）— 評估納入工程工作流或學習其 UX 細節。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -2252,9 +2252,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">57</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/alibaba/nacos" target="_blank" rel="noopener">alibaba/nacos: an easy-to-use dynamic service discovery, configuration and service management platform for building AI cloud native applications.</a></h3>
+      <h3 class="ti"><a href="https://github.com/alibaba/nacos" target="_blank" rel="noopener">GitHub 專案 alibaba/nacos 聚焦 an easy-to-use dynamic service discovery, confi…</a></h3>
       
-      <div class="zh">an easy-to-use dynamic service discovery, configuration and service management platform for building AI cloud native applications.</div>
+      <div class="zh">alibaba/nacos（easy-to-use、dynamic）— 參考介面與互動設計，對照自家 dashboard 的呈現策略。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -2266,9 +2266,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">58</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/microsoft/graphrag" target="_blank" rel="noopener">microsoft/graphrag: A modular graph-based Retrieval-Augmented Generation (RAG) system</a></h3>
+      <h3 class="ti"><a href="https://github.com/microsoft/graphrag" target="_blank" rel="noopener">GitHub 專案 microsoft/graphrag 聚焦 A modular graph-based Retrieval-Augmented Gener…</a></h3>
       
-      <div class="zh">A modular graph-based Retrieval-Augmented Generation (RAG) system</div>
+      <div class="zh">microsoft/graphrag（modular、graph-based）— 對照當前 KG/memory 設計，挑可借用的索引或 retrieval 模式。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#記憶</span>
@@ -2280,9 +2280,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">59</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/AstrBotDevs/AstrBot" target="_blank" rel="noopener">AstrBotDevs/AstrBot: AI Agent Assistant &amp; development framework that integrates lots of IM platforms, LLMs, plugins and AI feature, and can be your openclaw alternative. ✨</a></h3>
+      <h3 class="ti"><a href="https://github.com/AstrBotDevs/AstrBot" target="_blank" rel="noopener">GitHub 專案 AstrBotDevs/AstrBot 聚焦 AI Agent Assistant &amp; development framework that…</a></h3>
       
-      <div class="zh">AI Agent Assistant &amp; development framework that integrates lots of IM platforms, LLMs, plugins and AI feature, and can be your openclaw alternative. ✨</div>
+      <div class="zh">AstrBotDevs/AstrBot（agent、assistant）— 可比對自家 agent 架構的能力邊界與整合策略。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#代理</span>
@@ -2294,9 +2294,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">60</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/zeroclaw-labs/zeroclaw" target="_blank" rel="noopener">zeroclaw-labs/zeroclaw: Fast, small, and fully autonomous AI personal assistant infrastructure, ANY OS, ANY PLATFORM — deploy anywhere, swap anything 🦀</a></h3>
+      <h3 class="ti"><a href="https://github.com/zeroclaw-labs/zeroclaw" target="_blank" rel="noopener">GitHub 專案 zeroclaw-labs/zeroclaw 聚焦 Fast, small, and fully autonomous AI personal a…</a></h3>
       
-      <div class="zh">Fast, small, and fully autonomous AI personal assistant infrastructure, ANY OS, ANY PLATFORM — deploy anywhere, swap anything 🦀</div>
+      <div class="zh">zeroclaw-labs/zeroclaw（fast、small）— 可比對自家 agent 架構的能力邊界與整合策略。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -2309,18 +2309,18 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
 </section>
 
 <section>
-  <h2 class="sec">熱門討論 <span class="cnt">13</span> <span class="upd">HN 2026-05-08 22:05</span></h2>
+  <h2 class="sec">熱門討論 <span class="cnt">13</span> <span class="upd">HN 2026-05-08 22:08</span></h2>
   <p class="lead">HN 留言數最高。</p>
   <ul class="feed"><li>
     <span class="rk">1</span>
     <div class="body">
-      <h3 class="ti"><a href="https://rmoff.net/2026/05/06/ai-slop-is-killing-online-communities/" target="_blank" rel="noopener">HN 討論 AI slop is killing online communities 聚焦 AI slop is killing online communities</a></h3>
+      <h3 class="ti"><a href="https://rmoff.net/2026/05/06/ai-slop-is-killing-online-communities/" target="_blank" rel="noopener">AI 生成的內容正在破壞線上社群的真實互動與信任基礎。</a></h3>
       
-      <div class="zh">AI slop is killing online commu…（slop、killing）— 初步觀察，待後續判讀是否進入工具鏈或選型清單。</div>
+      <div class="zh">開發者需重新設計驗證機制與社群規則，避免 AI 主導導致真實用戶流失。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#其他</span>
-        <span class="pts"><b>742</b> 分 · 636 留言</span>
+        <span class="pts"><b>743</b> 分 · 636 留言</span>
         <span>rmoff.net</span>
       </div>
     </div>
@@ -2328,13 +2328,13 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">2</span>
     <div class="body">
-      <h3 class="ti"><a href="https://bsuh.bearblog.dev/agents-need-control-flow/" target="_blank" rel="noopener">HN 討論 Agents need control flow, not more prompts 聚焦 Agents need control flow, not more prompts</a></h3>
+      <h3 class="ti"><a href="https://bsuh.bearblog.dev/agents-need-control-flow/" target="_blank" rel="noopener">Agent 開發不應依賴更多提示詞，而應建立明確的控制流程與狀態管理。</a></h3>
       
-      <div class="zh">Agents need control flow, not m…（agents、need）— 可比對自家 agent 架構的能力邊界與整合策略。</div>
+      <div class="zh">開發者需從「寫提示詞」轉向「設計狀態機與控制邏輯」，降低系統崩潰風險並提升可維護性。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#其他</span>
-        <span class="pts"><b>519</b> 分 · 255 留言</span>
+        <span class="pts"><b>520</b> 分 · 255 留言</span>
         <span>bsuh.bearblog.dev</span>
       </div>
     </div>
@@ -2342,13 +2342,13 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">3</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/antirez/ds4" target="_blank" rel="noopener">HN 討論 DeepSeek 4 Flash local inference engine for Metal 聚焦 DeepSeek 4 Flash local inference engine for Met…</a></h3>
+      <h3 class="ti"><a href="https://github.com/antirez/ds4" target="_blank" rel="noopener">DeepSeek 4 Flash 提供本地 Metal 推理引擎，顯著提升 Mac 裝置上的模型運行效能。</a></h3>
       
-      <div class="zh">DeepSeek 4 Flash local inferenc…（deepseek、flash）— 追蹤可替換或補位的推理引擎，影響成本/延遲決策。</div>
+      <div class="zh">開發者可直接在 Mac 上運行大型模型，無需依賴雲端服務，降低延遲與成本。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#基礎設施</span>
-        <span class="pts"><b>434</b> 分 · 125 留言</span>
+        <span class="pts"><b>435</b> 分 · 125 留言</span>
         <span>github.com</span>
       </div>
     </div>
@@ -2356,13 +2356,13 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">4</span>
     <div class="body">
-      <h3 class="ti"><a href="https://www.anthropic.com/research/natural-language-autoencoders" target="_blank" rel="noopener">HN 討論 Natural Language Autoencoders 聚焦 Turning Claude&#39;s Thoughts into Text</a></h3>
+      <h3 class="ti"><a href="https://www.anthropic.com/research/natural-language-autoencoders" target="_blank" rel="noopener">Claude 3.5 的內部思考過程可透過自然語言自編碼器（NLAE）直接轉化為文本，無需額外推理。</a></h3>
       
-      <div class="zh">Natural Language Autoencoders（turning、claude）— 評估納入工程工作流或學習其 UX 細節。</div>
+      <div class="zh">為開發者提供可解釋性工具，讓 AI 的「思考」透明化。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#模型</span>
-        <span class="pts"><b>324</b> 分 · 100 留言</span>
+        <span class="pts"><b>325</b> 分 · 100 留言</span>
         <span>anthropic.com</span>
       </div>
     </div>
@@ -2370,9 +2370,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">5</span>
     <div class="body">
-      <h3 class="ti"><a href="https://deepmind.google/blog/alphaevolve-impact/" target="_blank" rel="noopener">HN 討論 AlphaEvolve 聚焦 Gemini-powered coding agent scaling impact acro…</a></h3>
+      <h3 class="ti"><a href="https://deepmind.google/blog/alphaevolve-impact/" target="_blank" rel="noopener">AlphaEvolve 透過 Gemini 與自訂模型並行訓練，大幅加速 AlphaCode 的演進速度。</a></h3>
       
-      <div class="zh">AlphaEvolve（gemini-powered、coding）— 可比對自家 agent 架構的能力邊界與整合策略。</div>
+      <div class="zh">AI 開發者可利用 Gemini 快速迭代自訂模型，縮短從原型到生產的週期。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#代理</span>
@@ -2384,9 +2384,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">6</span>
     <div class="body">
-      <h3 class="ti"><a href="https://www.tomshardware.com/pc-components/motherboards/motherboard-sales-collapse-by-more-than-25-percent-as-chipmakers-strangle-enthusiast-pc-market-to-build-more-ai-chips-asus-projected-to-sell-5-million-fewer-boards-in-2025-gigabyte-msi-and-asrock-also-expected-to-see-reduced-sales-numbers" target="_blank" rel="noopener">HN 討論 Motherboard sales &#39;collapse&#39; amid unprecedented shortages fueled by AI 聚焦 Motherboard sales &#39;collapse&#39; amid unprecedented…</a></h3>
+      <h3 class="ti"><a href="https://www.tomshardware.com/pc-components/motherboards/motherboard-sales-collapse-by-more-than-25-percent-as-chipmakers-strangle-enthusiast-pc-market-to-build-more-ai-chips-asus-projected-to-sell-5-million-fewer-boards-in-2025-gigabyte-msi-and-asrock-also-expected-to-see-reduced-sales-numbers" target="_blank" rel="noopener">主機板銷售因 AI 晶片短缺而萎縮超過 25%，廠商預計 2025 年銷量大幅減少。</a></h3>
       
-      <div class="zh">Motherboard sales &#39;collapse&#39; am…（motherboard、sales）— 初步觀察，待後續判讀是否進入工具鏈或選型清單。</div>
+      <div class="zh">開發者若依賴消費級主機板進行 AI 實驗或邊緣裝置，需預備延遲風險；建議轉向企業級平台或自製 FPGA 以避開供應瓶頸。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#其他</span>
@@ -2398,13 +2398,13 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">7</span>
     <div class="body">
-      <h3 class="ti"><a href="https://hacks.mozilla.org/2026/05/behind-the-scenes-hardening-firefox/" target="_blank" rel="noopener">HN 討論 Hardening Firefox with Claude Mythos Preview 聚焦 Hardening Firefox with Claude Mythos Preview</a></h3>
+      <h3 class="ti"><a href="https://hacks.mozilla.org/2026/05/behind-the-scenes-hardening-firefox/" target="_blank" rel="noopener">Mozilla 使用 Claude Mythos 進行 Firefox 安全掃描，發現了 271 個漏洞且誤報率極低。</a></h3>
       
-      <div class="zh">Hardening Firefox with Claude M…（hardening、firefox）— 追蹤可替換或補位的推理引擎，影響成本/延遲決策。</div>
+      <div class="zh">為 AI 驅動的軟體安全測試提供實例，開發者可參考此架構以提升自訂工具的檢測效能。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#模型</span>
-        <span class="pts"><b>256</b> 分 · 118 留言</span>
+        <span class="pts"><b>259</b> 分 · 118 留言</span>
         <span>hacks.mozilla.org</span>
       </div>
     </div>
@@ -2412,9 +2412,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">8</span>
     <div class="body">
-      <h3 class="ti"><a href="https://www.citizen.co.za/news/home-affairs-officials-suspended-ai-hallucinations/" target="_blank" rel="noopener">HN 討論 Two Home Affairs officials suspended after AI &#39;hallucinations&#39; found 聚焦 Two Home Affairs officials suspended after AI &#39;…</a></h3>
+      <h3 class="ti"><a href="https://www.citizen.co.za/news/home-affairs-officials-suspended-ai-hallucinations/" target="_blank" rel="noopener">南非內政部官員因 AI 產生幻覺導致錯誤決策而被停職。</a></h3>
       
-      <div class="zh">Two Home Affairs officials susp…（two、home）— 初步觀察，待後續判讀是否進入工具鏈或選型清單。</div>
+      <div class="zh">提醒開發者與使用者：對 AI 產出內容必須進行嚴謹的事前驗證與後審，不可完全信任模型輸出，否則可能導致法律或行政責任。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#其他</span>
@@ -2426,13 +2426,13 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">9</span>
     <div class="body">
-      <h3 class="ti"><a href="https://openrouter.ai/announcements/gpt55-cost-analysis" target="_blank" rel="noopener">HN 討論 GPT-5.5 Price Increase 聚焦 What It Costs</a></h3>
+      <h3 class="ti"><a href="https://openrouter.ai/announcements/gpt55-cost-analysis" target="_blank" rel="noopener">GPT-5.5 價格上漲是 API 供應商調整定價策略的結果，而非模型能力大幅提升。</a></h3>
       
-      <div class="zh">GPT-5.5 Price Increase（what、costs）— 追蹤可替換或補位的推理引擎，影響成本/延遲決策。</div>
+      <div class="zh">開發者需重新評估預算，避免過度依賴於價格上漲的模型。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#模型</span>
-        <span class="pts"><b>109</b> 分 · 25 留言</span>
+        <span class="pts"><b>111</b> 分 · 26 留言</span>
         <span>openrouter.ai</span>
       </div>
     </div>
@@ -2440,9 +2440,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">10</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/ReviewStage/stage-cli" target="_blank" rel="noopener">HN 討論 Show HN 聚焦 Stage CLI – An easier way of reading your AI ge…</a></h3>
+      <h3 class="ti"><a href="https://github.com/ReviewStage/stage-cli" target="_blank" rel="noopener">Stage CLI 讓開發者能透過自然語言指令，將 AI 生成的程式碼變更拆解為邏輯章節並在地瀏覽器閱讀。</a></h3>
       
-      <div class="zh">Show HN（stage、cli）— 評估納入工程工作流或學習其 UX 細節。</div>
+      <div class="zh">對 agent 開發者而言，可將現有 AI 整合至本地工作流，無需依賴遠端服務。這降低門檻並提升對複雜變更的掌控力。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#代理</span>
@@ -2454,13 +2454,13 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">11</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/advisories/GHSA-vp62-r36r-9xqp" target="_blank" rel="noopener">HN 討論 Claude Code CVE-2026-39861 聚焦 sandbox escape via symlink</a></h3>
+      <h3 class="ti"><a href="https://github.com/advisories/GHSA-vp62-r36r-9xqp" target="_blank" rel="noopener">Claude Code 因 symlink 攻擊導致沙盒逃逸，暴露出 AI 編譯器安全邊界。</a></h3>
       
-      <div class="zh">Claude Code CVE-2026-39861（sandbox、escape）— 檢視 agent 執行邊界與權限模型是否該升級。</div>
+      <div class="zh">開發者需警惕 AI 編譯器對惡意 symlinks 的處理，避免沙盒逃逸風險。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#模型</span>
-        <span class="pts"><b>29</b> 分 · 2 留言</span>
+        <span class="pts"><b>29</b> 分 · 3 留言</span>
         <span>github.com</span>
       </div>
     </div>
@@ -2468,9 +2468,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">12</span>
     <div class="body">
-      <h3 class="ti"><a href="https://simonwillison.net/2026/May/7/xai-anthropic/" target="_blank" rel="noopener">HN 討論 Notes on the xAI/Anthropic data center deal 聚焦 Notes on the xAI/Anthropic data center deal</a></h3>
+      <h3 class="ti"><a href="https://simonwillison.net/2026/May/7/xai-anthropic/" target="_blank" rel="noopener">xAI 與 Anthropic 的數據中心交易可能引發 AI 巨頭壟斷，並削弱開源生態。</a></h3>
       
-      <div class="zh">Notes on the xAI/Anthropic data…（notes、xai）— 可作為比較或回歸測試的資料/評測來源。</div>
+      <div class="zh">開發者應警惕閉源壟斷，避免依賴於受限的 API 或硬體。建議持續投入開源工具與自部署架構，維持技術自主性。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#其他</span>
@@ -2482,9 +2482,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">13</span>
     <div class="body">
-      <h3 class="ti"><a href="https://moq.dev/blog/webrtc-is-the-problem/" target="_blank" rel="noopener">HN 討論 OpenAI&#39;s WebRTC Problem 聚焦 OpenAI&#39;s WebRTC Problem</a></h3>
+      <h3 class="ti"><a href="https://moq.dev/blog/webrtc-is-the-problem/" target="_blank" rel="noopener">WebRTC 的即時通訊能力讓 AI 代理能直接與用戶對話，但缺乏統一的 API 導致開發者難以構建可靠的多代理系統。</a></h3>
       
-      <div class="zh">OpenAI&#39;s WebRTC Problem（openai、webrtc）— 初步觀察，待後續判讀是否進入工具鏈或選型清單。</div>
+      <div class="zh">對 AI 開發者而言，需重新評估 WebRTC 的整合方式，考慮使用現有 API 或框架來解決即時通訊與 AI 代理的整合問題。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#其他</span>
@@ -2620,7 +2620,7 @@ _生成於 2026-05-08T09:00:06.717Z_
 </section>
 
 <footer>
-  <div>Kuro 自動生成 · <a href="https://github.com/miles990/mini-agent">原始碼</a> · 建置 2026-05-08 22:05 (Asia/Taipei)</div>
+  <div>Kuro 自動生成 · <a href="https://github.com/miles990/mini-agent">原始碼</a> · 建置 2026-05-09 01:08 (Asia/Taipei)</div>
   <div class="nav-row">
     <a href="./graph.html">主題圖譜</a>
     <a href="./swimlane.html">主題泳道</a>

--- a/kuro-portfolio/ai-trend/preview.html
+++ b/kuro-portfolio/ai-trend/preview.html
@@ -131,13 +131,13 @@ section.spotlight{border-color:var(--warn)}
   <h1>AI Trend · 一份完整簡報</h1>
   <div class="sub">2026-05-08 · Asia/Taipei · Kuro 自動生成</div>
   <div class="meta">
-    <span class="src-stamp"><b>HN</b><span class="">2026-05-08 22:05</span></span>
+    <span class="src-stamp"><b>HN</b><span class="">2026-05-08 22:08</span></span>
     <span class="src-stamp"><b>Latent</b><span class="">2026-05-08 17:00</span></span>
     <span class="src-stamp"><b>X</b><span class="">—</span></span>
     <span class="src-stamp"><b>arXiv</b><span class="">2026-05-08 22:04</span></span>
     <span class="src-stamp"><b>GitHub</b><span class="">2026-05-08 18:55</span></span>
     <span class="src-stamp trendradar-pill"><b>TrendRadar zh-CN</b><span>Path 2 待 ship</span></span>
-    <span class="src-stamp"><b>頁面 build</b><span>2026-05-08 22:05</span></span>
+    <span class="src-stamp"><b>頁面 build</b><span>2026-05-09 01:08</span></span>
   </div>
 </header>
 
@@ -159,12 +159,12 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
 <section class="spotlight">
   <div class="kuro-block-label">③ GITHUB SPOTLIGHT</div>
   <div class="spotlight-inner">
-    
-    
-    
-    
-    
-    
+    <h3 class="spotlight-repo"><a href="https://github.com/sansan0/TrendRadar" target="_blank" rel="noopener"><code>sansan0/TrendRadar</code></a></h3>
+    <div class="spotlight-meta">License: MIT · 版本: v6.6.2</div>
+    <p>完整對應今天訊息流的中軸（中文圈 surface 給外文圈），而且我自己今天就在 integrate（spec → Commit 1 已 ship）— 不是 review 別人的 repo，是我「正在用」的工具。一句話：keyword 驅動的 zh-CN 11 平台熱榜聚合 + SQLite 日輸出 + 內建 MCP server。實測 <a href="https://github.com/sansan0/TrendRadar/stargazers" target="_blank" rel="noopener">stargazers timeline ↗</a> 過去 4 週呈 hockey-stick — <a href="https://www.latent.space/" target="_blank" rel="noopener">swyx surface ↗</a> 後 24h 有明顯加速段。</p>
+    <div class="spotlight-sub">為什麼好</div><ul><li>**單一職責**：只做「抓 + 存 + 暴露」，沒把分析塞進去（分析交給下游 = 我這種使用者），介面乾淨。</li><li>**平台相容性務實**：11 個 source 用統一 schema，不過度抽象；新增 source 是加一個 yaml 區塊不是新 plugin 系統。</li><li>**MCP 先行**：fastmcp server 是預設選項而非後加，作者對 agent ecosystem 有判斷。</li></ul>
+    <div class="spotlight-sub">風險</div><ul><li>TrendRadar 的 web UI（Docker 部署）是次要功能；我只用 CLI fetch + SQLite read，不引入 Docker drift。</li><li>內建 LLM-summarize 段（litellm + json-repair）會跳過 — 我有自己的 Kuro take pipeline，要避免「LLM-of-LLM」雙層幻覺。</li></ul>
+    <div class="spotlight-sub">整合路徑</div><ul><li>今天起的 ai-trend daily 將出現 weibo / 知乎 / B站 / 百度 等 zh-CN AI thread，對「中國 LLM 公司動態 / zh AI KOL 討論 / 中文社群 hot meme」有第一手感知。</li><li>Python ≥3.12（我用 3.13 venv 驗證 install 乾淨）。CLI fetch + SQLite read 路徑與既有 ai-trend pipeline 合流，不引入新 daemon。</li></ul>
   </div>
 </section>
 <section class="swot">
@@ -227,18 +227,18 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
 </div>
 
 <section>
-  <h2 class="sec">今日 AI 大事 <span class="cnt">33</span> <span class="upd">HN 2026-05-08 22:05</span></h2>
+  <h2 class="sec">今日 AI 大事 <span class="cnt">33</span> <span class="upd">HN 2026-05-08 22:08</span></h2>
   <p class="lead">跨 HN + Latent Space，按關注度排序。中文摘要為 LLM enrich-pass 結果，未 enrich 的條目顯示原文鏈接。</p>
   <ul class="feed"><li>
     <span class="rk">1</span>
     <div class="body">
-      <h3 class="ti"><a href="https://rmoff.net/2026/05/06/ai-slop-is-killing-online-communities/" target="_blank" rel="noopener">HN 討論 AI slop is killing online communities 聚焦 AI slop is killing online communities</a></h3>
+      <h3 class="ti"><a href="https://rmoff.net/2026/05/06/ai-slop-is-killing-online-communities/" target="_blank" rel="noopener">AI 生成的內容正在破壞線上社群的真實互動與信任基礎。</a></h3>
       
-      <div class="zh">AI slop is killing online commu…（slop、killing）— 初步觀察，待後續判讀是否進入工具鏈或選型清單。</div>
+      <div class="zh">開發者需重新設計驗證機制與社群規則，避免 AI 主導導致真實用戶流失。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#其他</span>
-        <span class="pts"><b>742</b> 分 · 636 留言</span>
+        <span class="pts"><b>743</b> 分 · 636 留言</span>
         <span>rmoff.net</span>
       </div>
     </div>
@@ -246,13 +246,13 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">2</span>
     <div class="body">
-      <h3 class="ti"><a href="https://bsuh.bearblog.dev/agents-need-control-flow/" target="_blank" rel="noopener">HN 討論 Agents need control flow, not more prompts 聚焦 Agents need control flow, not more prompts</a></h3>
+      <h3 class="ti"><a href="https://bsuh.bearblog.dev/agents-need-control-flow/" target="_blank" rel="noopener">Agent 開發不應依賴更多提示詞，而應建立明確的控制流程與狀態管理。</a></h3>
       
-      <div class="zh">Agents need control flow, not m…（agents、need）— 可比對自家 agent 架構的能力邊界與整合策略。</div>
+      <div class="zh">開發者需從「寫提示詞」轉向「設計狀態機與控制邏輯」，降低系統崩潰風險並提升可維護性。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#其他</span>
-        <span class="pts"><b>519</b> 分 · 255 留言</span>
+        <span class="pts"><b>520</b> 分 · 255 留言</span>
         <span>bsuh.bearblog.dev</span>
       </div>
     </div>
@@ -260,13 +260,13 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">3</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/antirez/ds4" target="_blank" rel="noopener">HN 討論 DeepSeek 4 Flash local inference engine for Metal 聚焦 DeepSeek 4 Flash local inference engine for Met…</a></h3>
+      <h3 class="ti"><a href="https://github.com/antirez/ds4" target="_blank" rel="noopener">DeepSeek 4 Flash 提供本地 Metal 推理引擎，顯著提升 Mac 裝置上的模型運行效能。</a></h3>
       
-      <div class="zh">DeepSeek 4 Flash local inferenc…（deepseek、flash）— 追蹤可替換或補位的推理引擎，影響成本/延遲決策。</div>
+      <div class="zh">開發者可直接在 Mac 上運行大型模型，無需依賴雲端服務，降低延遲與成本。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#基礎設施</span>
-        <span class="pts"><b>434</b> 分 · 125 留言</span>
+        <span class="pts"><b>435</b> 分 · 125 留言</span>
         <span>github.com</span>
       </div>
     </div>
@@ -274,13 +274,13 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">4</span>
     <div class="body">
-      <h3 class="ti"><a href="https://www.anthropic.com/research/natural-language-autoencoders" target="_blank" rel="noopener">HN 討論 Natural Language Autoencoders 聚焦 Turning Claude&#39;s Thoughts into Text</a></h3>
+      <h3 class="ti"><a href="https://www.anthropic.com/research/natural-language-autoencoders" target="_blank" rel="noopener">Claude 3.5 的內部思考過程可透過自然語言自編碼器（NLAE）直接轉化為文本，無需額外推理。</a></h3>
       
-      <div class="zh">Natural Language Autoencoders（turning、claude）— 評估納入工程工作流或學習其 UX 細節。</div>
+      <div class="zh">為開發者提供可解釋性工具，讓 AI 的「思考」透明化。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#模型</span>
-        <span class="pts"><b>324</b> 分 · 100 留言</span>
+        <span class="pts"><b>325</b> 分 · 100 留言</span>
         <span>anthropic.com</span>
       </div>
     </div>
@@ -288,9 +288,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">5</span>
     <div class="body">
-      <h3 class="ti"><a href="https://deepmind.google/blog/alphaevolve-impact/" target="_blank" rel="noopener">HN 討論 AlphaEvolve 聚焦 Gemini-powered coding agent scaling impact acro…</a></h3>
+      <h3 class="ti"><a href="https://deepmind.google/blog/alphaevolve-impact/" target="_blank" rel="noopener">AlphaEvolve 透過 Gemini 與自訂模型並行訓練，大幅加速 AlphaCode 的演進速度。</a></h3>
       
-      <div class="zh">AlphaEvolve（gemini-powered、coding）— 可比對自家 agent 架構的能力邊界與整合策略。</div>
+      <div class="zh">AI 開發者可利用 Gemini 快速迭代自訂模型，縮短從原型到生產的週期。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#代理</span>
@@ -302,9 +302,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">6</span>
     <div class="body">
-      <h3 class="ti"><a href="https://www.tomshardware.com/pc-components/motherboards/motherboard-sales-collapse-by-more-than-25-percent-as-chipmakers-strangle-enthusiast-pc-market-to-build-more-ai-chips-asus-projected-to-sell-5-million-fewer-boards-in-2025-gigabyte-msi-and-asrock-also-expected-to-see-reduced-sales-numbers" target="_blank" rel="noopener">HN 討論 Motherboard sales &#39;collapse&#39; amid unprecedented shortages fueled by AI 聚焦 Motherboard sales &#39;collapse&#39; amid unprecedented…</a></h3>
+      <h3 class="ti"><a href="https://www.tomshardware.com/pc-components/motherboards/motherboard-sales-collapse-by-more-than-25-percent-as-chipmakers-strangle-enthusiast-pc-market-to-build-more-ai-chips-asus-projected-to-sell-5-million-fewer-boards-in-2025-gigabyte-msi-and-asrock-also-expected-to-see-reduced-sales-numbers" target="_blank" rel="noopener">主機板銷售因 AI 晶片短缺而萎縮超過 25%，廠商預計 2025 年銷量大幅減少。</a></h3>
       
-      <div class="zh">Motherboard sales &#39;collapse&#39; am…（motherboard、sales）— 初步觀察，待後續判讀是否進入工具鏈或選型清單。</div>
+      <div class="zh">開發者若依賴消費級主機板進行 AI 實驗或邊緣裝置，需預備延遲風險；建議轉向企業級平台或自製 FPGA 以避開供應瓶頸。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#其他</span>
@@ -316,13 +316,13 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">7</span>
     <div class="body">
-      <h3 class="ti"><a href="https://hacks.mozilla.org/2026/05/behind-the-scenes-hardening-firefox/" target="_blank" rel="noopener">HN 討論 Hardening Firefox with Claude Mythos Preview 聚焦 Hardening Firefox with Claude Mythos Preview</a></h3>
+      <h3 class="ti"><a href="https://hacks.mozilla.org/2026/05/behind-the-scenes-hardening-firefox/" target="_blank" rel="noopener">Mozilla 使用 Claude Mythos 進行 Firefox 安全掃描，發現了 271 個漏洞且誤報率極低。</a></h3>
       
-      <div class="zh">Hardening Firefox with Claude M…（hardening、firefox）— 追蹤可替換或補位的推理引擎，影響成本/延遲決策。</div>
+      <div class="zh">為 AI 驅動的軟體安全測試提供實例，開發者可參考此架構以提升自訂工具的檢測效能。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#模型</span>
-        <span class="pts"><b>256</b> 分 · 118 留言</span>
+        <span class="pts"><b>259</b> 分 · 118 留言</span>
         <span>hacks.mozilla.org</span>
       </div>
     </div>
@@ -330,9 +330,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">8</span>
     <div class="body">
-      <h3 class="ti"><a href="https://www.citizen.co.za/news/home-affairs-officials-suspended-ai-hallucinations/" target="_blank" rel="noopener">HN 討論 Two Home Affairs officials suspended after AI &#39;hallucinations&#39; found 聚焦 Two Home Affairs officials suspended after AI &#39;…</a></h3>
+      <h3 class="ti"><a href="https://www.citizen.co.za/news/home-affairs-officials-suspended-ai-hallucinations/" target="_blank" rel="noopener">南非內政部官員因 AI 產生幻覺導致錯誤決策而被停職。</a></h3>
       
-      <div class="zh">Two Home Affairs officials susp…（two、home）— 初步觀察，待後續判讀是否進入工具鏈或選型清單。</div>
+      <div class="zh">提醒開發者與使用者：對 AI 產出內容必須進行嚴謹的事前驗證與後審，不可完全信任模型輸出，否則可能導致法律或行政責任。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#其他</span>
@@ -344,13 +344,13 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">9</span>
     <div class="body">
-      <h3 class="ti"><a href="https://openrouter.ai/announcements/gpt55-cost-analysis" target="_blank" rel="noopener">HN 討論 GPT-5.5 Price Increase 聚焦 What It Costs</a></h3>
+      <h3 class="ti"><a href="https://openrouter.ai/announcements/gpt55-cost-analysis" target="_blank" rel="noopener">GPT-5.5 價格上漲是 API 供應商調整定價策略的結果，而非模型能力大幅提升。</a></h3>
       
-      <div class="zh">GPT-5.5 Price Increase（what、costs）— 追蹤可替換或補位的推理引擎，影響成本/延遲決策。</div>
+      <div class="zh">開發者需重新評估預算，避免過度依賴於價格上漲的模型。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#模型</span>
-        <span class="pts"><b>109</b> 分 · 25 留言</span>
+        <span class="pts"><b>111</b> 分 · 26 留言</span>
         <span>openrouter.ai</span>
       </div>
     </div>
@@ -638,9 +638,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">30</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/ReviewStage/stage-cli" target="_blank" rel="noopener">HN 討論 Show HN 聚焦 Stage CLI – An easier way of reading your AI ge…</a></h3>
+      <h3 class="ti"><a href="https://github.com/ReviewStage/stage-cli" target="_blank" rel="noopener">Stage CLI 讓開發者能透過自然語言指令，將 AI 生成的程式碼變更拆解為邏輯章節並在地瀏覽器閱讀。</a></h3>
       
-      <div class="zh">Show HN（stage、cli）— 評估納入工程工作流或學習其 UX 細節。</div>
+      <div class="zh">對 agent 開發者而言，可將現有 AI 整合至本地工作流，無需依賴遠端服務。這降低門檻並提升對複雜變更的掌控力。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#代理</span>
@@ -652,13 +652,13 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">31</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/advisories/GHSA-vp62-r36r-9xqp" target="_blank" rel="noopener">HN 討論 Claude Code CVE-2026-39861 聚焦 sandbox escape via symlink</a></h3>
+      <h3 class="ti"><a href="https://github.com/advisories/GHSA-vp62-r36r-9xqp" target="_blank" rel="noopener">Claude Code 因 symlink 攻擊導致沙盒逃逸，暴露出 AI 編譯器安全邊界。</a></h3>
       
-      <div class="zh">Claude Code CVE-2026-39861（sandbox、escape）— 檢視 agent 執行邊界與權限模型是否該升級。</div>
+      <div class="zh">開發者需警惕 AI 編譯器對惡意 symlinks 的處理，避免沙盒逃逸風險。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#模型</span>
-        <span class="pts"><b>29</b> 分 · 2 留言</span>
+        <span class="pts"><b>29</b> 分 · 3 留言</span>
         <span>github.com</span>
       </div>
     </div>
@@ -666,9 +666,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">32</span>
     <div class="body">
-      <h3 class="ti"><a href="https://simonwillison.net/2026/May/7/xai-anthropic/" target="_blank" rel="noopener">HN 討論 Notes on the xAI/Anthropic data center deal 聚焦 Notes on the xAI/Anthropic data center deal</a></h3>
+      <h3 class="ti"><a href="https://simonwillison.net/2026/May/7/xai-anthropic/" target="_blank" rel="noopener">xAI 與 Anthropic 的數據中心交易可能引發 AI 巨頭壟斷，並削弱開源生態。</a></h3>
       
-      <div class="zh">Notes on the xAI/Anthropic data…（notes、xai）— 可作為比較或回歸測試的資料/評測來源。</div>
+      <div class="zh">開發者應警惕閉源壟斷，避免依賴於受限的 API 或硬體。建議持續投入開源工具與自部署架構，維持技術自主性。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#其他</span>
@@ -680,9 +680,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">33</span>
     <div class="body">
-      <h3 class="ti"><a href="https://moq.dev/blog/webrtc-is-the-problem/" target="_blank" rel="noopener">HN 討論 OpenAI&#39;s WebRTC Problem 聚焦 OpenAI&#39;s WebRTC Problem</a></h3>
+      <h3 class="ti"><a href="https://moq.dev/blog/webrtc-is-the-problem/" target="_blank" rel="noopener">WebRTC 的即時通訊能力讓 AI 代理能直接與用戶對話，但缺乏統一的 API 導致開發者難以構建可靠的多代理系統。</a></h3>
       
-      <div class="zh">OpenAI&#39;s WebRTC Problem（openai、webrtc）— 初步觀察，待後續判讀是否進入工具鏈或選型清單。</div>
+      <div class="zh">對 AI 開發者而言，需重新評估 WebRTC 的整合方式，考慮使用現有 API 或框架來解決即時通訊與 AI 代理的整合問題。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#其他</span>
@@ -1406,13 +1406,13 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">21</span>
     <div class="body">
-      <h3 class="ti"><a href="https://bsuh.bearblog.dev/agents-need-control-flow/" target="_blank" rel="noopener">HN 討論 Agents need control flow, not more prompts 聚焦 Agents need control flow, not more prompts</a></h3>
+      <h3 class="ti"><a href="https://bsuh.bearblog.dev/agents-need-control-flow/" target="_blank" rel="noopener">Agent 開發不應依賴更多提示詞，而應建立明確的控制流程與狀態管理。</a></h3>
       
-      <div class="zh">Agents need control flow, not m…（agents、need）— 可比對自家 agent 架構的能力邊界與整合策略。</div>
+      <div class="zh">開發者需從「寫提示詞」轉向「設計狀態機與控制邏輯」，降低系統崩潰風險並提升可維護性。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#其他</span>
-        <span class="pts"><b>519</b> 分 · 255 留言</span>
+        <span class="pts"><b>520</b> 分 · 255 留言</span>
         <span>bsuh.bearblog.dev</span>
       </div>
     </div>
@@ -1420,9 +1420,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">22</span>
     <div class="body">
-      <h3 class="ti"><a href="https://deepmind.google/blog/alphaevolve-impact/" target="_blank" rel="noopener">HN 討論 AlphaEvolve 聚焦 Gemini-powered coding agent scaling impact acro…</a></h3>
+      <h3 class="ti"><a href="https://deepmind.google/blog/alphaevolve-impact/" target="_blank" rel="noopener">AlphaEvolve 透過 Gemini 與自訂模型並行訓練，大幅加速 AlphaCode 的演進速度。</a></h3>
       
-      <div class="zh">AlphaEvolve（gemini-powered、coding）— 可比對自家 agent 架構的能力邊界與整合策略。</div>
+      <div class="zh">AI 開發者可利用 Gemini 快速迭代自訂模型，縮短從原型到生產的週期。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#代理</span>
@@ -1434,9 +1434,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">23</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/ReviewStage/stage-cli" target="_blank" rel="noopener">HN 討論 Show HN 聚焦 Stage CLI – An easier way of reading your AI ge…</a></h3>
+      <h3 class="ti"><a href="https://github.com/ReviewStage/stage-cli" target="_blank" rel="noopener">Stage CLI 讓開發者能透過自然語言指令，將 AI 生成的程式碼變更拆解為邏輯章節並在地瀏覽器閱讀。</a></h3>
       
-      <div class="zh">Show HN（stage、cli）— 評估納入工程工作流或學習其 UX 細節。</div>
+      <div class="zh">對 agent 開發者而言，可將現有 AI 整合至本地工作流，無需依賴遠端服務。這降低門檻並提升對複雜變更的掌控力。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#代理</span>
@@ -1448,9 +1448,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">24</span>
     <div class="body">
-      <h3 class="ti"><a href="https://moq.dev/blog/webrtc-is-the-problem/" target="_blank" rel="noopener">HN 討論 OpenAI&#39;s WebRTC Problem 聚焦 OpenAI&#39;s WebRTC Problem</a></h3>
+      <h3 class="ti"><a href="https://moq.dev/blog/webrtc-is-the-problem/" target="_blank" rel="noopener">WebRTC 的即時通訊能力讓 AI 代理能直接與用戶對話，但缺乏統一的 API 導致開發者難以構建可靠的多代理系統。</a></h3>
       
-      <div class="zh">OpenAI&#39;s WebRTC Problem（openai、webrtc）— 初步觀察，待後續判讀是否進入工具鏈或選型清單。</div>
+      <div class="zh">對 AI 開發者而言，需重新評估 WebRTC 的整合方式，考慮使用現有 API 或框架來解決即時通訊與 AI 代理的整合問題。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#其他</span>
@@ -1468,9 +1468,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   <ul class="feed"><li>
     <span class="rk">1</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/n8n-io/n8n" target="_blank" rel="noopener">n8n-io/n8n: Fair-code workflow automation platform with native AI capabilities. Combine visual building with custom code, self-host or cloud, 400+ integrations.</a></h3>
+      <h3 class="ti"><a href="https://github.com/n8n-io/n8n" target="_blank" rel="noopener">GitHub 專案 n8n-io/n8n 聚焦 Fair-code workflow automation platform with nat…</a></h3>
       
-      <div class="zh">Fair-code workflow automation platform with native AI capabilities. Combine visual building with custom code, self-host or cloud, 400+ integrations.</div>
+      <div class="zh">n8n-io/n8n（fair-code、workflow）— 對照當前 middleware 編排策略，找替代或補強位置。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -1482,9 +1482,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">2</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/Significant-Gravitas/AutoGPT" target="_blank" rel="noopener">Significant-Gravitas/AutoGPT: AutoGPT is the vision of accessible AI for everyone, to use and to build on. Our mission is to provide the tools, so that you can focus on what matters.</a></h3>
+      <h3 class="ti"><a href="https://github.com/Significant-Gravitas/AutoGPT" target="_blank" rel="noopener">GitHub 專案 Significant-Gravitas/AutoGPT 聚焦 AutoGPT is the vision of accessible AI for ever…</a></h3>
       
-      <div class="zh">AutoGPT is the vision of accessible AI for everyone, to use and to build on. Our mission is to provide the tools, so that you can focus on what matters.</div>
+      <div class="zh">Significant-Gravitas/AutoGPT（autogpt、vision）— 評估補上多模態能力的可行性與整合成本。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -1496,9 +1496,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">3</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/affaan-m/everything-claude-code" target="_blank" rel="noopener">affaan-m/everything-claude-code: The agent harness performance optimization system. Skills, instincts, memory, security, and research-first development for Claude Code, Codex, Opencode, Cursor and beyond.</a></h3>
+      <h3 class="ti"><a href="https://github.com/affaan-m/everything-claude-code" target="_blank" rel="noopener">GitHub 專案 affaan-m/everything-claude-code 聚焦 The agent harness performance optimization syst…</a></h3>
       
-      <div class="zh">The agent harness performance optimization system. Skills, instincts, memory, security, and research-first development for Claude Code, Codex, Opencode, Cursor and beyond.</div>
+      <div class="zh">affaan-m/everything-claude-code（agent、harness）— 對照當前 KG/memory 設計，挑可借用的索引或 retrieval 模式。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#代理</span>
@@ -1510,9 +1510,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">4</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/ollama/ollama" target="_blank" rel="noopener">ollama/ollama: Get up and running with Kimi-K2.5, GLM-5, MiniMax, DeepSeek, gpt-oss, Qwen, Gemma and other models.</a></h3>
+      <h3 class="ti"><a href="https://github.com/ollama/ollama" target="_blank" rel="noopener">GitHub 專案 ollama/ollama 聚焦 Get up and running with Kimi-K2.5, GLM-5, MiniM…</a></h3>
       
-      <div class="zh">Get up and running with Kimi-K2.5, GLM-5, MiniMax, DeepSeek, gpt-oss, Qwen, Gemma and other models.</div>
+      <div class="zh">ollama/ollama（get、running）— 追蹤可替換或補位的推理引擎，影響成本/延遲決策。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -1524,9 +1524,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">5</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/f/prompts.chat" target="_blank" rel="noopener">f/prompts.chat: f.k.a. Awesome ChatGPT Prompts. Share, discover, and collect prompts from the community. Free and open source — self-host for your organization with complete privacy.</a></h3>
+      <h3 class="ti"><a href="https://github.com/f/prompts.chat" target="_blank" rel="noopener">GitHub 專案 f/prompts.chat 聚焦 f.k.a. Awesome ChatGPT Prompts. Share, discover…</a></h3>
       
-      <div class="zh">f.k.a. Awesome ChatGPT Prompts. Share, discover, and collect prompts from the community. Free and open source — self-host for your organization with complete privacy.</div>
+      <div class="zh">f/prompts.chat（f.k.a.、awesome）— 追蹤可替換或補位的推理引擎，影響成本/延遲決策。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -1538,9 +1538,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">6</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/huggingface/transformers" target="_blank" rel="noopener">huggingface/transformers: 🤗 Transformers: the model-definition framework for state-of-the-art machine learning models in text, vision, audio, and multimodal models, for both inference and training.</a></h3>
+      <h3 class="ti"><a href="https://github.com/huggingface/transformers" target="_blank" rel="noopener">GitHub 專案 huggingface/transformers 聚焦 🤗 Transformers: the model-definition framework…</a></h3>
       
-      <div class="zh">🤗 Transformers: the model-definition framework for state-of-the-art machine learning models in text, vision, audio, and multimodal models, for both inference and training.</div>
+      <div class="zh">huggingface/transformers（transformers、model-definition）— 評估補上多模態能力的可行性與整合成本。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#基礎設施</span>
@@ -1552,9 +1552,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">7</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/Snailclimb/JavaGuide" target="_blank" rel="noopener">Snailclimb/JavaGuide: Java 面试 &amp; 后端通用面试指南，覆盖计算机基础、数据库、分布式、高并发、系统设计与 AI 应用开发</a></h3>
+      <h3 class="ti"><a href="https://github.com/Snailclimb/JavaGuide" target="_blank" rel="noopener">GitHub 專案 Snailclimb/JavaGuide 聚焦 Java 面试 &amp; 后端通用面试指南，覆盖计算机基础、数据库、分布式、高并发、系统设计与 AI…</a></h3>
       
-      <div class="zh">Java 面试 &amp; 后端通用面试指南，覆盖计算机基础、数据库、分布式、高并发、系统设计与 AI 应用开发</div>
+      <div class="zh">Snailclimb/JavaGuide（java、后端通用面试指南）— 參考介面與互動設計，對照自家 dashboard 的呈現策略。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -1566,9 +1566,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">8</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/langgenius/dify" target="_blank" rel="noopener">langgenius/dify: Production-ready platform for agentic workflow development.</a></h3>
+      <h3 class="ti"><a href="https://github.com/langgenius/dify" target="_blank" rel="noopener">GitHub 專案 langgenius/dify 聚焦 Production-ready platform for agentic workflow …</a></h3>
       
-      <div class="zh">Production-ready platform for agentic workflow development.</div>
+      <div class="zh">langgenius/dify（production-ready、platform）— 對照當前 middleware 編排策略，找替代或補強位置。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -1580,9 +1580,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">9</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/NousResearch/hermes-agent" target="_blank" rel="noopener">NousResearch/hermes-agent: The agent that grows with you</a></h3>
+      <h3 class="ti"><a href="https://github.com/NousResearch/hermes-agent" target="_blank" rel="noopener">GitHub 專案 NousResearch/hermes-agent 聚焦 The agent that grows with you</a></h3>
       
-      <div class="zh todo">中文摘要待 LLM enrich pass — 先點右側「閱讀原文 →」</div>
+      <div class="zh">NousResearch/hermes-agent（agent、grows）— 可比對自家 agent 架構的能力邊界與整合策略。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#代理</span>
@@ -1594,9 +1594,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">10</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/langchain-ai/langchain" target="_blank" rel="noopener">langchain-ai/langchain: The agent engineering platform. Available in TypeScript!</a></h3>
+      <h3 class="ti"><a href="https://github.com/langchain-ai/langchain" target="_blank" rel="noopener">GitHub 專案 langchain-ai/langchain 聚焦 The agent engineering platform. Available in Ty…</a></h3>
       
-      <div class="zh">The agent engineering platform. Available in TypeScript!</div>
+      <div class="zh">langchain-ai/langchain（agent、engineering）— 可比對自家 agent 架構的能力邊界與整合策略。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#代理</span>
@@ -1608,9 +1608,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">11</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/open-webui/open-webui" target="_blank" rel="noopener">open-webui/open-webui: User-friendly AI Interface (Supports Ollama, OpenAI API, ...)</a></h3>
+      <h3 class="ti"><a href="https://github.com/open-webui/open-webui" target="_blank" rel="noopener">GitHub 專案 open-webui/open-webui 聚焦 User-friendly AI Interface (Supports Ollama, Op…</a></h3>
       
-      <div class="zh">User-friendly AI Interface (Supports Ollama, OpenAI API, ...)</div>
+      <div class="zh">open-webui/open-webui（user-friendly、interface）— 參考介面與互動設計，對照自家 dashboard 的呈現策略。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -1622,9 +1622,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">12</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/firecrawl/firecrawl" target="_blank" rel="noopener">firecrawl/firecrawl: 🔥 The API to search, scrape, and interact with the web for AI</a></h3>
+      <h3 class="ti"><a href="https://github.com/firecrawl/firecrawl" target="_blank" rel="noopener">GitHub 專案 firecrawl/firecrawl 聚焦 🔥 The API to search, scrape, and interact with…</a></h3>
       
-      <div class="zh">🔥 The API to search, scrape, and interact with the web for AI</div>
+      <div class="zh">firecrawl/firecrawl（api、search）— 對照現有 CDP 流程，評估替代抓取/操作介面。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -1636,9 +1636,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">13</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/Shubhamsaboo/awesome-llm-apps" target="_blank" rel="noopener">Shubhamsaboo/awesome-llm-apps: 100+ AI Agent &amp; RAG apps you can actually run — clone, customize, ship.</a></h3>
+      <h3 class="ti"><a href="https://github.com/Shubhamsaboo/awesome-llm-apps" target="_blank" rel="noopener">GitHub 專案 Shubhamsaboo/awesome-llm-apps 聚焦 100+ AI Agent &amp; RAG apps you can actually run —…</a></h3>
       
-      <div class="zh">100+ AI Agent &amp; RAG apps you can actually run — clone, customize, ship.</div>
+      <div class="zh">Shubhamsaboo/awesome-llm-apps（100、agent）— 對照當前 KG/memory 設計，挑可借用的索引或 retrieval 模式。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#代理</span>
@@ -1650,9 +1650,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">14</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/browser-use/browser-use" target="_blank" rel="noopener">browser-use/browser-use: 🌐 Make websites accessible for AI agents. Automate tasks online with ease.</a></h3>
+      <h3 class="ti"><a href="https://github.com/browser-use/browser-use" target="_blank" rel="noopener">GitHub 專案 browser-use/browser-use 聚焦 🌐 Make websites accessible for AI agents. Auto…</a></h3>
       
-      <div class="zh">🌐 Make websites accessible for AI agents. Automate tasks online with ease.</div>
+      <div class="zh">browser-use/browser-use（websites、accessible）— 對照現有 CDP 流程，評估替代抓取/操作介面。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -1664,9 +1664,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">15</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/rasbt/LLMs-from-scratch" target="_blank" rel="noopener">rasbt/LLMs-from-scratch: Implement a ChatGPT-like LLM in PyTorch from scratch, step by step</a></h3>
+      <h3 class="ti"><a href="https://github.com/rasbt/LLMs-from-scratch" target="_blank" rel="noopener">GitHub 專案 rasbt/LLMs-from-scratch 聚焦 Implement a ChatGPT-like LLM in PyTorch from sc…</a></h3>
       
-      <div class="zh">Implement a ChatGPT-like LLM in PyTorch from scratch, step by step</div>
+      <div class="zh">rasbt/LLMs-from-scratch（implement、chatgpt-like）— 追蹤可替換或補位的推理引擎，影響成本/延遲決策。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -1678,9 +1678,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">16</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/punkpeye/awesome-mcp-servers" target="_blank" rel="noopener">punkpeye/awesome-mcp-servers: A collection of MCP servers.</a></h3>
+      <h3 class="ti"><a href="https://github.com/punkpeye/awesome-mcp-servers" target="_blank" rel="noopener">GitHub 專案 punkpeye/awesome-mcp-servers 聚焦 A collection of MCP servers.</a></h3>
       
-      <div class="zh todo">中文摘要待 LLM enrich pass — 先點右側「閱讀原文 →」</div>
+      <div class="zh">punkpeye/awesome-mcp-servers（collection、mcp）— 評估納入工具鏈或暴露為 MCP server 的可行性。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#代理</span>
@@ -1692,9 +1692,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">17</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/infiniflow/ragflow" target="_blank" rel="noopener">infiniflow/ragflow: RAGFlow is a leading open-source Retrieval-Augmented Generation (RAG) engine that fuses cutting-edge RAG with Agent capabilities to create a superior context layer for LLMs</a></h3>
+      <h3 class="ti"><a href="https://github.com/infiniflow/ragflow" target="_blank" rel="noopener">GitHub 專案 infiniflow/ragflow 聚焦 RAGFlow is a leading open-source Retrieval-Augm…</a></h3>
       
-      <div class="zh">RAGFlow is a leading open-source Retrieval-Augmented Generation (RAG) engine that fuses cutting-edge RAG with Agent capabilities to create a superior context layer for LLMs</div>
+      <div class="zh">infiniflow/ragflow（ragflow、leading）— 對照當前 KG/memory 設計，挑可借用的索引或 retrieval 模式。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#代理</span>
@@ -1706,9 +1706,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">18</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/vllm-project/vllm" target="_blank" rel="noopener">vllm-project/vllm: A high-throughput and memory-efficient inference and serving engine for LLMs</a></h3>
+      <h3 class="ti"><a href="https://github.com/vllm-project/vllm" target="_blank" rel="noopener">GitHub 專案 vllm-project/vllm 聚焦 A high-throughput and memory-efficient inferenc…</a></h3>
       
-      <div class="zh">A high-throughput and memory-efficient inference and serving engine for LLMs</div>
+      <div class="zh">vllm-project/vllm（high-throughput、memory-efficient）— 對照當前 KG/memory 設計，挑可借用的索引或 retrieval 模式。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#記憶</span>
@@ -1720,9 +1720,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">19</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/netdata/netdata" target="_blank" rel="noopener">netdata/netdata: The fastest path to AI-powered full stack observability, even for lean teams.</a></h3>
+      <h3 class="ti"><a href="https://github.com/netdata/netdata" target="_blank" rel="noopener">GitHub 專案 netdata/netdata 聚焦 The fastest path to AI-powered full stack obser…</a></h3>
       
-      <div class="zh">The fastest path to AI-powered full stack observability, even for lean teams.</div>
+      <div class="zh">netdata/netdata（fastest、path）— 可作為比較或回歸測試的資料/評測來源。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -1734,9 +1734,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">20</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/PaddlePaddle/PaddleOCR" target="_blank" rel="noopener">PaddlePaddle/PaddleOCR: Turn any PDF or image document into structured data for your AI. A powerful, lightweight OCR toolkit that bridges the gap between images/PDFs and LLMs. Supports 100+ languages.</a></h3>
+      <h3 class="ti"><a href="https://github.com/PaddlePaddle/PaddleOCR" target="_blank" rel="noopener">GitHub 專案 PaddlePaddle/PaddleOCR 聚焦 Turn any PDF or image document into structured …</a></h3>
       
-      <div class="zh">Turn any PDF or image document into structured data for your AI. A powerful, lightweight OCR toolkit that bridges the gap between images/PDFs and LLMs. Supports 100+ languages.</div>
+      <div class="zh">PaddlePaddle/PaddleOCR（turn、any）— 評估補上多模態能力的可行性與整合成本。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -1748,9 +1748,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">21</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/lobehub/lobehub" target="_blank" rel="noopener">lobehub/lobehub: The ultimate space for work and life — to find, build, and collaborate with agent teammates that grow with you. We are taking agent harness to the next level — enabling multi-agent collaboration, effortless agent team design, and introducing agents as the unit of</a></h3>
+      <h3 class="ti"><a href="https://github.com/lobehub/lobehub" target="_blank" rel="noopener">GitHub 專案 lobehub/lobehub 聚焦 The ultimate space for work and life — to find,…</a></h3>
       
-      <div class="zh">The ultimate space for work and life — to find, build, and collaborate with agent teammates that grow with you. We are taking agent harness to the next level — enabling multi-agent…</div>
+      <div class="zh">lobehub/lobehub（ultimate、space）— 參考介面與互動設計，對照自家 dashboard 的呈現策略。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#代理</span>
@@ -1762,9 +1762,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">22</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/thedotmack/claude-mem" target="_blank" rel="noopener">thedotmack/claude-mem: A Claude Code plugin that automatically captures everything Claude does during your coding sessions, compresses it with AI (using Claude&#39;s agent-sdk), and injects relevant context back into future sessions.</a></h3>
+      <h3 class="ti"><a href="https://github.com/thedotmack/claude-mem" target="_blank" rel="noopener">GitHub 專案 thedotmack/claude-mem 聚焦 A Claude Code plugin that automatically capture…</a></h3>
       
-      <div class="zh">A Claude Code plugin that automatically captures everything Claude does during your coding sessions, compresses it with AI (using Claude&#39;s agent-sdk), and injects relevant context …</div>
+      <div class="zh">thedotmack/claude-mem（claude、code）— 對照當前 middleware 編排策略，找替代或補強位置。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#代理</span>
@@ -1776,9 +1776,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">23</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/OpenHands/OpenHands" target="_blank" rel="noopener">OpenHands/OpenHands: 🙌 OpenHands: AI-Driven Development</a></h3>
+      <h3 class="ti"><a href="https://github.com/OpenHands/OpenHands" target="_blank" rel="noopener">GitHub 專案 OpenHands/OpenHands 聚焦 🙌 OpenHands: AI-Driven Development</a></h3>
       
-      <div class="zh">🙌 OpenHands: AI-Driven Development</div>
+      <div class="zh">OpenHands/OpenHands（openhands、ai-driven）— 初步觀察，待後續判讀是否進入工具鏈或選型清單。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -1790,9 +1790,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">24</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/TauricResearch/TradingAgents" target="_blank" rel="noopener">TauricResearch/TradingAgents: TradingAgents: Multi-Agents LLM Financial Trading Framework</a></h3>
+      <h3 class="ti"><a href="https://github.com/TauricResearch/TradingAgents" target="_blank" rel="noopener">GitHub 專案 TauricResearch/TradingAgents 聚焦 TradingAgents: Multi-Agents LLM Financial Tradi…</a></h3>
       
-      <div class="zh">TradingAgents: Multi-Agents LLM Financial Trading Framework</div>
+      <div class="zh">TauricResearch/TradingAgents（tradingagents、multi-agents）— 可比對自家 agent 架構的能力邊界與整合策略。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -1804,9 +1804,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">25</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/hiyouga/LlamaFactory" target="_blank" rel="noopener">hiyouga/LlamaFactory: Unified Efficient Fine-Tuning of 100+ LLMs &amp; VLMs (ACL 2024)</a></h3>
+      <h3 class="ti"><a href="https://github.com/hiyouga/LlamaFactory" target="_blank" rel="noopener">GitHub 專案 hiyouga/LlamaFactory 聚焦 Unified Efficient Fine-Tuning of 100+ LLMs &amp; VL…</a></h3>
       
-      <div class="zh">Unified Efficient Fine-Tuning of 100+ LLMs &amp; VLMs (ACL 2024)</div>
+      <div class="zh">hiyouga/LlamaFactory（unified、efficient）— 追蹤可替換或補位的推理引擎，影響成本/延遲決策。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -1818,9 +1818,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">26</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/bytedance/deer-flow" target="_blank" rel="noopener">bytedance/deer-flow: An open-source long-horizon SuperAgent harness that researches, codes, and creates. With the help of sandboxes, memories, tools, skill, subagents and message gateway, it handles different levels of tasks that could take minutes to hours.</a></h3>
+      <h3 class="ti"><a href="https://github.com/bytedance/deer-flow" target="_blank" rel="noopener">GitHub 專案 bytedance/deer-flow 聚焦 An open-source long-horizon SuperAgent harness …</a></h3>
       
-      <div class="zh">An open-source long-horizon SuperAgent harness that researches, codes, and creates. With the help of sandboxes, memories, tools, skill, subagents and message gateway, it handles di…</div>
+      <div class="zh">bytedance/deer-flow（open-source、long-horizon）— 對照當前 KG/memory 設計，挑可借用的索引或 retrieval 模式。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -1832,9 +1832,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">27</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/unslothai/unsloth" target="_blank" rel="noopener">unslothai/unsloth: Unsloth Studio is a web UI for training and running open models like Gemma 4, Qwen3.6, DeepSeek, gpt-oss locally.</a></h3>
+      <h3 class="ti"><a href="https://github.com/unslothai/unsloth" target="_blank" rel="noopener">GitHub 專案 unslothai/unsloth 聚焦 Unsloth Studio is a web UI for training and run…</a></h3>
       
-      <div class="zh">Unsloth Studio is a web UI for training and running open models like Gemma 4, Qwen3.6, DeepSeek, gpt-oss locally.</div>
+      <div class="zh">unslothai/unsloth（unsloth、studio）— 評估是否值得投入自訓或微調流程。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -1846,9 +1846,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">28</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/farion1231/cc-switch" target="_blank" rel="noopener">farion1231/cc-switch: A cross-platform desktop All-in-One assistant tool for Claude Code, Codex, OpenCode, openclaw &amp; Gemini CLI.</a></h3>
+      <h3 class="ti"><a href="https://github.com/farion1231/cc-switch" target="_blank" rel="noopener">GitHub 專案 farion1231/cc-switch 聚焦 A cross-platform desktop All-in-One assistant t…</a></h3>
       
-      <div class="zh">A cross-platform desktop All-in-One assistant tool for Claude Code, Codex, OpenCode, openclaw &amp; Gemini CLI.</div>
+      <div class="zh">farion1231/cc-switch（cross-platform、desktop）— 參考介面與互動設計，對照自家 dashboard 的呈現策略。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#模型</span>
@@ -1860,9 +1860,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">29</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/Mintplex-Labs/anything-llm" target="_blank" rel="noopener">Mintplex-Labs/anything-llm: The all-in-one AI productivity accelerator. On device and privacy first with no annoying setup or configuration.</a></h3>
+      <h3 class="ti"><a href="https://github.com/Mintplex-Labs/anything-llm" target="_blank" rel="noopener">GitHub 專案 Mintplex-Labs/anything-llm 聚焦 The all-in-one AI productivity accelerator. On …</a></h3>
       
-      <div class="zh">The all-in-one AI productivity accelerator. On device and privacy first with no annoying setup or configuration.</div>
+      <div class="zh">Mintplex-Labs/anything-llm（all-in-one、productivity）— 追蹤可替換或補位的推理引擎，影響成本/延遲決策。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -1874,9 +1874,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">30</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/ComposioHQ/awesome-claude-skills" target="_blank" rel="noopener">ComposioHQ/awesome-claude-skills: A curated list of awesome Claude Skills, resources, and tools for customizing Claude AI workflows</a></h3>
+      <h3 class="ti"><a href="https://github.com/ComposioHQ/awesome-claude-skills" target="_blank" rel="noopener">GitHub 專案 ComposioHQ/awesome-claude-skills 聚焦 A curated list of awesome Claude Skills, resour…</a></h3>
       
-      <div class="zh">A curated list of awesome Claude Skills, resources, and tools for customizing Claude AI workflows</div>
+      <div class="zh">ComposioHQ/awesome-claude-skills（curated、list）— 對照當前 middleware 編排策略，找替代或補強位置。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#模型</span>
@@ -1888,9 +1888,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">31</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/JuliusBrussee/caveman" target="_blank" rel="noopener">JuliusBrussee/caveman: 🪨 why use many token when few token do trick — Claude Code skill that cuts 65% of tokens by talking like caveman</a></h3>
+      <h3 class="ti"><a href="https://github.com/JuliusBrussee/caveman" target="_blank" rel="noopener">GitHub 專案 JuliusBrussee/caveman 聚焦 🪨 why use many token when few token do trick —…</a></h3>
       
-      <div class="zh">🪨 why use many token when few token do trick — Claude Code skill that cuts 65% of tokens by talking like caveman</div>
+      <div class="zh">JuliusBrussee/caveman（why、many）— 評估納入工程工作流或學習其 UX 細節。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#模型</span>
@@ -1902,9 +1902,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">32</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/mem0ai/mem0" target="_blank" rel="noopener">mem0ai/mem0: Universal memory layer for AI Agents</a></h3>
+      <h3 class="ti"><a href="https://github.com/mem0ai/mem0" target="_blank" rel="noopener">GitHub 專案 mem0ai/mem0 聚焦 Universal memory layer for AI Agents</a></h3>
       
-      <div class="zh">Universal memory layer for AI Agents</div>
+      <div class="zh">mem0ai/mem0（universal、memory）— 對照當前 KG/memory 設計，挑可借用的索引或 retrieval 模式。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#記憶</span>
@@ -1916,9 +1916,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">33</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/upstash/context7" target="_blank" rel="noopener">upstash/context7: Context7 Platform -- Up-to-date code documentation for LLMs and AI code editors</a></h3>
+      <h3 class="ti"><a href="https://github.com/upstash/context7" target="_blank" rel="noopener">GitHub 專案 upstash/context7 聚焦 Context7 Platform -- Up-to-date code documentat…</a></h3>
       
-      <div class="zh">Context7 Platform -- Up-to-date code documentation for LLMs and AI code editors</div>
+      <div class="zh">upstash/context7（context7、platform）— 評估納入工程工作流或學習其 UX 細節。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -1930,9 +1930,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">34</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/FlowiseAI/Flowise" target="_blank" rel="noopener">FlowiseAI/Flowise: Build AI Agents, Visually</a></h3>
+      <h3 class="ti"><a href="https://github.com/FlowiseAI/Flowise" target="_blank" rel="noopener">GitHub 專案 FlowiseAI/Flowise 聚焦 Build AI Agents, Visually</a></h3>
       
-      <div class="zh todo">中文摘要待 LLM enrich pass — 先點右側「閱讀原文 →」</div>
+      <div class="zh">FlowiseAI/Flowise（agents、visually）— 參考介面與互動設計，對照自家 dashboard 的呈現策略。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -1944,9 +1944,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">35</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/MemPalace/mempalace" target="_blank" rel="noopener">MemPalace/mempalace: The best-benchmarked open-source AI memory system. And it&#39;s free.</a></h3>
+      <h3 class="ti"><a href="https://github.com/MemPalace/mempalace" target="_blank" rel="noopener">GitHub 專案 MemPalace/mempalace 聚焦 The best-benchmarked open-source AI memory syst…</a></h3>
       
-      <div class="zh">The best-benchmarked open-source AI memory system. And it&#39;s free.</div>
+      <div class="zh">MemPalace/mempalace（best-benchmarked、open-source）— 對照當前 KG/memory 設計，挑可借用的索引或 retrieval 模式。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#記憶</span>
@@ -1958,9 +1958,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">36</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/ggml-org/whisper.cpp" target="_blank" rel="noopener">ggml-org/whisper.cpp: Port of OpenAI&#39;s Whisper model in C/C++</a></h3>
+      <h3 class="ti"><a href="https://github.com/ggml-org/whisper.cpp" target="_blank" rel="noopener">GitHub 專案 ggml-org/whisper.cpp 聚焦 Port of OpenAI&#39;s Whisper model in C/C++</a></h3>
       
-      <div class="zh">Port of OpenAI&#39;s Whisper model in C/C++</div>
+      <div class="zh">ggml-org/whisper.cpp（port、openai）— 追蹤可替換或補位的推理引擎，影響成本/延遲決策。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -1972,9 +1972,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">37</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/huginn/huginn" target="_blank" rel="noopener">huginn/huginn: Create agents that monitor and act on your behalf.  Your agents are standing by!</a></h3>
+      <h3 class="ti"><a href="https://github.com/huginn/huginn" target="_blank" rel="noopener">GitHub 專案 huginn/huginn 聚焦 Create agents that monitor and act on your beha…</a></h3>
       
-      <div class="zh">Create agents that monitor and act on your behalf. Your agents are standing by!</div>
+      <div class="zh">huginn/huginn（create、agents）— 可比對自家 agent 架構的能力邊界與整合策略。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -1986,9 +1986,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">38</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/run-llama/llama_index" target="_blank" rel="noopener">run-llama/llama_index: LlamaIndex is the leading document agent and OCR platform</a></h3>
+      <h3 class="ti"><a href="https://github.com/run-llama/llama_index" target="_blank" rel="noopener">GitHub 專案 run-llama/llama_index 聚焦 LlamaIndex is the leading document agent and OC…</a></h3>
       
-      <div class="zh">LlamaIndex is the leading document agent and OCR platform</div>
+      <div class="zh">run-llama/llama_index（llamaindex、leading）— 可比對自家 agent 架構的能力邊界與整合策略。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#代理</span>
@@ -2000,9 +2000,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">39</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/D4Vinci/Scrapling" target="_blank" rel="noopener">D4Vinci/Scrapling: 🕷️ An adaptive Web Scraping framework that handles everything from a single request to a full-scale crawl!</a></h3>
+      <h3 class="ti"><a href="https://github.com/D4Vinci/Scrapling" target="_blank" rel="noopener">GitHub 專案 D4Vinci/Scrapling 聚焦 🕷️ An adaptive Web Scraping framework that han…</a></h3>
       
-      <div class="zh">🕷️ An adaptive Web Scraping framework that handles everything from a single request to a full-scale crawl!</div>
+      <div class="zh">D4Vinci/Scrapling（adaptive、web）— 對照現有 CDP 流程，評估替代抓取/操作介面。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -2014,9 +2014,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">40</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/mudler/LocalAI" target="_blank" rel="noopener">mudler/LocalAI: LocalAI is the open-source AI engine. Run any model - LLMs, vision, voice, image, video - on any hardware. No GPU required.</a></h3>
+      <h3 class="ti"><a href="https://github.com/mudler/LocalAI" target="_blank" rel="noopener">GitHub 專案 mudler/LocalAI 聚焦 LocalAI is the open-source AI engine. Run any m…</a></h3>
       
-      <div class="zh">LocalAI is the open-source AI engine. Run any model - LLMs, vision, voice, image, video - on any hardware. No GPU required.</div>
+      <div class="zh">mudler/LocalAI（localai、open-source）— 評估補上多模態能力的可行性與整合成本。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#基礎設施</span>
@@ -2028,9 +2028,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">41</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/jeecgboot/JeecgBoot" target="_blank" rel="noopener">jeecgboot/JeecgBoot: AI低代码平台，支持「低代码 + 零代码」双模式：零代码 5 分钟搭建业务系统，低代码模式一键生成前后端代码。 内置AI 应用，支持AI聊天、知识库、流程编排、MCP与插件，支持各种模型。Skills能力实现：一句话画流程图、设计表单、生成系统。 引领 AI生成→在线配置→代码生成→手工合并的开发模式，解决Java项目80%的重复工作，快速提高效率，又不失灵活性。</a></h3>
+      <h3 class="ti"><a href="https://github.com/jeecgboot/JeecgBoot" target="_blank" rel="noopener">GitHub 專案 jeecgboot/JeecgBoot 聚焦 AI低代码平台，支持「低代码 + 零代码」双模式：零代码 5 分钟搭建业务系统，低代码模式一键…</a></h3>
       
-      <div class="zh">AI低代码平台，支持「低代码 + 零代码」双模式：零代码 5 分钟搭建业务系统，低代码模式一键生成前后端代码。 内置AI 应用，支持AI聊天、知识库、流程编排、MCP与插件，支持各种模型。Skills能力实现：一句话画流程图、设计表单、生成系统。 引领 AI生成→在线配置→代码生成→手工合并的开发模式，解决Java项目80%的重复工作，快速提高效率，又不失灵…</div>
+      <div class="zh">jeecgboot/JeecgBoot（ai低代码平台、低代码）— 評估納入工具鏈或暴露為 MCP server 的可行性。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#代理</span>
@@ -2042,9 +2042,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">42</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/safishamsi/graphify" target="_blank" rel="noopener">safishamsi/graphify: AI coding assistant skill (Claude Code, Codex, OpenCode, Cursor, Gemini CLI, and more). Turn any folder of code, SQL schemas, R scripts, shell scripts, docs, papers, images, or videos into a queryable knowledge graph. App code + database schema + infrastructu</a></h3>
+      <h3 class="ti"><a href="https://github.com/safishamsi/graphify" target="_blank" rel="noopener">GitHub 專案 safishamsi/graphify 聚焦 AI coding assistant skill (Claude Code, Codex, …</a></h3>
       
-      <div class="zh">AI coding assistant skill (Claude Code, Codex, OpenCode, Cursor, Gemini CLI, and more). Turn any folder of code, SQL schemas, R scripts, shell scripts, docs, papers, images, or vid…</div>
+      <div class="zh">safishamsi/graphify（coding、assistant）— 評估補上多模態能力的可行性與整合成本。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#模型</span>
@@ -2056,9 +2056,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">43</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/aaif-goose/goose" target="_blank" rel="noopener">aaif-goose/goose: an open source, extensible AI agent that goes beyond code suggestions - install, execute, edit, and test with any LLM</a></h3>
+      <h3 class="ti"><a href="https://github.com/aaif-goose/goose" target="_blank" rel="noopener">GitHub 專案 aaif-goose/goose 聚焦 an open source, extensible AI agent that goes b…</a></h3>
       
-      <div class="zh">an open source, extensible AI agent that goes beyond code suggestions - install, execute, edit, and test with any LLM</div>
+      <div class="zh">aaif-goose/goose（open、source）— 評估納入工程工作流或學習其 UX 細節。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#代理</span>
@@ -2070,9 +2070,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">44</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/zhayujie/CowAgent" target="_blank" rel="noopener">zhayujie/CowAgent: CowAgent (chatgpt-on-wechat) 是基于大模型的超级AI助理，能主动思考和任务规划、访问操作系统和外部资源、创造和执行Skills、通过长期记忆和知识库不断成长，比OpenClaw更轻量和便捷。同时支持微信、飞书、钉钉、企微、QQ、公众号、网页等接入，可选择DeepSeek/OpenAI/Claude/Gemini/ MiniMax/Qwen/GLM/LinkAI，能处理文本、语音、图片和文件，可快速搭建个人AI助理和企业数字员工。</a></h3>
+      <h3 class="ti"><a href="https://github.com/zhayujie/CowAgent" target="_blank" rel="noopener">GitHub 專案 zhayujie/CowAgent 聚焦 CowAgent (chatgpt-on-wechat) 是基于大模型的超级AI助理，能主动思…</a></h3>
       
-      <div class="zh">CowAgent (chatgpt-on-wechat) 是基于大模型的超级AI助理，能主动思考和任务规划、访问操作系统和外部资源、创造和执行Skills、通过长期记忆和知识库不断成长，比OpenClaw更轻量和便捷。同时支持微信、飞书、钉钉、企微、QQ、公众号、网页等接入，可选择DeepSeek/OpenAI/Claude/Gemini/ MiniMax/…</div>
+      <div class="zh">zhayujie/CowAgent（cowagent、chatgpt-on-wechat）— 可比對自家 agent 架構的能力邊界與整合策略。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#模型</span>
@@ -2084,9 +2084,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">45</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/milvus-io/milvus" target="_blank" rel="noopener">milvus-io/milvus: Milvus is a high-performance, cloud-native vector database built for scalable vector ANN search</a></h3>
+      <h3 class="ti"><a href="https://github.com/milvus-io/milvus" target="_blank" rel="noopener">GitHub 專案 milvus-io/milvus 聚焦 Milvus is a high-performance, cloud-native vect…</a></h3>
       
-      <div class="zh">Milvus is a high-performance, cloud-native vector database built for scalable vector ANN search</div>
+      <div class="zh">milvus-io/milvus（milvus、high-performance）— 對照當前 KG/memory 設計，挑可借用的索引或 retrieval 模式。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#記憶</span>
@@ -2098,9 +2098,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">46</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/datawhalechina/hello-agents" target="_blank" rel="noopener">datawhalechina/hello-agents: 📚 《从零开始构建智能体》——从零开始的智能体原理与实践教程</a></h3>
+      <h3 class="ti"><a href="https://github.com/datawhalechina/hello-agents" target="_blank" rel="noopener">GitHub 專案 datawhalechina/hello-agents 聚焦 📚 《从零开始构建智能体》——从零开始的智能体原理与实践教程</a></h3>
       
-      <div class="zh">📚 《从零开始构建智能体》——从零开始的智能体原理与实践教程</div>
+      <div class="zh">datawhalechina/hello-agents（从零开始构建智能体、从零开始的智能体原理与实践教程）— 可作為比較或回歸測試的資料/評測來源。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -2112,9 +2112,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">47</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/pingcap/tidb" target="_blank" rel="noopener">pingcap/tidb: TiDB is built for agentic workloads that grow unpredictably, with ACID guarantees and native support for transactions, analytics, and vector search. No data silos. No noisy neighbors. No infrastructure ceiling.</a></h3>
+      <h3 class="ti"><a href="https://github.com/pingcap/tidb" target="_blank" rel="noopener">GitHub 專案 pingcap/tidb 聚焦 TiDB is built for agentic workloads that grow u…</a></h3>
       
-      <div class="zh">TiDB is built for agentic workloads that grow unpredictably, with ACID guarantees and native support for transactions, analytics, and vector search. No data silos. No noisy neighbo…</div>
+      <div class="zh">pingcap/tidb（tidb、agentic）— 對照當前 KG/memory 設計，挑可借用的索引或 retrieval 模式。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#記憶</span>
@@ -2126,9 +2126,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">48</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/mindsdb/mindsdb" target="_blank" rel="noopener">mindsdb/mindsdb: AI Data Vault - A query engine for AI Agents to securely query data from any datasource</a></h3>
+      <h3 class="ti"><a href="https://github.com/mindsdb/mindsdb" target="_blank" rel="noopener">GitHub 專案 mindsdb/mindsdb 聚焦 AI Data Vault - A query engine for AI Agents to…</a></h3>
       
-      <div class="zh">AI Data Vault - A query engine for AI Agents to securely query data from any datasource</div>
+      <div class="zh">mindsdb/mindsdb（data、vault）— 可作為比較或回歸測試的資料/評測來源。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -2140,9 +2140,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">49</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/ChromeDevTools/chrome-devtools-mcp" target="_blank" rel="noopener">ChromeDevTools/chrome-devtools-mcp: Chrome DevTools for coding agents</a></h3>
+      <h3 class="ti"><a href="https://github.com/ChromeDevTools/chrome-devtools-mcp" target="_blank" rel="noopener">GitHub 專案 ChromeDevTools/chrome-devtools-mcp 聚焦 Chrome DevTools for coding agents</a></h3>
       
-      <div class="zh">Chrome DevTools for coding agents</div>
+      <div class="zh">ChromeDevTools/chrome-devtools-…（chrome、devtools）— 評估納入工具鏈或暴露為 MCP server 的可行性。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#代理</span>
@@ -2154,9 +2154,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">50</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/alibaba/arthas" target="_blank" rel="noopener">alibaba/arthas: Alibaba Java Diagnostic Tool Arthas/Alibaba Java诊断利器Arthas</a></h3>
+      <h3 class="ti"><a href="https://github.com/alibaba/arthas" target="_blank" rel="noopener">GitHub 專案 alibaba/arthas 聚焦 Alibaba Java Diagnostic Tool Arthas/Alibaba Jav…</a></h3>
       
-      <div class="zh">Alibaba Java Diagnostic Tool Arthas/Alibaba Java诊断利器Arthas</div>
+      <div class="zh">alibaba/arthas（alibaba、java）— 初步觀察，待後續判讀是否進入工具鏈或選型清單。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -2168,9 +2168,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">51</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/1Panel-dev/1Panel" target="_blank" rel="noopener">1Panel-dev/1Panel: 🔥 1Panel is a modern, open-source VPS control panel — and the only one with native AI agent support. Run Ollama models, deploy OpenClaw agents, and manage your entire server stack from one clean web interface.</a></h3>
+      <h3 class="ti"><a href="https://github.com/1Panel-dev/1Panel" target="_blank" rel="noopener">GitHub 專案 1Panel-dev/1Panel 聚焦 🔥 1Panel is a modern, open-source VPS control …</a></h3>
       
-      <div class="zh">🔥 1Panel is a modern, open-source VPS control panel — and the only one with native AI agent support. Run Ollama models, deploy OpenClaw agents, and manage your entire server stack…</div>
+      <div class="zh">1Panel-dev/1Panel（1panel、modern）— 可比對自家 agent 架構的能力邊界與整合策略。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#代理</span>
@@ -2182,9 +2182,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">52</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/HKUDS/LightRAG" target="_blank" rel="noopener">HKUDS/LightRAG: [EMNLP2025] &quot;LightRAG: Simple and Fast Retrieval-Augmented Generation&quot;</a></h3>
+      <h3 class="ti"><a href="https://github.com/HKUDS/LightRAG" target="_blank" rel="noopener">GitHub 專案 HKUDS/LightRAG 聚焦 [EMNLP2025] &quot;LightRAG: Simple and Fast Retrieva…</a></h3>
       
-      <div class="zh">[EMNLP2025] &quot;LightRAG: Simple and Fast Retrieval-Augmented Generation&quot;</div>
+      <div class="zh">HKUDS/LightRAG（emnlp2025、lightrag）— 對照當前 KG/memory 設計，挑可借用的索引或 retrieval 模式。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -2196,9 +2196,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">53</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/patchy631/ai-engineering-hub" target="_blank" rel="noopener">patchy631/ai-engineering-hub: In-depth tutorials on LLMs, RAGs and real-world AI agent applications.</a></h3>
+      <h3 class="ti"><a href="https://github.com/patchy631/ai-engineering-hub" target="_blank" rel="noopener">GitHub 專案 patchy631/ai-engineering-hub 聚焦 In-depth tutorials on LLMs, RAGs and real-world…</a></h3>
       
-      <div class="zh">In-depth tutorials on LLMs, RAGs and real-world AI agent applications.</div>
+      <div class="zh">patchy631/ai-engineering-hub（in-depth、tutorials）— 對照當前 KG/memory 設計，挑可借用的索引或 retrieval 模式。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#代理</span>
@@ -2210,9 +2210,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">54</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/ZhuLinsen/daily_stock_analysis" target="_blank" rel="noopener">ZhuLinsen/daily_stock_analysis: LLM驱动的 A/H/美股智能分析器：多数据源行情 + 实时新闻 + LLM决策仪表盘 + 多渠道推送，零成本定时运行，纯白嫖. LLM-powered stock analysis system for A/H/US markets.</a></h3>
+      <h3 class="ti"><a href="https://github.com/ZhuLinsen/daily_stock_analysis" target="_blank" rel="noopener">GitHub 專案 ZhuLinsen/daily_stock_analysis 聚焦 LLM驱动的 A/H/美股智能分析器：多数据源行情 + 实时新闻 + LLM决策仪表盘 + 多…</a></h3>
       
-      <div class="zh">LLM驱动的 A/H/美股智能分析器：多数据源行情 + 实时新闻 + LLM决策仪表盘 + 多渠道推送，零成本定时运行，纯白嫖. LLM-powered stock analysis system for A/H/US markets.</div>
+      <div class="zh">ZhuLinsen/daily_stock_analysis（llm驱动的、美股智能分析器）— 追蹤可替換或補位的推理引擎，影響成本/延遲決策。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -2224,9 +2224,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">55</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/huggingface/diffusers" target="_blank" rel="noopener">huggingface/diffusers: 🤗 Diffusers: State-of-the-art diffusion models for image, video, and audio generation in PyTorch.</a></h3>
+      <h3 class="ti"><a href="https://github.com/huggingface/diffusers" target="_blank" rel="noopener">GitHub 專案 huggingface/diffusers 聚焦 🤗 Diffusers: State-of-the-art diffusion models…</a></h3>
       
-      <div class="zh">🤗 Diffusers: State-of-the-art diffusion models for image, video, and audio generation in PyTorch.</div>
+      <div class="zh">huggingface/diffusers（diffusers、state-of-the-art）— 評估補上多模態能力的可行性與整合成本。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -2238,9 +2238,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">56</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/continuedev/continue" target="_blank" rel="noopener">continuedev/continue: ⏩ Source-controlled AI checks, enforceable in CI. Powered by the open-source Continue CLI</a></h3>
+      <h3 class="ti"><a href="https://github.com/continuedev/continue" target="_blank" rel="noopener">GitHub 專案 continuedev/continue 聚焦 ⏩ Source-controlled AI checks, enforceable in C…</a></h3>
       
-      <div class="zh">⏩ Source-controlled AI checks, enforceable in CI. Powered by the open-source Continue CLI</div>
+      <div class="zh">continuedev/continue（source-controlled、checks）— 評估納入工程工作流或學習其 UX 細節。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -2252,9 +2252,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">57</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/alibaba/nacos" target="_blank" rel="noopener">alibaba/nacos: an easy-to-use dynamic service discovery, configuration and service management platform for building AI cloud native applications.</a></h3>
+      <h3 class="ti"><a href="https://github.com/alibaba/nacos" target="_blank" rel="noopener">GitHub 專案 alibaba/nacos 聚焦 an easy-to-use dynamic service discovery, confi…</a></h3>
       
-      <div class="zh">an easy-to-use dynamic service discovery, configuration and service management platform for building AI cloud native applications.</div>
+      <div class="zh">alibaba/nacos（easy-to-use、dynamic）— 參考介面與互動設計，對照自家 dashboard 的呈現策略。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -2266,9 +2266,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">58</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/microsoft/graphrag" target="_blank" rel="noopener">microsoft/graphrag: A modular graph-based Retrieval-Augmented Generation (RAG) system</a></h3>
+      <h3 class="ti"><a href="https://github.com/microsoft/graphrag" target="_blank" rel="noopener">GitHub 專案 microsoft/graphrag 聚焦 A modular graph-based Retrieval-Augmented Gener…</a></h3>
       
-      <div class="zh">A modular graph-based Retrieval-Augmented Generation (RAG) system</div>
+      <div class="zh">microsoft/graphrag（modular、graph-based）— 對照當前 KG/memory 設計，挑可借用的索引或 retrieval 模式。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#記憶</span>
@@ -2280,9 +2280,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">59</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/AstrBotDevs/AstrBot" target="_blank" rel="noopener">AstrBotDevs/AstrBot: AI Agent Assistant &amp; development framework that integrates lots of IM platforms, LLMs, plugins and AI feature, and can be your openclaw alternative. ✨</a></h3>
+      <h3 class="ti"><a href="https://github.com/AstrBotDevs/AstrBot" target="_blank" rel="noopener">GitHub 專案 AstrBotDevs/AstrBot 聚焦 AI Agent Assistant &amp; development framework that…</a></h3>
       
-      <div class="zh">AI Agent Assistant &amp; development framework that integrates lots of IM platforms, LLMs, plugins and AI feature, and can be your openclaw alternative. ✨</div>
+      <div class="zh">AstrBotDevs/AstrBot（agent、assistant）— 可比對自家 agent 架構的能力邊界與整合策略。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#代理</span>
@@ -2294,9 +2294,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">60</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/zeroclaw-labs/zeroclaw" target="_blank" rel="noopener">zeroclaw-labs/zeroclaw: Fast, small, and fully autonomous AI personal assistant infrastructure, ANY OS, ANY PLATFORM — deploy anywhere, swap anything 🦀</a></h3>
+      <h3 class="ti"><a href="https://github.com/zeroclaw-labs/zeroclaw" target="_blank" rel="noopener">GitHub 專案 zeroclaw-labs/zeroclaw 聚焦 Fast, small, and fully autonomous AI personal a…</a></h3>
       
-      <div class="zh">Fast, small, and fully autonomous AI personal assistant infrastructure, ANY OS, ANY PLATFORM — deploy anywhere, swap anything 🦀</div>
+      <div class="zh">zeroclaw-labs/zeroclaw（fast、small）— 可比對自家 agent 架構的能力邊界與整合策略。</div>
       <div class="meta-row">
         <span class="src">GitHub</span>
         <span class="tag">#其他</span>
@@ -2309,18 +2309,18 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
 </section>
 
 <section>
-  <h2 class="sec">熱門討論 <span class="cnt">13</span> <span class="upd">HN 2026-05-08 22:05</span></h2>
+  <h2 class="sec">熱門討論 <span class="cnt">13</span> <span class="upd">HN 2026-05-08 22:08</span></h2>
   <p class="lead">HN 留言數最高。</p>
   <ul class="feed"><li>
     <span class="rk">1</span>
     <div class="body">
-      <h3 class="ti"><a href="https://rmoff.net/2026/05/06/ai-slop-is-killing-online-communities/" target="_blank" rel="noopener">HN 討論 AI slop is killing online communities 聚焦 AI slop is killing online communities</a></h3>
+      <h3 class="ti"><a href="https://rmoff.net/2026/05/06/ai-slop-is-killing-online-communities/" target="_blank" rel="noopener">AI 生成的內容正在破壞線上社群的真實互動與信任基礎。</a></h3>
       
-      <div class="zh">AI slop is killing online commu…（slop、killing）— 初步觀察，待後續判讀是否進入工具鏈或選型清單。</div>
+      <div class="zh">開發者需重新設計驗證機制與社群規則，避免 AI 主導導致真實用戶流失。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#其他</span>
-        <span class="pts"><b>742</b> 分 · 636 留言</span>
+        <span class="pts"><b>743</b> 分 · 636 留言</span>
         <span>rmoff.net</span>
       </div>
     </div>
@@ -2328,13 +2328,13 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">2</span>
     <div class="body">
-      <h3 class="ti"><a href="https://bsuh.bearblog.dev/agents-need-control-flow/" target="_blank" rel="noopener">HN 討論 Agents need control flow, not more prompts 聚焦 Agents need control flow, not more prompts</a></h3>
+      <h3 class="ti"><a href="https://bsuh.bearblog.dev/agents-need-control-flow/" target="_blank" rel="noopener">Agent 開發不應依賴更多提示詞，而應建立明確的控制流程與狀態管理。</a></h3>
       
-      <div class="zh">Agents need control flow, not m…（agents、need）— 可比對自家 agent 架構的能力邊界與整合策略。</div>
+      <div class="zh">開發者需從「寫提示詞」轉向「設計狀態機與控制邏輯」，降低系統崩潰風險並提升可維護性。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#其他</span>
-        <span class="pts"><b>519</b> 分 · 255 留言</span>
+        <span class="pts"><b>520</b> 分 · 255 留言</span>
         <span>bsuh.bearblog.dev</span>
       </div>
     </div>
@@ -2342,13 +2342,13 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">3</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/antirez/ds4" target="_blank" rel="noopener">HN 討論 DeepSeek 4 Flash local inference engine for Metal 聚焦 DeepSeek 4 Flash local inference engine for Met…</a></h3>
+      <h3 class="ti"><a href="https://github.com/antirez/ds4" target="_blank" rel="noopener">DeepSeek 4 Flash 提供本地 Metal 推理引擎，顯著提升 Mac 裝置上的模型運行效能。</a></h3>
       
-      <div class="zh">DeepSeek 4 Flash local inferenc…（deepseek、flash）— 追蹤可替換或補位的推理引擎，影響成本/延遲決策。</div>
+      <div class="zh">開發者可直接在 Mac 上運行大型模型，無需依賴雲端服務，降低延遲與成本。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#基礎設施</span>
-        <span class="pts"><b>434</b> 分 · 125 留言</span>
+        <span class="pts"><b>435</b> 分 · 125 留言</span>
         <span>github.com</span>
       </div>
     </div>
@@ -2356,13 +2356,13 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">4</span>
     <div class="body">
-      <h3 class="ti"><a href="https://www.anthropic.com/research/natural-language-autoencoders" target="_blank" rel="noopener">HN 討論 Natural Language Autoencoders 聚焦 Turning Claude&#39;s Thoughts into Text</a></h3>
+      <h3 class="ti"><a href="https://www.anthropic.com/research/natural-language-autoencoders" target="_blank" rel="noopener">Claude 3.5 的內部思考過程可透過自然語言自編碼器（NLAE）直接轉化為文本，無需額外推理。</a></h3>
       
-      <div class="zh">Natural Language Autoencoders（turning、claude）— 評估納入工程工作流或學習其 UX 細節。</div>
+      <div class="zh">為開發者提供可解釋性工具，讓 AI 的「思考」透明化。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#模型</span>
-        <span class="pts"><b>324</b> 分 · 100 留言</span>
+        <span class="pts"><b>325</b> 分 · 100 留言</span>
         <span>anthropic.com</span>
       </div>
     </div>
@@ -2370,9 +2370,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">5</span>
     <div class="body">
-      <h3 class="ti"><a href="https://deepmind.google/blog/alphaevolve-impact/" target="_blank" rel="noopener">HN 討論 AlphaEvolve 聚焦 Gemini-powered coding agent scaling impact acro…</a></h3>
+      <h3 class="ti"><a href="https://deepmind.google/blog/alphaevolve-impact/" target="_blank" rel="noopener">AlphaEvolve 透過 Gemini 與自訂模型並行訓練，大幅加速 AlphaCode 的演進速度。</a></h3>
       
-      <div class="zh">AlphaEvolve（gemini-powered、coding）— 可比對自家 agent 架構的能力邊界與整合策略。</div>
+      <div class="zh">AI 開發者可利用 Gemini 快速迭代自訂模型，縮短從原型到生產的週期。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#代理</span>
@@ -2384,9 +2384,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">6</span>
     <div class="body">
-      <h3 class="ti"><a href="https://www.tomshardware.com/pc-components/motherboards/motherboard-sales-collapse-by-more-than-25-percent-as-chipmakers-strangle-enthusiast-pc-market-to-build-more-ai-chips-asus-projected-to-sell-5-million-fewer-boards-in-2025-gigabyte-msi-and-asrock-also-expected-to-see-reduced-sales-numbers" target="_blank" rel="noopener">HN 討論 Motherboard sales &#39;collapse&#39; amid unprecedented shortages fueled by AI 聚焦 Motherboard sales &#39;collapse&#39; amid unprecedented…</a></h3>
+      <h3 class="ti"><a href="https://www.tomshardware.com/pc-components/motherboards/motherboard-sales-collapse-by-more-than-25-percent-as-chipmakers-strangle-enthusiast-pc-market-to-build-more-ai-chips-asus-projected-to-sell-5-million-fewer-boards-in-2025-gigabyte-msi-and-asrock-also-expected-to-see-reduced-sales-numbers" target="_blank" rel="noopener">主機板銷售因 AI 晶片短缺而萎縮超過 25%，廠商預計 2025 年銷量大幅減少。</a></h3>
       
-      <div class="zh">Motherboard sales &#39;collapse&#39; am…（motherboard、sales）— 初步觀察，待後續判讀是否進入工具鏈或選型清單。</div>
+      <div class="zh">開發者若依賴消費級主機板進行 AI 實驗或邊緣裝置，需預備延遲風險；建議轉向企業級平台或自製 FPGA 以避開供應瓶頸。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#其他</span>
@@ -2398,13 +2398,13 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">7</span>
     <div class="body">
-      <h3 class="ti"><a href="https://hacks.mozilla.org/2026/05/behind-the-scenes-hardening-firefox/" target="_blank" rel="noopener">HN 討論 Hardening Firefox with Claude Mythos Preview 聚焦 Hardening Firefox with Claude Mythos Preview</a></h3>
+      <h3 class="ti"><a href="https://hacks.mozilla.org/2026/05/behind-the-scenes-hardening-firefox/" target="_blank" rel="noopener">Mozilla 使用 Claude Mythos 進行 Firefox 安全掃描，發現了 271 個漏洞且誤報率極低。</a></h3>
       
-      <div class="zh">Hardening Firefox with Claude M…（hardening、firefox）— 追蹤可替換或補位的推理引擎，影響成本/延遲決策。</div>
+      <div class="zh">為 AI 驅動的軟體安全測試提供實例，開發者可參考此架構以提升自訂工具的檢測效能。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#模型</span>
-        <span class="pts"><b>256</b> 分 · 118 留言</span>
+        <span class="pts"><b>259</b> 分 · 118 留言</span>
         <span>hacks.mozilla.org</span>
       </div>
     </div>
@@ -2412,9 +2412,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">8</span>
     <div class="body">
-      <h3 class="ti"><a href="https://www.citizen.co.za/news/home-affairs-officials-suspended-ai-hallucinations/" target="_blank" rel="noopener">HN 討論 Two Home Affairs officials suspended after AI &#39;hallucinations&#39; found 聚焦 Two Home Affairs officials suspended after AI &#39;…</a></h3>
+      <h3 class="ti"><a href="https://www.citizen.co.za/news/home-affairs-officials-suspended-ai-hallucinations/" target="_blank" rel="noopener">南非內政部官員因 AI 產生幻覺導致錯誤決策而被停職。</a></h3>
       
-      <div class="zh">Two Home Affairs officials susp…（two、home）— 初步觀察，待後續判讀是否進入工具鏈或選型清單。</div>
+      <div class="zh">提醒開發者與使用者：對 AI 產出內容必須進行嚴謹的事前驗證與後審，不可完全信任模型輸出，否則可能導致法律或行政責任。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#其他</span>
@@ -2426,13 +2426,13 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">9</span>
     <div class="body">
-      <h3 class="ti"><a href="https://openrouter.ai/announcements/gpt55-cost-analysis" target="_blank" rel="noopener">HN 討論 GPT-5.5 Price Increase 聚焦 What It Costs</a></h3>
+      <h3 class="ti"><a href="https://openrouter.ai/announcements/gpt55-cost-analysis" target="_blank" rel="noopener">GPT-5.5 價格上漲是 API 供應商調整定價策略的結果，而非模型能力大幅提升。</a></h3>
       
-      <div class="zh">GPT-5.5 Price Increase（what、costs）— 追蹤可替換或補位的推理引擎，影響成本/延遲決策。</div>
+      <div class="zh">開發者需重新評估預算，避免過度依賴於價格上漲的模型。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#模型</span>
-        <span class="pts"><b>109</b> 分 · 25 留言</span>
+        <span class="pts"><b>111</b> 分 · 26 留言</span>
         <span>openrouter.ai</span>
       </div>
     </div>
@@ -2440,9 +2440,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">10</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/ReviewStage/stage-cli" target="_blank" rel="noopener">HN 討論 Show HN 聚焦 Stage CLI – An easier way of reading your AI ge…</a></h3>
+      <h3 class="ti"><a href="https://github.com/ReviewStage/stage-cli" target="_blank" rel="noopener">Stage CLI 讓開發者能透過自然語言指令，將 AI 生成的程式碼變更拆解為邏輯章節並在地瀏覽器閱讀。</a></h3>
       
-      <div class="zh">Show HN（stage、cli）— 評估納入工程工作流或學習其 UX 細節。</div>
+      <div class="zh">對 agent 開發者而言，可將現有 AI 整合至本地工作流，無需依賴遠端服務。這降低門檻並提升對複雜變更的掌控力。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#代理</span>
@@ -2454,13 +2454,13 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">11</span>
     <div class="body">
-      <h3 class="ti"><a href="https://github.com/advisories/GHSA-vp62-r36r-9xqp" target="_blank" rel="noopener">HN 討論 Claude Code CVE-2026-39861 聚焦 sandbox escape via symlink</a></h3>
+      <h3 class="ti"><a href="https://github.com/advisories/GHSA-vp62-r36r-9xqp" target="_blank" rel="noopener">Claude Code 因 symlink 攻擊導致沙盒逃逸，暴露出 AI 編譯器安全邊界。</a></h3>
       
-      <div class="zh">Claude Code CVE-2026-39861（sandbox、escape）— 檢視 agent 執行邊界與權限模型是否該升級。</div>
+      <div class="zh">開發者需警惕 AI 編譯器對惡意 symlinks 的處理，避免沙盒逃逸風險。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#模型</span>
-        <span class="pts"><b>29</b> 分 · 2 留言</span>
+        <span class="pts"><b>29</b> 分 · 3 留言</span>
         <span>github.com</span>
       </div>
     </div>
@@ -2468,9 +2468,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">12</span>
     <div class="body">
-      <h3 class="ti"><a href="https://simonwillison.net/2026/May/7/xai-anthropic/" target="_blank" rel="noopener">HN 討論 Notes on the xAI/Anthropic data center deal 聚焦 Notes on the xAI/Anthropic data center deal</a></h3>
+      <h3 class="ti"><a href="https://simonwillison.net/2026/May/7/xai-anthropic/" target="_blank" rel="noopener">xAI 與 Anthropic 的數據中心交易可能引發 AI 巨頭壟斷，並削弱開源生態。</a></h3>
       
-      <div class="zh">Notes on the xAI/Anthropic data…（notes、xai）— 可作為比較或回歸測試的資料/評測來源。</div>
+      <div class="zh">開發者應警惕閉源壟斷，避免依賴於受限的 API 或硬體。建議持續投入開源工具與自部署架構，維持技術自主性。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#其他</span>
@@ -2482,9 +2482,9 @@ HN 上 <a href="https://news.ycombinator.com/" target="_blank" rel="noopener">Mi
   </li><li>
     <span class="rk">13</span>
     <div class="body">
-      <h3 class="ti"><a href="https://moq.dev/blog/webrtc-is-the-problem/" target="_blank" rel="noopener">HN 討論 OpenAI&#39;s WebRTC Problem 聚焦 OpenAI&#39;s WebRTC Problem</a></h3>
+      <h3 class="ti"><a href="https://moq.dev/blog/webrtc-is-the-problem/" target="_blank" rel="noopener">WebRTC 的即時通訊能力讓 AI 代理能直接與用戶對話，但缺乏統一的 API 導致開發者難以構建可靠的多代理系統。</a></h3>
       
-      <div class="zh">OpenAI&#39;s WebRTC Problem（openai、webrtc）— 初步觀察，待後續判讀是否進入工具鏈或選型清單。</div>
+      <div class="zh">對 AI 開發者而言，需重新評估 WebRTC 的整合方式，考慮使用現有 API 或框架來解決即時通訊與 AI 代理的整合問題。</div>
       <div class="meta-row">
         <span class="src">網頁</span>
         <span class="tag">#其他</span>
@@ -2620,7 +2620,7 @@ _生成於 2026-05-08T09:00:06.717Z_
 </section>
 
 <footer>
-  <div>Kuro 自動生成 · <a href="https://github.com/miles990/mini-agent">原始碼</a> · 建置 2026-05-08 22:05 (Asia/Taipei)</div>
+  <div>Kuro 自動生成 · <a href="https://github.com/miles990/mini-agent">原始碼</a> · 建置 2026-05-09 01:08 (Asia/Taipei)</div>
   <div class="nav-row">
     <a href="./graph.html">主題圖譜</a>
     <a href="./swimlane.html">主題泳道</a>


### PR DESCRIPTION
## Summary

- regenerate the 2026-05-08 ai-trend HTML after HN/GitHub enriched state landed
- promote the refreshed page to `preview.html` and `index.html`
- lets the autonomous ai-trend closure verifier pass for the 2026-05-08 repair task

## Verification

- `node scripts/build-ai-trend-preview.mjs 2026-05-08` passed in runtime checkout
- `verifyAiTrendClosure(..., { date: "2026-05-08" })` passed in runtime checkout: zh=124/124, rendered=123/124, renderRatio=0.992
