### PR TITLE
fix(loop): rename preflight.drain → preflight.observe (#414 Gap 2)

### DIFF
--- a/src/loop.ts
+++ b/src/loop.ts
@@ -2755,8 +2755,8 @@ export class AgentLoop {
         }
       } catch { /* best-effort: fall back to default 35K */ }
       if (effectivePrompt.length >= PREFLIGHT_SIZE_THRESHOLD) {
-        slog('LOOP', `[preflight.drain] prompt size ${effectivePrompt.length} >= ${PREFLIGHT_SIZE_THRESHOLD} (silent_exit_void_40k risk)`);
-        eventBus.emit('action:loop', { event: 'preflight.drain', promptSize: effectivePrompt.length, threshold: PREFLIGHT_SIZE_THRESHOLD, cycleMode, trigger: currentTriggerReason ?? null });
+        slog('LOOP', `[preflight.observe] prompt size ${effectivePrompt.length} >= ${PREFLIGHT_SIZE_THRESHOLD} (drain not yet wired; observability only)`);
+        eventBus.emit('action:loop', { event: 'preflight.observe', promptSize: effectivePrompt.length, threshold: PREFLIGHT_SIZE_THRESHOLD, cycleMode, trigger: currentTriggerReason ?? null });
       }
 
       // Intelligent model routing: decide Opus vs Sonnet based on cycle characteristics


### PR DESCRIPTION
## Summary

Closes Gap 2 of #414 via Path B (rename, recommended cheap option).

The preflight branch at `src/loop.ts:2757-2760` logs `[preflight.drain]` and emits `event: 'preflight.drain'`, but never mutates `effectivePrompt`. The comment at line 2735 already describes this as "Pre-flight observability (issue #304 phase 1)" — phase-2 actual drain is deferred.

This rename aligns the tag with the actual behavior so future readers do not expect drain semantics from a log/emit-only branch.

## Changes

- `[preflight.drain]` slog tag → `[preflight.observe]`
- `event: 'preflight.drain'` → `event: 'preflight.observe'`
- Message clarified: "(drain not yet wired; observability only)"

## Verification

- Zero downstream consumers: `grep -rn "preflight.drain" src/` returned only the two emit sites (no listeners).
- `pnpm tsc --noEmit` — pre-existing 42 errors in `loop.ts` (node-types config), zero new errors from this change.
- Diff is 2 lines, behavior-preserving.

## Falsifier

After merge: `grep -rn "preflight\\.drain" src/` should return 0 hits. Phase-2 drain remains a separate future task tracked under #304.

## Test plan

- [x] Type-check shows zero new errors
- [x] grep confirms no downstream consumers
- [ ] No runtime behavior change expected (observability-only branch)

Refs: #414 (Gap 2), #415 (Gap 1, merged), #304 (phase 1 ship).

🤖 Generated with [Claude Code](https://claude.com/claude-code)