### PR TITLE
fix(loop): preflight threshold reads _http/_40k lastSeen too (#414)

### DIFF
--- a/src/loop.ts
+++ b/src/loop.ts
@@ -2736,18 +2736,22 @@ export class AgentLoop {
       // Measure ≥35K prompt rate before deciding rebuild/drain strategy in phase 2.
       // Issue #368 (Step B): lower threshold 35K→25K when _midprompt seen in last 24h,
       // so cycles in the 25-35K band are flagged while the instance is still in the stall window.
+      // Issue #414: also lower threshold when _http or _40k variants seen in last 24h,
+      // so the 25-35K band is flagged regardless of which silent_exit_void variant is recent.
       // lastSeen is YYYY-MM-DD; treat "today or yesterday" as within 24h window.
       let PREFLIGHT_SIZE_THRESHOLD = 35_000;
       try {
         const epPath = path.join(getMemoryStateDir(), 'error-patterns.json');
         const epRaw = fs.existsSync(epPath) ? JSON.parse(fs.readFileSync(epPath, 'utf8')) : {};
+        const today = new Date().toISOString().slice(0, 10);
+        const yesterday = new Date(Date.now() - 86_400_000).toISOString().slice(0, 10);
+        const isRecent = (entry: { lastSeen?: string } | undefined): boolean =>
+          !!entry?.lastSeen && entry.lastSeen >= yesterday && entry.lastSeen <= today;
         const midpromptEntry = epRaw['TIMEOUT:silent_exit_void_midprompt::callClaude'] as { lastSeen?: string } | undefined;
-        if (midpromptEntry?.lastSeen) {
-          const today = new Date().toISOString().slice(0, 10);
-          const yesterday = new Date(Date.now() - 86_400_000).toISOString().slice(0, 10);
-          if (midpromptEntry.lastSeen >= yesterday && midpromptEntry.lastSeen <= today) {
-            PREFLIGHT_SIZE_THRESHOLD = 25_000;
-          }
+        const httpEntry = epRaw['TIMEOUT:silent_exit_void_http::callClaude'] as { lastSeen?: string } | undefined;
+        const fortyKEntry = epRaw['TIMEOUT:silent_exit_void_40k::callClaude'] as { lastSeen?: string } | undefined;
+        if (isRecent(midpromptEntry) || isRecent(httpEntry) || isRecent(fortyKEntry)) {
+          PREFLIGHT_SIZE_THRESHOLD = 25_000;
         }
       } catch { /* best-effort: fall back to default 35K */ }
       if (effectivePrompt.length >= PREFLIGHT_SIZE_THRESHOLD) {


### PR DESCRIPTION
Closes #414 (Fix path A).

## Problem
`silent_exit_void_http` resurfaced 3× since #191 closed. Live sample is a 25,250-char prompt × 1052s stall — exactly the 25–35K band the adaptive PREFLIGHT_SIZE_THRESHOLD was meant to flag.

The preflight in `src/loop.ts:2740-2752` only lowered the threshold from 35K→25K when `silent_exit_void_midprompt.lastSeen` was recent. When `_http` or `_40k` is the live failure mode and `_midprompt` is quiet, threshold stays at 35K and 25K-band prompts slide through unflagged.

## Fix (Fix path A from #414 body)
Extend the `isRecent()` check to also consider `silent_exit_void_http.lastSeen` and `silent_exit_void_40k.lastSeen`. 5-line behavioral diff (10 insertions / 6 deletions including comment). No-op when keys absent.

## Diff overview
- Hoist `today`/`yesterday` derivation out of the `_midprompt`-only branch.
- Add `isRecent(entry)` helper.
- OR-fold `_midprompt`, `_http`, `_40k` recency checks.

## Falsifier
Post-merge: `memory/state/error-patterns.json` `TIMEOUT:silent_exit_void_http::callClaude.lastSeen` should not advance for 7 days. If a new event does occur, `app.log` should now contain `[preflight.drain]` with `promptSize >= 25_000` for that cycle (currently it would have been silent).

## Out of scope
Fix path B (actually drain the prompt downstream of the slog) — separate PR. This change makes the observability gate fire correctly across all three variants; the drain wiring is the next step.

## Refs
- #414 (this fix)
- #368 (Step B midprompt threshold)
- #304 (preflight phase 1)
- #191 (HTTP-stall classifier split, original)

🤖 Generated with [Claude Code](https://claude.com/claude-code)