### PR TITLE
fix(#422): mtime-aware feedback-loops cache + regression test

### DIFF
--- a/src/feedback-loops.ts
+++ b/src/feedback-loops.ts
@@ -10,7 +10,7 @@
  * 全部 fire-and-forget，不影響 OODA cycle。
  */
 
-import { existsSync, readFileSync, writeFileSync, mkdirSync, appendFileSync } from 'node:fs';
+import { existsSync, readFileSync, writeFileSync, mkdirSync, appendFileSync, statSync } from 'node:fs';
 import path from 'node:path';
 import { getMemoryRootDir, resolveMemoryPath } from './memory-paths.js';
 import { getInstanceDir, getCurrentInstanceId } from './instance.js';  // getInstanceDir kept for features.json (ephemeral)
@@ -61,23 +61,41 @@ interface DecisionQualityState {
 // Helpers — in-memory state cache + dirty flag
 // =============================================================================
 
-const stateCache = new Map<string, { data: unknown; dirty: boolean }>();
+// Issue #422: cache must be mtime-aware. Out-of-band writers (e.g.
+// `pnpm error-patterns:resolve` running as a separate subprocess) update disk
+// directly. A stale in-memory cache that survives across cycles will then
+// clobber those updates on the next `flushFeedbackState`, silently stripping
+// resolvedAt/resolvedBy. Snapshot mtime at read; reload on next read if disk
+// has advanced (and the cache isn't dirty with our own pending writes).
+const stateCache = new Map<string, { data: unknown; dirty: boolean; mtimeMs: number }>();
 
 function getStatePath(filename: string): string {
   return path.join(getMemoryStateDir(), filename);
 }
 
-export function readState<T>(filename: string, fallback: T): T {
-  const cached = stateCache.get(filename);
-  if (cached) return cached.data as T;
+function getDiskMtimeMs(filePath: string): number {
+  try { return statSync(filePath).mtimeMs; } catch { return 0; }
+}
 
-  const data = readJsonFile(getStatePath(filename), fallback);
-  stateCache.set(filename, { data, dirty: false });
+export function readState<T>(filename: string, fallback: T): T {
+  const p = getStatePath(filename);
+  const diskMtime = getDiskMtimeMs(p);
+  const cached = stateCache.get(filename);
+  // Reuse cache when:
+  //  - we have pending writes (dirty) — flushing is our responsibility, don't drop
+  //  - or disk hasn't advanced past the snapshot we read
+  if (cached && (cached.dirty || diskMtime <= cached.mtimeMs)) {
+    return cached.data as T;
+  }
+
+  const data = readJsonFile(p, fallback);
+  stateCache.set(filename, { data, dirty: false, mtimeMs: diskMtime });
   return data;
 }
 
 export function writeState(filename: string, data: unknown): void {
-  stateCache.set(filename, { data, dirty: true });
+  const cached = stateCache.get(filename);
+  stateCache.set(filename, { data, dirty: true, mtimeMs: cached?.mtimeMs ?? 0 });
 }
 
 /** Flush all dirty state files to disk. Call once at cycle end. */
@@ -89,10 +107,20 @@ export function flushFeedbackState(): void {
       if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
       try {
         writeFileSync(p, JSON.stringify(entry.data, null, 2), 'utf-8');
+        entry.mtimeMs = getDiskMtimeMs(p);
       } catch { /* best effort */ }
       entry.dirty = false;
     }
   }
+}
+
+/**
+ * Issue #422 test seam: drop the in-memory cache so the next readState pulls
+ * fresh from disk. Unit tests that simulate cross-process writes use this to
+ * mimic a fresh worker process; production code should not need it.
+ */
+export function _resetFeedbackStateCacheForTests(): void {
+  stateCache.clear();
 }
 
 // =============================================================================
@@ -338,8 +366,11 @@ export async function detectErrorPatterns(): Promise<void> {
   // Subtype-rename migration: drop today's orphan keys absent from current groups.
   // Without this, renaming a subtype (e.g. econnrefused -> dns_lookup_failed) leaves
   // the old key with stale today-counts; 7-day TTL won't clean it because lastSeen=today.
+  // Issue #422: skip entries with resolvedAt — resolution provenance is sticky and
+  // must survive reorganisations. If the same key re-fires later, we still want to
+  // know "this was resolved at SHA X" rather than treating it as a brand-new pattern.
   for (const key of Object.keys(state)) {
-    if (state[key].lastSeen === today && !groups.has(key)) {
+    if (state[key].lastSeen === today && !groups.has(key) && !state[key].resolvedAt) {
       slog('FEEDBACK', `Error pattern orphaned by subtype rename: ${key}`);
       delete state[key];
       changed = true;
@@ -365,10 +396,14 @@ export async function detectErrorPatterns(): Promise<void> {
     slog('FEEDBACK', `Error pattern detected: ${key} (${count}×)`);
   }
 
-  // Clean up patterns not seen in 7 days
+  // Clean up patterns not seen in 7 days.
+  // Issue #422: keep entries with resolvedAt — they record sticky resolution
+  // provenance. Without this guard, a 7-day quiet window deletes the entry; if
+  // the same pattern then re-fires (real regression OR cache-race re-add), the
+  // newly created bucket has no resolvedAt and the heartbeat raises a P1 again.
   const sevenDaysAgo = new Date(Date.now() - 7 * 86400_000).toISOString().split('T')[0];
   for (const key of Object.keys(state)) {
-    if (state[key].lastSeen < sevenDaysAgo) {
+    if (state[key].lastSeen < sevenDaysAgo && !state[key].resolvedAt) {
       slog('FEEDBACK', `Error pattern resolved (no recurrence in 7d): ${key}`);
       delete state[key];
       changed = true;

--- a/tests/feedback-loops-error-patterns-resolution.test.ts
+++ b/tests/feedback-loops-error-patterns-resolution.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, mkdirSync, statSync, utimesSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+// Issue #422 regression coverage.
+//
+// Root cause: feedback-loops.ts kept a process-lifetime in-memory state cache
+// with no mtime check. Out-of-band writers (notably `pnpm error-patterns:resolve`,
+// which runs as an independent subprocess) stamp `resolvedAt`/`resolvedBy`
+// directly on disk. The next `flushFeedbackState` in the live OODA loop then
+// serialised its stale cache back to disk, silently stripping those fields.
+//
+// Observed symptom: `TIMEOUT:silent_exit_void_http::callClaude` had
+// resolvedAt=2026-05-08T17:43:30Z stamped after PR #415 merged, then the file
+// was rewritten 9h later with resolvedAt=null while count/lastSeen were
+// preserved unchanged — the smoking gun for a stale cache clobber.
+
+let tmpStateDir: string;
+const stateFile = () => path.join(tmpStateDir, 'error-patterns.json');
+
+vi.mock('../src/memory.js', () => ({
+  getMemoryStateDir: () => tmpStateDir,
+  getMemory: () => ({}),
+  invalidateFlagCache: () => {},
+}));
+
+vi.mock('../src/utils.js', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return { ...actual, slog: () => {} };
+});
+
+import {
+  readState,
+  writeState,
+  flushFeedbackState,
+  _resetFeedbackStateCacheForTests,
+} from '../src/feedback-loops.js';
+
+type ErrorPattern = {
+  count: number;
+  taskCreated: boolean;
+  lastSeen: string;
+  lastMessage?: string;
+  resolvedAt?: string;
+  resolvedBy?: string;
+};
+type State = Record<string, ErrorPattern>;
+
+function writeStateFileDirect(state: State): void {
+  mkdirSync(tmpStateDir, { recursive: true });
+  writeFileSync(stateFile(), `${JSON.stringify(state, null, 2)}\n`, 'utf-8');
+}
+
+function bumpMtime(filePath: string, deltaMs = 1000): void {
+  // Push mtime forward so the cache's mtime snapshot is strictly less than disk.
+  // Some filesystems have second-granularity mtimes; +1s guarantees a strict bump.
+  const now = new Date(Date.now() + deltaMs);
+  utimesSync(filePath, now, now);
+}
+
+beforeEach(() => {
+  tmpStateDir = mkdtempSync(path.join(tmpdir(), 'fb-loops-422-'));
+  _resetFeedbackStateCacheForTests();
+});
+
+afterEach(() => {
+  rmSync(tmpStateDir, { recursive: true, force: true });
+});
+
+describe('issue #422 — error-patterns resolvedAt strip', () => {
+  it('readState reloads when disk advances (resolve script wrote between cycles)', () => {
+    // Cycle 1: cache populates from initial disk state (no resolvedAt yet).
+    writeStateFileDirect({
+      'TIMEOUT:silent_exit_void_http::callClaude': {
+        count: 3,
+        taskCreated: false,
+        lastSeen: '2026-05-08',
+        lastMessage: 'silent exit void',
+      },
+    });
+    const first = readState<State>('error-patterns.json', {});
+    expect(first['TIMEOUT:silent_exit_void_http::callClaude'].resolvedAt).toBeUndefined();
+
+    // Out-of-band writer (resolve script) stamps resolvedAt directly to disk.
+    writeStateFileDirect({
+      'TIMEOUT:silent_exit_void_http::callClaude': {
+        count: 3,
+        taskCreated: false,
+        lastSeen: '2026-05-08',
+        lastMessage: 'silent exit void',
+        resolvedAt: '2026-05-08T17:43:30.000Z',
+        resolvedBy: '09a5ccc3',
+      },
+    });
+    bumpMtime(stateFile());
+
+    // Cycle 2: a fresh readState in the same process must see the new resolution
+    // — pre-fix behaviour was a cache hit returning stale data.
+    const second = readState<State>('error-patterns.json', {});
+    expect(second['TIMEOUT:silent_exit_void_http::callClaude'].resolvedAt).toBe('2026-05-08T17:43:30.000Z');
+    expect(second['TIMEOUT:silent_exit_void_http::callClaude'].resolvedBy).toBe('09a5ccc3');
+  });
+
+  it('flushFeedbackState does not clobber an out-of-band resolvedAt stamp', () => {
+    // Initial disk state — cycle starts.
+    writeStateFileDirect({
+      'TIMEOUT:silent_exit_void_http::callClaude': {
+        count: 3,
+        taskCreated: false,
+        lastSeen: '2026-05-08',
+      },
+      // Unrelated entry the loop will mutate this cycle (drives `changed=true`
+      // and forces a flush).
+      'UNRELATED:foo::bar': {
+        count: 2,
+        taskCreated: false,
+        lastSeen: '2026-05-08',
+      },
+    });
+
+    const state = readState<State>('error-patterns.json', {});
+
+    // Resolve script runs out-of-band: stamps resolvedAt on the http entry.
+    writeStateFileDirect({
+      'TIMEOUT:silent_exit_void_http::callClaude': {
+        count: 3,
+        taskCreated: false,
+        lastSeen: '2026-05-08',
+        resolvedAt: '2026-05-08T17:43:30.000Z',
+        resolvedBy: '09a5ccc3',
+      },
+      'UNRELATED:foo::bar': {
+        count: 2,
+        taskCreated: false,
+        lastSeen: '2026-05-08',
+      },
+    });
+    bumpMtime(stateFile());
+
+    // Loop continues in this cycle: it has no work to do for the http entry,
+    // but it touches the unrelated entry and writeState/flush — pre-fix, that
+    // flush serialised the stale cache and stripped resolvedAt.
+    state['UNRELATED:foo::bar'].count = 4;
+    writeState('error-patterns.json', state);
+    flushFeedbackState();
+
+    const onDisk = JSON.parse(readFileSync(stateFile(), 'utf-8')) as State;
+    expect(onDisk['TIMEOUT:silent_exit_void_http::callClaude'].resolvedAt).toBe('2026-05-08T17:43:30.000Z');
+    expect(onDisk['TIMEOUT:silent_exit_void_http::callClaude'].resolvedBy).toBe('09a5ccc3');
+    expect(onDisk['UNRELATED:foo::bar'].count).toBe(4);
+  });
+
+  it('writeState then flush updates cache mtime so subsequent reads stay cache-hot', () => {
+    // Guard against a regression where mtime tracking forgets the post-flush
+    // mtime and causes spurious reloads (which would also drop in-flight changes
+    // by re-reading our just-written disk image).
+    writeStateFileDirect({});
+    readState<State>('error-patterns.json', {});
+
+    const next: State = {
+      'X:Y::Z': { count: 5, taskCreated: false, lastSeen: '2026-05-09' },
+    };
+    writeState('error-patterns.json', next);
+    flushFeedbackState();
+
+    // No out-of-band writer; same mtime should be respected as cache-hot.
+    const after = readState<State>('error-patterns.json', {});
+    expect(after['X:Y::Z'].count).toBe(5);
+    // And it must still be on disk identically.
+    const disk = JSON.parse(readFileSync(stateFile(), 'utf-8')) as State;
+    expect(disk['X:Y::Z'].count).toBe(5);
+  });
+});


### PR DESCRIPTION
## Summary
- Carries the **mtime-aware READ cache** fix (a4ad517a) currently riding inside PR #423 under a mis-scoped autocorrect title; this PR makes the #422 closure reviewable independently of the autocorrect mechanic.
- Adds 3 regression vitest cases for the stale-cache strip-and-revert that re-converged `silent_exit_void_http` on 2026-05-08T18:23Z (resolvedAt stamp wiped within ~9h).
- 2/3 tests pass against a4ad517a; the third **intentionally fails** to surface a remaining gap on the WRITE path — see Verification.

## Verification
- [x] `pnpm test tests/feedback-loops-error-patterns-resolution.test.ts` — 2 pass / 1 fail (failure is informative, not infrastructure)
- [x] Failing test: `flushFeedbackState does not clobber an out-of-band resolvedAt stamp`. Demonstrates the gap a4ad517a does NOT close: when in-process loop mutates one key and triggers `flushFeedbackState`, the entire cached state object is serialised back, dropping out-of-band keys (e.g. `resolvedAt` stamped by a separate `pnpm error-patterns:resolve` subprocess) that were added to disk after the in-process `readState`.
- [x] Reproduction matches live observation in `error-patterns.json` mtime 2026-05-09T03:04:30Z showing `resolvedAt=null` despite a stamped resolution at 2026-05-08T17:43:30Z.

## Closure path
Two options for closing #422 fully:
1. **Merge-on-flush:** before write, re-read disk if mtime advanced and merge non-mutated keys back into the cache snapshot.
2. **Per-key dirty tracking:** instead of dirty-flagging the whole file, track which keys the loop wrote this cycle, and only overwrite those keys (read others fresh from disk at flush time).

Option 2 is the cleaner long-term shape; option 1 is a smaller diff. Suggest merging this PR with the failing test exposed (so the gap is visible), then a follow-up PR closes it.

## Relation to PR #423
PR #423's commit a4ad517a is mislabelled "fix(runtime): preserve tracked runtime workspace changes" but its diff is the #422 cache fix. Recommend closing #423 as superseded once this PR lands, or splitting the autocorrect machinery into its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)