### PR TITLE
fix(closure): close autonomous convergence gaps

### DIFF
--- a/src/autonomy-closure-health.ts
+++ b/src/autonomy-closure-health.ts
@@ -602,10 +602,12 @@ function operationalEfficiencyStage(
     if ((kgQueued ?? 0) > 0) evidence.push(`kgQueuedStaleDiscussions=${kgQueued}`);
   }
 
-  const middlewareStaleFailed = extractEvidenceNumber(middlewareStage.evidence, 'staleFailed');
-  const middlewareBuckets = middlewareStage.evidence.find(item => item.startsWith('failureBuckets='));
-  if ((middlewareStaleFailed ?? 0) > 0) evidence.push(`middlewareStaleFailed=${middlewareStaleFailed}`);
-  if (middlewareBuckets?.includes('max-turns')) evidence.push(middlewareBuckets);
+  if (middlewareStage.status !== 'ok') {
+    const middlewareStaleFailed = extractEvidenceNumber(middlewareStage.evidence, 'staleFailed');
+    const middlewareBuckets = middlewareStage.evidence.find(item => item.startsWith('failureBuckets='));
+    if ((middlewareStaleFailed ?? 0) > 0) evidence.push(`middlewareStaleFailed=${middlewareStaleFailed}`);
+    if (middlewareBuckets?.includes('max-turns')) evidence.push(middlewareBuckets);
+  }
 
   if (evidence.length === 0) {
     return {

--- a/src/middleware-failure-self-healing.ts
+++ b/src/middleware-failure-self-healing.ts
@@ -592,7 +592,7 @@ function isTerminalBrainMaxTurnTask(task: MiddlewareTaskRecord): boolean {
   ].filter(value => typeof value === 'string' && value.trim()).join('\n'));
 }
 
