### PR TITLE
feat(kuro-content): #436 step 1 — URL liveness check (HEAD→GET fallback)

### DIFF
--- a/scripts/build-kuro-content.mjs
+++ b/scripts/build-kuro-content.mjs
@@ -185,6 +185,63 @@ export function validate(content) {
   return issues;
 }
 
+// -- URL liveness check (#436) ----------------------------------------------
+/** Extract [text](url) links from the kuro-take section. Returns array of urls. */
+export function extractTakeUrls(content) {
+  const m = content.match(/## kuro-take([\s\S]*?)(?=\n## |\s*$)/);
+  if (!m) return [];
+  const body = m[1] || '';
+  const out = [];
+  const re = /\[[^\]]+\]\((https?:\/\/[^)\s]+)\)/g;
+  let mm;
+  while ((mm = re.exec(body)) !== null) out.push(mm[1]);
+  return out;
+}
+
+/**
+ * Check liveness of each URL: HEAD first, fall back to GET on 403/405/501.
+ * Returns { broken: [{url,status,reason}], warned: [{url,reason}] }.
+ *  - broken: 4xx/5xx (excluding HEAD-blocking 403/405/501) — gates the run
+ *  - warned: network/timeout errors — does NOT gate (avoid cron flake)
+ *
+ * Options: { fetchImpl, timeoutMs=5000, concurrency=8 }
+ */
+export async function checkUrlLiveness(urls, options = {}) {
+  const fetchImpl = options.fetchImpl || globalThis.fetch;
+  const timeoutMs = options.timeoutMs ?? 5000;
+  const broken = [];
+  const warned = [];
+  const seen = new Set();
+  const unique = urls.filter(u => { if (seen.has(u)) return false; seen.add(u); return true; });
+
+  async function probe(url, method) {
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+    try {
+      const res = await fetchImpl(url, { method, redirect: 'follow', signal: ctrl.signal });
+      return { status: res.status };
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  await Promise.all(unique.map(async (url) => {
+    try {
+      let r = await probe(url, 'HEAD');
+      if (r.status === 403 || r.status === 405 || r.status === 501) {
+        r = await probe(url, 'GET');
+      }
+      if (r.status >= 200 && r.status < 400) return; // ok
+      // 403/405/501 after GET fallback => treat as broken
+      broken.push({ url, status: r.status, reason: `HTTP ${r.status}` });
+    } catch (err) {
+      warned.push({ url, reason: err.name === 'AbortError' ? 'timeout' : (err.message || 'fetch-error') });
+    }
+  }));
+
+  return { broken, warned };
+}
+
 async function verifyWrittenArtifact(filePath, expectedDate) {
   const fileStat = await stat(filePath);
   if (!fileStat.isFile() || fileStat.size <= 0) {
@@ -382,17 +439,30 @@ async function main() {
 
   const _en=(generated.match(/[a-zA-Z][a-zA-Z'\-]*/g)||[]).length;const _cjk=(generated.match(/[\u4e00-\u9fff]/g)||[]).length;console.log(`[kuro-content] generated ${_en+Math.ceil(_cjk/1.6)} words (en=${_en} cjk=${_cjk})`);
 
-  // 6. Validation gate
+  // 6. Validation gate (sync structural) + URL liveness (async, #436)
   const validationErrors = validate(generated);
+  const takeUrls = extractTakeUrls(generated);
+  let urlCheck = { broken: [], warned: [] };
+  if (takeUrls.length > 0) {
+    try {
+      urlCheck = await checkUrlLiveness(takeUrls, { timeoutMs: 5000 });
+      console.log(`[kuro-content] url-liveness: checked=${takeUrls.length} broken=${urlCheck.broken.length} warned=${urlCheck.warned.length}`);
+      for (const w of urlCheck.warned) console.warn(`[kuro-content]   url-warn (non-blocking): ${w.url} — ${w.reason}`);
+      for (const b of urlCheck.broken) console.warn(`[kuro-content]   url-broken: ${b.url} — ${b.reason}`);
+    } catch (e) {
+      console.warn(`[kuro-content] url-liveness check threw: ${e.message} (treating as warn, not block)`);
+    }
+  }
+  const allFailures = [...validationErrors, ...urlCheck.broken.map(b => `broken-url: ${b.url} (${b.reason})`)];
   const outDir = join(STATE_DIR, 'kuro-content');
 
   if (!dryRun) {
     await mkdir(outDir, { recursive: true });
   }
 
-  if (validationErrors.length > 0) {
+  if (allFailures.length > 0) {
     console.warn('[kuro-content] VALIDATION FAILED:');
-    for (const e of validationErrors) console.warn(`  - ${e}`);
+    for (const e of allFailures) console.warn(`  - ${e}`);
     const draftPath = join(outDir, `${DATE}.md.draft`);
     if (!dryRun) {
       await writeFile(draftPath, generated, 'utf8');

--- a/tests/build-kuro-content-url-liveness.test.ts
+++ b/tests/build-kuro-content-url-liveness.test.ts
@@ -1,0 +1,82 @@
+// @ts-nocheck
+import { describe, expect, it, vi } from 'vitest';
+import { extractTakeUrls, checkUrlLiveness } from '../scripts/build-kuro-content.mjs';
+
+describe('build-kuro-content URL liveness (#436)', () => {
+  describe('extractTakeUrls', () => {
+    it('returns empty for missing kuro-take section', () => {
+      expect(extractTakeUrls('## other\n[a](https://x.com)')).toEqual([]);
+    });
+    it('extracts http(s) urls from kuro-take only', () => {
+      const c = `## kuro-take\nfoo [a](https://example.com/a) bar [b](http://x.io)\n## next\n[c](https://nope.com)`;
+      expect(extractTakeUrls(c)).toEqual(['https://example.com/a', 'http://x.io']);
+    });
+    it('skips relative/non-http links', () => {
+      const c = `## kuro-take\n[rel](/foo) [mailto](mailto:x@y) [ok](https://ok.com)`;
+      expect(extractTakeUrls(c)).toEqual(['https://ok.com']);
+    });
+  });
+
+  describe('checkUrlLiveness', () => {
+    function mkFetch(table: Record<string, { HEAD?: number; GET?: number; throws?: string }>) {
+      return vi.fn(async (url: string, opts: any) => {
+        const entry = table[url];
+        if (!entry) throw new Error('unmocked url ' + url);
+        if (entry.throws) { const e: any = new Error(entry.throws); e.name = entry.throws === 'timeout' ? 'AbortError' : 'TypeError'; throw e; }
+        const status = opts.method === 'HEAD' ? entry.HEAD : entry.GET;
+        if (status == null) throw new Error('no status for ' + opts.method);
+        return { status } as any;
+      });
+    }
+
+    it('passes when all HEADs return 200', async () => {
+      const fetchImpl = mkFetch({ 'https://a.com': { HEAD: 200 }, 'https://b.com': { HEAD: 301 } });
+      const r = await checkUrlLiveness(['https://a.com', 'https://b.com'], { fetchImpl });
+      expect(r.broken).toEqual([]);
+      expect(r.warned).toEqual([]);
+    });
+
+    it('falls back to GET on 403/405/501 and passes if GET 200', async () => {
+      const fetchImpl = mkFetch({ 'https://blocked.com': { HEAD: 403, GET: 200 } });
+      const r = await checkUrlLiveness(['https://blocked.com'], { fetchImpl });
+      expect(r.broken).toEqual([]);
+      expect(fetchImpl).toHaveBeenCalledTimes(2);
+    });
+
+    it('flags 4xx (other than 403/405/501) as broken', async () => {
+      const fetchImpl = mkFetch({ 'https://gone.com': { HEAD: 404 } });
+      const r = await checkUrlLiveness(['https://gone.com'], { fetchImpl });
+      expect(r.broken).toHaveLength(1);
+      expect(r.broken[0]).toMatchObject({ url: 'https://gone.com', status: 404 });
+    });
+
+    it('flags 5xx as broken', async () => {
+      const fetchImpl = mkFetch({ 'https://err.com': { HEAD: 500 } });
+      const r = await checkUrlLiveness(['https://err.com'], { fetchImpl });
+      expect(r.broken).toHaveLength(1);
+      expect(r.broken[0].status).toBe(500);
+    });
+
+    it('flags HEAD-blocking codes as broken if GET also fails', async () => {
+      const fetchImpl = mkFetch({ 'https://both.com': { HEAD: 403, GET: 403 } });
+      const r = await checkUrlLiveness(['https://both.com'], { fetchImpl });
+      expect(r.broken).toHaveLength(1);
+      expect(r.broken[0].status).toBe(403);
+    });
+
+    it('routes network errors to warned (non-blocking), not broken', async () => {
+      const fetchImpl = mkFetch({ 'https://oops.com': { throws: 'ENOTFOUND' } });
+      const r = await checkUrlLiveness(['https://oops.com'], { fetchImpl });
+      expect(r.broken).toEqual([]);
+      expect(r.warned).toHaveLength(1);
+      expect(r.warned[0].url).toBe('https://oops.com');
+    });
+
+    it('deduplicates repeated urls', async () => {
+      const fetchImpl = mkFetch({ 'https://dup.com': { HEAD: 200 } });
+      const r = await checkUrlLiveness(['https://dup.com', 'https://dup.com', 'https://dup.com'], { fetchImpl });
+      expect(r.broken).toEqual([]);
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
## What

Implements **acceptance criterion #2** from #436: URL liveness check for every `[text](url)` link in the kuro-take section.

- `extractTakeUrls(content)` — pulls http(s) URLs from `## kuro-take` only
- `checkUrlLiveness(urls, opts)` — HEAD first; falls back to GET on 403/405/501; deduplicates; 5s timeout per URL; concurrent
- Wired into `main()`: `broken` URLs join `validationErrors` → output goes to `<DATE>.md.draft`. `warned` (network/timeout errors) are logged but **non-blocking** (per #436 risk-mitigation: don't make cron flaky on infra)

## Tests

10 new tests (`tests/build-kuro-content-url-liveness.test.ts`):
- URL extraction: only `## kuro-take`, only http(s)
- HEAD 200/3xx pass
- HEAD 403/405/501 → GET fallback succeeds
- 4xx/5xx → broken
- HEAD-blocked + GET-blocked → broken
- Network/abort error → warned (non-blocking)
- Dedup: 3× same URL → 1 fetch

All 10 pass; existing 24 build-kuro-content tests still pass.

## Verification

```
$ ./node_modules/.bin/vitest run tests/build-kuro-content-url-liveness.test.ts tests/build-kuro-content.test.ts
Test Files  2 passed (2)
     Tests  34 passed (34)
```

## Out of scope (still in #436)

- Acceptance #1: GitHub `gh api repos/<owner>/<name>` cross-check on `license`/`forks_count`/`stargazers_count`
- Acceptance #3: cron heartbeat `[kuro-content] cron-tick <ISO>` written from wrapper before generator runs

These are independent and can ship as follow-up PRs against #436.

## Refs

- Closes (partially) #436 — acceptance #2
- Decomposed from #394 acceptance #2 quality-gap surface

🤖 Authored by Kuro autonomous cycle 03bbc29a (2026-05-09T11:42 TST)