### PR TITLE
fix: respect visible output momentum

### DIFF
--- a/src/correction-gate.ts
+++ b/src/correction-gate.ts
@@ -110,7 +110,7 @@ export function evaluateCorrectionGate(memoryDir: string, repoRoot = process.cwd
     }
   }
 
-  if (hasPulseHistory && quality < 0.4) {
+  if (hasPulseHistory && quality < 0.4 && signals.momentumStreak === 0) {
     const message = `產出品質低 (${Math.round(quality * 100)}%) — 多數 cycle 無 visible output。交付成品，不要只思考。`;
     reasons.push({ type: 'low-output-quality', severity: 'medium', message });
     guidance.push(message);

--- a/tests/correction-gate.test.ts
+++ b/tests/correction-gate.test.ts
@@ -329,6 +329,62 @@ describe('correction gate', () => {
     expect(snapshot.guidance).toEqual([]);
   });
 
+  it('does not keep low-output-quality open when the latest pulse has visible output momentum', () => {
+    const previousMemoryDir = process.env.MINI_AGENT_MEMORY_DIR;
+    process.env.MINI_AGENT_MEMORY_DIR = tmpDir;
+    mkdirSync(path.join(tmpDir, 'state'), { recursive: true });
+    writeFileSync(path.join(tmpDir, 'state/pulse-state.json'), JSON.stringify({
+      cycleCount: 8,
+      recentOutputFlags: [
+        true, false, true, false, false,
+        false, false, true, false, false,
+        false, false, false, true, false,
+        false, false, false, false, true,
+      ],
+      recentDecisionScores: [],
+      signalHistory: {},
+      errorPatterns: {},
+    }), 'utf-8');
+
+    try {
+      const snapshot = evaluateCorrectionGate(tmpDir, tmpDir);
+
+      expect(snapshot.reasons.map(r => r.type)).not.toContain('low-output-quality');
+      expect(snapshot.needsCorrection).toBe(false);
+    } finally {
+      if (previousMemoryDir === undefined) delete process.env.MINI_AGENT_MEMORY_DIR;
+      else process.env.MINI_AGENT_MEMORY_DIR = previousMemoryDir;
+    }
+  });
+
+  it('still flags low-output-quality when low output has no current momentum', () => {
+    const previousMemoryDir = process.env.MINI_AGENT_MEMORY_DIR;
+    process.env.MINI_AGENT_MEMORY_DIR = tmpDir;
+    mkdirSync(path.join(tmpDir, 'state'), { recursive: true });
+    writeFileSync(path.join(tmpDir, 'state/pulse-state.json'), JSON.stringify({
+      cycleCount: 8,
+      recentOutputFlags: [
+        true, false, true, false, false,
+        false, false, true, false, false,
+        false, false, false, true, false,
+        false, false, false, false, false,
+      ],
+      recentDecisionScores: [],
+      signalHistory: {},
+      errorPatterns: {},
+    }), 'utf-8');
+
+    try {
+      const snapshot = evaluateCorrectionGate(tmpDir, tmpDir);
+
+      expect(snapshot.reasons.map(r => r.type)).toContain('low-output-quality');
+      expect(snapshot.needsCorrection).toBe(true);
+    } finally {
+      if (previousMemoryDir === undefined) delete process.env.MINI_AGENT_MEMORY_DIR;
+      else process.env.MINI_AGENT_MEMORY_DIR = previousMemoryDir;
+    }
+  });
+
   it('acknowledges an active low-responsiveness hold instead of emitting a correction reason', async () => {
     await appendMemoryIndexEntry(tmpDir, {
       type: 'task',


### PR DESCRIPTION
## Summary

- keep `low-output-quality` from opening when the latest pulse has visible output momentum
- preserve the warning for genuinely low-output windows with no current momentum
- add correction-gate regression coverage for both cases

## Verification

- `pnpm exec vitest run tests/correction-gate.test.ts` passed
- `pnpm typecheck` passed

## Root Cause

The correction gate used only sliding-window visible output rate. After a real delivery, the average could remain low and keep autonomy closure degraded even though the latest pulse was a visible output.