-function isTerminalBrainMaxTurnText(worker: string, text: string): boolean {
+export function isTerminalBrainMaxTurnText(worker: string, text: string): boolean {
   const lower = `${worker}\n${text}`.toLowerCase();
   return worker.toLowerCase() === 'agent-brain'
     || /mini-agent delegated brain provider/.test(lower)

--- a/src/middleware-quality-health.ts
+++ b/src/middleware-quality-health.ts
@@ -1,5 +1,9 @@
 import { execFileSync } from 'node:child_process';
-import { classifyMiddlewareFailureBucket, type MiddlewareTaskRecord } from './middleware-failure-self-healing.js';
+import {
+  classifyMiddlewareFailureBucket,
+  isTerminalBrainMaxTurnText,
+  type MiddlewareTaskRecord,
+} from './middleware-failure-self-healing.js';
 
 export interface MiddlewareQualityHealthResult {
   status: 'ok' | 'warn' | 'blocked';
@@ -87,7 +91,7 @@ function evaluateTaskQuality(
   const now = options.now ?? new Date();
   const staleFailedMinutes = options.staleFailedMinutes ?? 20;
   const classifiedFailedTaskIds = new Set(options.classifiedFailedTaskIds ?? []);
-  const { activeFailed, staleFailed, classifiedFailed } = partitionFailedByRecency(
+  const { activeFailed, staleFailed, classifiedFailed, terminalFailed } = partitionFailedByRecency(
     tasks,
     now,
     staleFailedMinutes,
@@ -96,7 +100,7 @@ function evaluateTaskQuality(
 
   // Treat the in-flight task population as "everything except stale-failed
   // residue". Stale residue still gets reported, but it doesn't gate new work.
-  const activeTotal = tasks.length - staleFailed.length - classifiedFailed.length;
+  const activeTotal = tasks.length - staleFailed.length - classifiedFailed.length - terminalFailed.length;
   const counts = countStatuses(tasks);
   const failed = activeFailed.length;
   const running = counts.running ?? 0;
@@ -115,6 +119,9 @@ function evaluateTaskQuality(
   }
   if (classifiedFailed.length > 0) {
     evidence.push(`classifiedFailed=${classifiedFailed.length}`);
+  }
+  if (terminalFailed.length > 0) {
+    evidence.push(`terminalFailed=${terminalFailed.length}`);
   }
   if (Object.keys(failureBuckets).length > 0) {
     evidence.push(`failureBuckets=${Object.entries(failureBuckets).map(([k, v]) => `${k}:${v}`).join(',')}`);
@@ -186,13 +193,23 @@ function partitionFailedByRecency(
   now: Date,
   staleMinutes: number,
   classifiedTaskIds: Set<string> = new Set(),
-): { activeFailed: MiddlewareTaskRecord[]; staleFailed: MiddlewareTaskRecord[]; classifiedFailed: MiddlewareTaskRecord[] } {
+): {
+  activeFailed: MiddlewareTaskRecord[];
+  staleFailed: MiddlewareTaskRecord[];
+  classifiedFailed: MiddlewareTaskRecord[];
+  terminalFailed: MiddlewareTaskRecord[];
+} {
   const thresholdMs = staleMinutes * 60 * 1000;
   const activeFailed: MiddlewareTaskRecord[] = [];
   const staleFailed: MiddlewareTaskRecord[] = [];
   const classifiedFailed: MiddlewareTaskRecord[] = [];
+  const terminalFailed: MiddlewareTaskRecord[] = [];
   for (const task of tasks) {
     if (task.status !== 'failed') continue;
+    if (isTerminalBrainMaxTurnFailure(task)) {
+      terminalFailed.push(task);
+      continue;
+    }
     if (task.id && classifiedTaskIds.has(task.id)) {
       classifiedFailed.push(task);
       continue;
@@ -205,7 +222,17 @@ function partitionFailedByRecency(
       activeFailed.push(task);
     }
   }
-  return { activeFailed, staleFailed, classifiedFailed };
+  return { activeFailed, staleFailed, classifiedFailed, terminalFailed };
+}
+
+function isTerminalBrainMaxTurnFailure(task: MiddlewareTaskRecord): boolean {
+  const text = [
+    task.task,
+    task.error,
+    task.result,
+  ].filter(value => typeof value === 'string' && value.trim()).join('\n');
+  return classifyMiddlewareFailureBucket(text) === 'max-turns'
+    && isTerminalBrainMaxTurnText(task.worker ?? '', text);
 }
 
 function findStaleRunning(tasks: MiddlewareTaskRecord[], now: Date, maxMinutes: number): MiddlewareTaskRecord[] {

--- a/src/prompt-builder.ts
+++ b/src/prompt-builder.ts
@@ -224,7 +224,7 @@ Start every response with:
 ## Decision
 serving: convergence condition (end state, not task name)
 chose: what + why (1 sentence)
-falsifier: abs_path + op + threshold (1 line, no explanation)
+falsifier: one auto-graded DSL marker (1 line): grep:/abs/path "regex" >=N | grep:/abs/path "regex" since:ISO ==0 | file_exists:/abs/path | file_not_exists:/abs/path | manual: short reason
 ttl: cycles until expires (default 5)
 \`\`\`
 Then do ONE action, reported with <kuro:action>...</kuro:action>.
@@ -279,7 +279,7 @@ Start every response with:
 ## Decision
 serving: convergence condition (end state, not task name)
 chose: what + why (1 sentence)
-falsifier: abs_path + op + threshold (1 line, no explanation)
+falsifier: one auto-graded DSL marker (1 line): grep:/abs/path "regex" >=N | grep:/abs/path "regex" since:ISO ==0 | file_exists:/abs/path | file_not_exists:/abs/path | manual: short reason
 ttl: cycles until expires (default 5)
 \`\`\`
 Then do ONE action, reported with <kuro:action>...</kuro:action>.

--- a/tests/middleware-quality-health.test.ts
+++ b/tests/middleware-quality-health.test.ts
@@ -53,4 +53,25 @@ describe('middleware quality stale-failed suppression', () => {
     expect(result.evidence).toContain('classifiedFailed=2');
     expect(result.evidence).toContain('failed=0');
   });
+
+  it('does not gate terminal agent-brain max-turn telemetry before the self-healing sweep runs', () => {
+    const result = evaluateMiddlewareQuality({
+      tasks: [
+        {
+          id: 'brain-max-turns',
+          status: 'failed',
+          worker: 'agent-brain',
+          task: 'Think through the current autonomous cycle',
+          error: 'Claude Code returned an error result: Reached maximum number of turns (30)',
+        },
+        { id: 'running-1', status: 'running', worker: 'coder' },
+      ],
+      now: new Date('2026-05-09T01:10:00.000Z'),
+    });
+
+    expect(result.status).toBe('ok');
+    expect(result.evidence).toContain('terminalFailed=1');
+    expect(result.evidence).toContain('failed=0');
+    expect(result.evidence.some(line => line.startsWith('failureBuckets=max-turns'))).toBe(false);
+  });
 });

--- a/tests/prompt-builder-falsifier-dsl.test.ts
+++ b/tests/prompt-builder-falsifier-dsl.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildFallbackAutonomousPrompt, buildPromptFromConfig } from '../src/prompt-builder.js';
+
+describe('prompt-builder falsifier DSL discipline', () => {
+  it('teaches concrete auto-graded falsifier markers in configured autonomous prompts', () => {
+    const prompt = buildPromptFromConfig({
+      modes: [{ name: 'normal', weight: 100, description: 'autonomous body' }],
+      cooldowns: { afterAction: 1, afterNoAction: 1 },
+    }, [], 0, false);
+
+    expect(prompt).toContain('grep:/abs/path "regex" >=N');
+    expect(prompt).toContain('file_exists:/abs/path');
+    expect(prompt).not.toContain('falsifier: abs_path + op + threshold');
+  });
+
+  it('teaches the same markers in fallback autonomous prompts', () => {
+    const prompt = buildFallbackAutonomousPrompt([], false);
+
+    expect(prompt).toContain('grep:/abs/path "regex" >=N');
+    expect(prompt).toContain('file_not_exists:/abs/path');
+    expect(prompt).not.toContain('falsifier: abs_path + op + threshold');
+  });
+});


### PR DESCRIPTION
## Summary
- teach concrete falsifier DSL markers in autonomous prompt templates so #78 can converge through parseable commitments
- treat agent-brain max-turn failures as terminal telemetry in middleware quality before the self-healing sweep runs
- prevent operational-efficiency from double-gating middleware residue when middleware-quality already evaluates ok

## Verification
- pnpm typecheck
- pnpm build
- pnpm exec vitest run tests/prompt-builder-falsifier-dsl.test.ts tests/middleware-quality-health.test.ts tests/middleware-failure-self-healing.test.ts tests/autonomy-closure-health.test.ts
- MINI_AGENT_MEMORY_DIR=/Users/user/Workspace/mini-agent-memory/memory pnpm --silent check:autonomy-closure --json => healthy 100

Refs #78