### PR TITLE
fix(stash-governance): route managed deploy-backup append-only stashes to merge-append-union (#431)

### DIFF
--- a/src/stash-governance.ts
+++ b/src/stash-governance.ts
@@ -17,6 +17,7 @@ export type StashGovernanceDecision =
   | 'ignore'
   | 'drop-absorbed'
   | 'regenerate-generated-artifacts'
+  | 'merge-append-union'
   | 'manual-diagnostic';
 
 export interface StashGovernanceCase {
@@ -175,6 +176,32 @@ export function classifyStash(stash: GitStashRecord, reason = 'periodic-scan'): 
       rootCause: 'Stash is unrelated to autonomous runtime recovery.',
       evidence: [`reason=${reason}`, `message=${stash.message}`],
       mechanicalAction: 'none',
+      fallbackTask: null,
+    };
+  }
+
+  const onlyAppendUnion = assessment.manual.length === 0
+    && assessment.autoResolvable.length > 0
+    && assessment.autoResolvable.every(file => file.resolution === 'append-union');
+
+  if (isManagedStash(stash) && onlyAppendUnion) {
+    return {
+      id,
+      ts: new Date().toISOString(),
+      stashRef: stash.ref,
+      message: stash.message,
+      files: stash.files,
+      assessment,
+      decision: 'merge-append-union',
+      rootCause: 'Managed recovery stash contains only append-only memory files; safe to append-union and drop instead of opening a manual diagnose task.',
+      evidence: [
+        `trigger=${reason}`,
+        `stash=${stash.ref}`,
+        `message=${stash.message}`,
+        `files=${stash.files.join(',')}`,
+        'policy=managed deploy-backup with append-only conflicts auto-merges and drops; no fallback task needed',
+      ],
+      mechanicalAction: 'append-union-and-drop',
       fallbackTask: null,
     };
   }

--- a/tests/stash-governance.test.ts
+++ b/tests/stash-governance.test.ts
@@ -79,6 +79,43 @@ describe('stash governance', () => {
     }));
   });
 
+  it('routes managed deploy-backup with append-only memory conflicts to merge-append-union without a fallback task', () => {
+    const diagnostic = classifyStash(deployBackupAppendOnlyStash());
+
+    expect(diagnostic).toEqual(expect.objectContaining({
+      decision: 'merge-append-union',
+      mechanicalAction: 'append-union-and-drop',
+      fallbackTask: null,
+      rootCause: expect.stringContaining('append-only'),
+    }));
+    expect(diagnostic.assessment.manual).toHaveLength(0);
+    expect(diagnostic.assessment.autoResolvable.every(f => f.resolution === 'append-union')).toBe(true);
+  });
+
+  it('does not create scheduler tasks for managed deploy-backup append-only stashes (regression: phantom P1 loop)', async () => {
+    const memoryDir = path.join(tmpDir, 'memory');
+    mkdirSync(path.join(memoryDir, 'state'), { recursive: true });
+    mkdirSync(path.join(memoryDir, 'state', 'index'), { recursive: true });
+    writeFileSync(path.join(memoryDir, 'state', 'task-events.jsonl'), '', 'utf-8');
+    writeFileSync(path.join(memoryDir, 'state', 'index', 'relations.jsonl'), '', { encoding: 'utf-8', flag: 'w' });
+
+    const first = await governGitStashes(memoryDir, tmpDir, {
+      createTasks: true,
+      reason: 'test',
+      stashes: [deployBackupAppendOnlyStash()],
+    });
+    const second = await governGitStashes(memoryDir, tmpDir, {
+      createTasks: true,
+      reason: 'test',
+      stashes: [deployBackupAppendOnlyStash()],
+    });
+
+    expect(first.createdTasks).toHaveLength(0);
+    expect(second.createdTasks).toHaveLength(0);
+    expect(first.cases).toHaveLength(1);
+    expect(first.cases[0].decision).toBe('merge-append-union');
+  });
+
   it('closes active stash tasks when the underlying stash case disappears', async () => {
     const memoryDir = path.join(tmpDir, 'memory');
     mkdirSync(path.join(memoryDir, 'state'), { recursive: true });
@@ -118,5 +155,13 @@ function aiTrendStash(): GitStashRecord {
       'kuro-portfolio/ai-trend/index.html',
       'kuro-portfolio/ai-trend/preview.html',
     ],
+  };
+}
+
+function deployBackupAppendOnlyStash(): GitStashRecord {
+  return {
+    ref: 'stash@{0}',
+    message: 'On runtime/main: deploy-backup-20260508T165720Z',
+    files: ['memory/handoffs/active.md'],
   };
 }


### PR DESCRIPTION
## Summary
- Adds `merge-append-union` decision in `classifyStash()` for managed `runtime/main: deploy-backup-*` stashes whose conflicts are 100% auto-resolvable append-only memory (e.g. `memory/handoffs/active.md`).
- Returns `fallbackTask: null` so the periodic scan no longer regenerates a phantom P1 task on every run (3 instances on `stash-359368032b86` observed in 24h).
- Defers the mechanical `append-union-and-drop` executor to a follow-up so the safety classification lands first without churn risk on the production recovery flow.

Closes the bleed described in #431. The stash itself is left in `git stash list` until the executor follow-up — bounded and safe (one assessment-only entry per scan, no scheduler load).

## Verification
- [x] `pnpm test tests/stash-governance.test.ts tests/conflict-governance.test.ts` → 12/12 passing (2 new)
- [x] `pnpm typecheck` → clean
- [x] New test `routes managed deploy-backup with append-only memory conflicts to merge-append-union without a fallback task` covers the classifier branch
- [x] New test `does not create scheduler tasks for managed deploy-backup append-only stashes (regression: phantom P1 loop)` runs governGitStashes twice and asserts zero tasks created — the exact 24h regression
- [ ] Post-merge: confirm `grep '"decision":"manual-diagnostic"' .*deploy-backup` in `mini-agent-memory/memory/state/stash-governance.jsonl` produces no new lines after merge ts

## Falsifier
- `grep:mini-agent-memory/memory/state/stash-governance.jsonl "\"decision\":\"manual-diagnostic\".*deploy-backup" since:<merge-ts> ==0`
- `grep:mini-agent-memory/memory/state/task-events.jsonl "stash-359368032b86.*pending" since:<merge-ts> ==0`

Refs #431