### PR TITLE
fix: converge kuro content artifact truth

### DIFF
--- a/scripts/build-ai-trend-preview.mjs
+++ b/scripts/build-ai-trend-preview.mjs
@@ -14,7 +14,10 @@ import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(__dirname, '..');
-const STATE_DIR = join(ROOT, 'memory/state');
+const REPO_STATE_DIR = join(ROOT, 'memory/state');
+const MEMORY_ROOT = process.env.MINI_AGENT_MEMORY_DIR?.trim();
+const STATE_DIR = MEMORY_ROOT ? join(MEMORY_ROOT, 'state') : REPO_STATE_DIR;
+const READ_STATE_DIRS = Array.from(new Set([STATE_DIR, REPO_STATE_DIR]));
 const OUT = join(ROOT, 'kuro-portfolio/ai-trend/preview.html');
 
 function todayTaipei() {
@@ -53,7 +56,7 @@ async function loadLatest(subdir, fromDate, days = 14, opts = {}) {
     const dd = new Date(d.getTime() - i * 86400_000);
     const key = dd.toISOString().slice(0, 10);
     try {
-      const raw = JSON.parse(await readFile(join(STATE_DIR, subdir, `${key}.json`), 'utf8'));
+      const raw = JSON.parse(await readStateFile(subdir, `${key}.json`));
       const posts = (raw.posts || []).filter(p => {
         if (keepX) return true;
         const u = String(p.url || p.story_url || '').toLowerCase();
@@ -71,7 +74,7 @@ async function loadKuroPick(date) {
     const dd = new Date(d.getTime() - i * 86400_000);
     const key = dd.toISOString().slice(0, 10);
     try {
-      const md = await readFile(join(STATE_DIR, 'kuro-daily-pick', `${key}.md`), 'utf8');
+      const md = await readStateFile('kuro-daily-pick', `${key}.md`);
       return { key, md };
     } catch {}
   }
@@ -91,9 +94,7 @@ async function loadKuroPick(date) {
 async function loadKuroContent(date) {
   const empty = { take: null, spotlight: null, swot: null };
   try {
-    const raw = await readFile(
-      join(STATE_DIR, 'kuro-content', `${date}.md`), 'utf8'
-    );
+    const raw = await readStateFile('kuro-content', `${date}.md`);
     // Split on H2 boundaries; keep delimiter via lookahead-style split
     const sections = raw.split(/^(?=## )/m);
     const result = { take: null, spotlight: null, swot: null };
@@ -369,7 +370,7 @@ async function loadTopicTrend(fromDate) {
     const dd = new Date(d.getTime() - i * 86400_000);
     const key = dd.toISOString().slice(0, 10);
     try {
-      const raw = JSON.parse(await readFile(join(STATE_DIR, 'hn-ai-trend', `${key}.json`), 'utf8'));
+      const raw = JSON.parse(await readStateFile('hn-ai-trend', `${key}.json`));
       const target = i < 7 ? counts : prevCounts;
       for (const p of (raw.posts || [])) {
         const t = tagOf(p);
@@ -378,6 +379,18 @@ async function loadTopicTrend(fromDate) {
     } catch {}
   }
   return { counts, prevCounts };
+}
+
+async function readStateFile(...segments) {
+  let lastError;
+  for (const stateDir of READ_STATE_DIRS) {
+    try {
+      return await readFile(join(stateDir, ...segments), 'utf8');
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  throw lastError ?? new Error(`state file not found: ${segments.join('/')}`);
 }
 
 async function listArchiveDates() {

--- a/scripts/build-kuro-content.mjs
+++ b/scripts/build-kuro-content.mjs
@@ -27,13 +27,16 @@
  *   3. Output matches schema consumed by loadKuroContent() in build-ai-trend-preview.mjs
  */
 
-import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { readFile, writeFile, mkdir, stat } from 'node:fs/promises';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = join(__dirname, '..');
-const STATE_DIR = join(REPO_ROOT, 'memory', 'state');
+const REPO_STATE_DIR = join(REPO_ROOT, 'memory', 'state');
+const MEMORY_ROOT = process.env.MINI_AGENT_MEMORY_DIR?.trim();
+const STATE_DIR = MEMORY_ROOT ? join(MEMORY_ROOT, 'state') : REPO_STATE_DIR;
+const READ_STATE_DIRS = Array.from(new Set([STATE_DIR, REPO_STATE_DIR]));
 
 // -- CLI args -----------------------------------------------------------------
 const args = process.argv.slice(2).filter(a => !a.startsWith('--'));
@@ -56,13 +59,21 @@ async function tryRead(filePath) {
   }
 }
 
+async function tryReadState(...segments) {
+  for (const stateDir of READ_STATE_DIRS) {
+    const raw = await tryRead(join(stateDir, ...segments));
+    if (raw !== null) return raw;
+  }
+  return null;
+}
+
 /** Load most-recent feeder JSON within lookback window, return { key, posts, run_at, daysOld } */
 async function loadFeeder(subdir, fromDate, lookbackDays = 4) {
   const d = new Date(fromDate + 'T00:00:00Z');
   for (let i = 0; i < lookbackDays; i++) {
     const dd = new Date(d.getTime() - i * 86400_000);
     const key = dd.toISOString().slice(0, 10);
-    const raw = await tryRead(join(STATE_DIR, subdir, `${key}.json`));
+    const raw = await tryReadState(subdir, `${key}.json`);
     if (raw) {
       try {
         const parsed = JSON.parse(raw);
@@ -81,7 +92,7 @@ async function loadDailyPick(fromDate, lookbackDays = 4) {
   for (let i = 0; i < lookbackDays; i++) {
     const dd = new Date(d.getTime() - i * 86400_000);
     const key = dd.toISOString().slice(0, 10);
-    const md = await tryRead(join(STATE_DIR, 'kuro-daily-pick', `${key}.md`));
+    const md = await tryReadState('kuro-daily-pick', `${key}.md`);
     if (md) return { key, md, daysOld: i };
   }
   return { key: null, md: '', daysOld: null };
@@ -94,7 +105,7 @@ async function loadHistory(subdir, fromDate, days) {
   for (let i = 1; i <= days; i++) {
     const dd = new Date(d.getTime() - i * 86400_000);
     const key = dd.toISOString().slice(0, 10);
-    const raw = await tryRead(join(STATE_DIR, subdir, `${key}.json`));
+    const raw = await tryReadState(subdir, `${key}.json`);
     if (raw) {
       try { results.push({ key, ...(JSON.parse(raw)) }); } catch {}
     }
@@ -174,6 +185,23 @@ export function validate(content) {
   return issues;
 }
 
+async function verifyWrittenArtifact(filePath, expectedDate) {
+  const fileStat = await stat(filePath);
+  if (!fileStat.isFile() || fileStat.size <= 0) {
+    throw new Error(`written artifact is empty or not a file: ${filePath}`);
+  }
+  const persisted = await readFile(filePath, 'utf8');
+  const errors = validate(persisted);
+  if (errors.length > 0) {
+    throw new Error(`written artifact failed readback validation: ${errors.join('; ')}`);
+  }
+  const dateRe = new RegExp(`^date:\\s*${expectedDate}$`, 'm');
+  if (!dateRe.test(persisted)) {
+    throw new Error(`written artifact date mismatch: expected ${expectedDate}`);
+  }
+  return { bytes: fileStat.size };
+}
+
 // -- Anthropic call -----------------------------------------------------------
 async function callAnthropic(systemPrompt, userPrompt) {
   const apiKey = process.env.ANTHROPIC_API_KEY;
@@ -215,6 +243,7 @@ async function callAnthropic(systemPrompt, userPrompt) {
 // -- Main ---------------------------------------------------------------------
 async function main() {
   console.log(`[kuro-content] building ${DATE}${dryRun ? ' (dry-run)' : ''}`);
+  console.log(`[kuro-content] state dir ${STATE_DIR}`);
 
   // 1. Load upstream feeders (all graceful -- missing -> warn, continue)
   const hn = await loadFeeder('hn-ai-trend', DATE);
@@ -258,8 +287,7 @@ async function main() {
   const githubHistory = await loadHistory('github-trend', DATE, 3);
 
   // 3. Load 1-shot exemplar
-  const exemplarPath = join(STATE_DIR, 'kuro-content', '2026-05-08.md');
-  const exemplar = await tryRead(exemplarPath);
+  const exemplar = await tryReadState('kuro-content', '2026-05-08.md');
   if (!exemplar) {
     console.warn('[kuro-content] WARN: 1-shot exemplar 2026-05-08.md not found; continuing without it');
   }
@@ -380,7 +408,9 @@ async function main() {
   const outPath = join(outDir, `${DATE}.md`);
   if (!dryRun) {
     await writeFile(outPath, generated, 'utf8');
+    const verified = await verifyWrittenArtifact(outPath, DATE);
     console.log(`[kuro-content] wrote ${outPath}`);
+    console.log(`[kuro-content] verified artifact bytes=${verified.bytes}`);
   } else {
     console.log('[kuro-content] dry-run: content would be written to', outPath);
     console.log('[kuro-content] --- generated content preview (first 500 chars) ---');

--- a/scripts/launchd-wrappers/build-kuro-content.sh
+++ b/scripts/launchd-wrappers/build-kuro-content.sh
@@ -11,10 +11,11 @@ export PATH="$HOME/.local/bin:/opt/homebrew/bin:$PATH"
 set -a
 . ./.env
 set +a
+export MINI_AGENT_MEMORY_DIR="${MINI_AGENT_MEMORY_DIR:-/Users/user/Workspace/mini-agent-memory/memory}"
 # build-kuro-content.mjs returns:
 #   0 = wrote live <DATE>.md (gate passed)
-#   1 = wrote <DATE>.md.draft (gate failed — DO NOT promote)
-#   2 = hard error
+#   1 = hard error before output
+#   2 = wrote <DATE>.md.draft (gate failed — DO NOT promote)
 set +e
 /opt/homebrew/bin/node scripts/build-kuro-content.mjs
 _exit=$?

--- a/src/autonomy-closure-health.ts
+++ b/src/autonomy-closure-health.ts
@@ -76,7 +76,7 @@ export function evaluateAutonomyClosure(
     runtimeWorkspaceStage(correction),
     taskExecutionStage(openTasks),
     testHealthStage(memoryDir),
-    issueAutopilotStage(openTasks),
+    issueAutopilotStage(openTasks, options.now ?? new Date()),
     prReviewConsensusStage(memoryDir, options.now ?? new Date()),
     publicWriteIdentityStage(memoryDir),
     shipAndDeployStage(correction),
@@ -341,12 +341,16 @@ function testHealthStage(memoryDir: string): AutonomyClosureStageResult {
   };
 }
 
-function issueAutopilotStage(openTasks: MemoryIndexEntry[]): AutonomyClosureStageResult {
+function issueAutopilotStage(openTasks: MemoryIndexEntry[], now: Date): AutonomyClosureStageResult {
   const issueTasks = openTasks.filter(task => {
     const payload = (task.payload ?? {}) as Record<string, unknown>;
     return task.source === 'github-issue' || payload.origin === 'github-issue' || typeof payload.issue_number === 'number';
   });
-  const staleIssueTasks = issueTasks.filter(task => ['blocked', 'hold', 'needs-decomposition'].includes(String(task.status)));
+  const staleIssueTasks = issueTasks.filter(task => {
+    const status = String(task.status);
+    if (status === 'hold') return !hasActiveTimedHold(task, now);
+    return ['blocked', 'needs-decomposition'].includes(status);
+  });
   if (staleIssueTasks.length > 0) {
     return {
       stage: 'issue-autopilot',
@@ -362,6 +366,14 @@ function issueAutopilotStage(openTasks: MemoryIndexEntry[]): AutonomyClosureStag
     summary: `${issueTasks.length} GitHub issue task(s) visible to scheduler`,
     evidence: issueTasks.slice(0, 5).map(formatTaskEvidence),
   };
+}
+
+function hasActiveTimedHold(task: MemoryIndexEntry, now: Date): boolean {
+  const payload = (task.payload ?? {}) as Record<string, unknown>;
+  const condition = payload.holdCondition as Record<string, unknown> | undefined;
+  if (condition?.type !== 'date-after' || typeof condition.value !== 'string') return false;
+  const releaseAt = Date.parse(condition.value);
+  return Number.isFinite(releaseAt) && releaseAt > now.getTime();
 }
 
 function prReviewConsensusStage(memoryDir: string, now: Date): AutonomyClosureStageResult {

--- a/tests/autonomy-closure-health.test.ts
+++ b/tests/autonomy-closure-health.test.ts
@@ -40,6 +40,74 @@ describe('autonomy closure health', () => {
     expect(snapshot.stages.map(s => s.stage)).toContain('memory-context');
   });
 
+  it('does not degrade issue autopilot for a GitHub issue task with an active timed hold', () => {
+    writeFileSync(
+      path.join(tmpDir, 'state/task-events.jsonl'),
+      JSON.stringify({
+        id: 'idx-github-issue-394',
+        ts: '2026-05-09T00:00:00.000Z',
+        type: 'task',
+        source: 'github-issue',
+        status: 'hold',
+        summary: 'P2 GitHub issue #394: ai-trend content generator',
+        refs: ['github:issue:394'],
+        payload: {
+          origin: 'github-issue',
+          priority: 2,
+          issue_number: 394,
+          holdCondition: { type: 'date-after', value: '2026-05-09T18:36:28.341Z' },
+        },
+      }) + '\n',
+      'utf-8',
+    );
+    writeFileSync(path.join(tmpDir, 'index/relations.jsonl'), '', 'utf-8');
+
+    const snapshot = evaluateAutonomyClosure(tmpDir, {
+      repoRoot,
+      now: new Date('2026-05-09T12:00:00.000Z'),
+    });
+
+    expect(snapshot.warningStages).not.toContain('issue-autopilot');
+    expect(snapshot.stages.find(s => s.stage === 'issue-autopilot')).toEqual(expect.objectContaining({
+      status: 'ok',
+      summary: '1 GitHub issue task(s) visible to scheduler',
+    }));
+  });
+
+  it('warns issue autopilot after a GitHub issue timed hold expires', () => {
+    writeFileSync(
+      path.join(tmpDir, 'state/task-events.jsonl'),
+      JSON.stringify({
+        id: 'idx-github-issue-394',
+        ts: '2026-05-09T00:00:00.000Z',
+        type: 'task',
+        source: 'github-issue',
+        status: 'hold',
+        summary: 'P2 GitHub issue #394: ai-trend content generator',
+        refs: ['github:issue:394'],
+        payload: {
+          origin: 'github-issue',
+          priority: 2,
+          issue_number: 394,
+          holdCondition: { type: 'date-after', value: '2026-05-09T18:36:28.341Z' },
+        },
+      }) + '\n',
+      'utf-8',
+    );
+    writeFileSync(path.join(tmpDir, 'index/relations.jsonl'), '', 'utf-8');
+
+    const snapshot = evaluateAutonomyClosure(tmpDir, {
+      repoRoot,
+      now: new Date('2026-05-09T19:00:00.000Z'),
+    });
+
+    expect(snapshot.warningStages).toContain('issue-autopilot');
+    expect(snapshot.stages.find(s => s.stage === 'issue-autopilot')).toEqual(expect.objectContaining({
+      status: 'warn',
+      summary: '1 GitHub issue task(s) are not flowing',
+    }));
+  });
+
   it('degrades and queues operational-efficiency repair when correction advisories are the remaining closure gap', async () => {
     writeFileSync(
       path.join(tmpDir, 'state/task-events.jsonl'),

--- a/tests/build-kuro-content.test.ts
+++ b/tests/build-kuro-content.test.ts
@@ -83,6 +83,13 @@ describe('build-kuro-content.mjs script', () => {
     expect(script).toContain('ANTHROPIC_API_KEY');
   });
 
+  it('uses MINI_AGENT_MEMORY_DIR as durable state root with repo fallback', () => {
+    script = readFileSync(SCRIPT_PATH, 'utf-8');
+    expect(script).toContain('MINI_AGENT_MEMORY_DIR');
+    expect(script).toContain('READ_STATE_DIRS');
+    expect(script).toContain('tryReadState');
+  });
+
   it('exits with error when zero feeders are available', () => {
     script = readFileSync(SCRIPT_PATH, 'utf-8');
     // Must have the zero-feeder guard (Acceptance #1)
@@ -104,6 +111,13 @@ describe('build-kuro-content.mjs script', () => {
   it('corrects date in frontmatter to prevent exemplar date leaking', () => {
     script = readFileSync(SCRIPT_PATH, 'utf-8');
     expect(script).toMatch(/replace.*date:.*DATE/);
+  });
+
+  it('read-back verifies the written artifact before reporting success', () => {
+    script = readFileSync(SCRIPT_PATH, 'utf-8');
+    expect(script).toContain('verifyWrittenArtifact');
+    expect(script).toContain('written artifact failed readback validation');
+    expect(script).toContain('verified artifact bytes=');
   });
 });
 
@@ -203,6 +217,12 @@ describe('build-kuro-content launchd wrapper', () => {
     const wrapper = readFileSync(WRAPPER_PATH, 'utf-8');
     expect(wrapper).toContain('.env');
     expect(wrapper).toContain('set -a');
+  });
+
+  it('wrapper defaults durable state to external mini-agent-memory', () => {
+    const wrapper = readFileSync(WRAPPER_PATH, 'utf-8');
+    expect(wrapper).toContain('MINI_AGENT_MEMORY_DIR');
+    expect(wrapper).toContain('/Users/user/Workspace/mini-agent-memory/memory');
   });
 });
 


### PR DESCRIPTION
## Summary
- route kuro-content generation and ai-trend rendering through MINI_AGENT_MEMORY_DIR with repo-state fallback
- verify generated kuro-content by reading the written artifact back before reporting success
- treat active date-after GitHub issue holds as scheduled convergence instead of issue-autopilot drift

## Verification
- pnpm exec vitest run tests/build-kuro-content.test.ts tests/autonomy-closure-health.test.ts
- pnpm typecheck
- pnpm test
- pnpm build
- MINI_AGENT_MEMORY_DIR=/Users/user/Workspace/mini-agent-memory/memory node scripts/build-ai-trend-preview.mjs 2026-05-09