### PR TITLE
feat(kuro-content): #436 step 2+3 — GitHub repo cross-check + cron heartbeat

### DIFF
--- a/scripts/build-kuro-content.mjs
+++ b/scripts/build-kuro-content.mjs
@@ -185,6 +185,66 @@ export function validate(content) {
   return issues;
 }
 
+// -- GitHub repo cross-check (#436 acceptance #1) ----------------------------
+/** Extract owner/repo from the `repo:` field. Returns null if absent/malformed. */
+export function extractRepoField(content) {
+  const m = content.match(/^repo:\s*([a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+)\s*$/m);
+  return m ? m[1].trim() : null;
+}
+
+/** Extract first `license:` field value from content. */
+export function extractLicenseField(content) {
+  const m = content.match(/^license:\s*(.+)$/m);
+  return m ? m[1].trim() : null;
+}
+
+/**
+ * Cross-check repo metadata via `gh api repos/<owner>/<repo>`.
+ * Returns { warnings: string[] } — never throws, never blocks the run.
+ *
+ * Options:
+ *   execImpl(cmd: string) => Promise<string>  — injectable for tests
+ */
+export async function checkRepoMetadata(content, options = {}) {
+  const warnings = [];
+  const repo = extractRepoField(content);
+  if (!repo) return { warnings };
+
+  let apiData;
+  try {
+    let raw;
+    if (options.execImpl) {
+      raw = await options.execImpl(`gh api repos/${repo}`);
+    } else {
+      const { spawnSync } = await import('node:child_process');
+      const r = spawnSync('gh', ['api', `repos/${repo}`], { encoding: 'utf8', timeout: 10_000 });
+      if (r.error) throw r.error;
+      if (r.status !== 0) throw new Error(`gh api exited ${r.status}: ${(r.stderr || '').slice(0, 200)}`);
+      raw = r.stdout;
+    }
+    apiData = JSON.parse(raw);
+  } catch (err) {
+    warnings.push(`gh-api-warn: ${err.message}`);
+    return { warnings };
+  }
+
+  // License cross-check
+  const contentLicense = extractLicenseField(content);
+  const apiLicense = apiData?.license?.spdx_id;
+  if (contentLicense && apiLicense && contentLicense !== apiLicense) {
+    warnings.push(`license-mismatch: content="${contentLicense}" api="${apiLicense}"`);
+  }
+
+  // Log actual forks/stars for reviewability (±10 tolerance; explicit fields not in template)
+  const forks = apiData?.forks_count ?? null;
+  const stars = apiData?.stargazers_count ?? null;
+  if (forks !== null) {
+    warnings.push(`repo-info: ${repo} forks=${forks} stars=${stars ?? '?'} (verify content is consistent, ±10 tolerance)`);
+  }
+
+  return { warnings };
+}
+
 // -- URL liveness check (#436) ----------------------------------------------
 /** Extract [text](url) links from the kuro-take section. Returns array of urls. */
 export function extractTakeUrls(content) {
@@ -439,7 +499,7 @@ async function main() {
 
   const _en=(generated.match(/[a-zA-Z][a-zA-Z'\-]*/g)||[]).length;const _cjk=(generated.match(/[\u4e00-\u9fff]/g)||[]).length;console.log(`[kuro-content] generated ${_en+Math.ceil(_cjk/1.6)} words (en=${_en} cjk=${_cjk})`);
 
-  // 6. Validation gate (sync structural) + URL liveness (async, #436)
+  // 6. Validation gate (sync structural) + URL liveness (#436 #2) + repo cross-check (#436 #1)
   const validationErrors = validate(generated);
   const takeUrls = extractTakeUrls(generated);
   let urlCheck = { broken: [], warned: [] };
@@ -452,6 +512,13 @@ async function main() {
     } catch (e) {
       console.warn(`[kuro-content] url-liveness check threw: ${e.message} (treating as warn, not block)`);
     }
+  }
+  // Repo cross-check (non-blocking — warn only)
+  try {
+    const repoCheck = await checkRepoMetadata(generated);
+    for (const w of repoCheck.warnings) console.warn(`[kuro-content]   ${w}`);
+  } catch (e) {
+    console.warn(`[kuro-content] repo-check threw: ${e.message} (non-blocking)`);
   }
   const allFailures = [...validationErrors, ...urlCheck.broken.map(b => `broken-url: ${b.url} (${b.reason})`)];
   const outDir = join(STATE_DIR, 'kuro-content');

--- a/scripts/launchd-wrappers/build-kuro-content.sh
+++ b/scripts/launchd-wrappers/build-kuro-content.sh
@@ -12,6 +12,10 @@ set -a
 . ./.env
 set +a
 export MINI_AGENT_MEMORY_DIR="${MINI_AGENT_MEMORY_DIR:-/Users/user/Workspace/mini-agent-memory/memory}"
+# Cron heartbeat (#436 acceptance #3): append tick before generator runs
+_LOG_DIR="${MINI_AGENT_MEMORY_DIR}/logs"
+mkdir -p "$_LOG_DIR"
+printf '[kuro-content] cron-tick %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$_LOG_DIR/build-kuro-content-launchd.log"
 # build-kuro-content.mjs returns:
 #   0 = wrote live <DATE>.md (gate passed)
 #   1 = hard error before output

--- a/tests/build-kuro-content-repo-check.test.ts
+++ b/tests/build-kuro-content-repo-check.test.ts
@@ -1,0 +1,104 @@
+// @ts-nocheck
+import { describe, expect, it } from 'vitest';
+import {
+  extractRepoField,
+  extractLicenseField,
+  checkRepoMetadata,
+} from '../scripts/build-kuro-content.mjs';
+
+const makeContent = (repo: string, license: string) =>
+  `---\ndate: 2026-05-09\nauthor: kuro\n---\n## github-spotlight\nrepo: ${repo}\nlicense: ${license}\nversion: 1.0\n`;
+
+describe('build-kuro-content GitHub repo cross-check (#436 acceptance #1)', () => {
+  describe('extractRepoField', () => {
+    it('extracts owner/repo from repo: line', () => {
+      expect(extractRepoField(makeContent('owner/name', 'MIT'))).toBe('owner/name');
+    });
+
+    it('returns null when no repo: field', () => {
+      expect(extractRepoField('## kuro-take\nsome content')).toBeNull();
+    });
+
+    it('rejects plain word without slash', () => {
+      expect(extractRepoField('repo: notarepo')).toBeNull();
+    });
+
+    it('handles dots and hyphens in owner and repo names', () => {
+      expect(extractRepoField('repo: my-org/my.repo\n')).toBe('my-org/my.repo');
+    });
+
+    it('handles underscores', () => {
+      expect(extractRepoField('repo: open_ai/whisper\n')).toBe('open_ai/whisper');
+    });
+  });
+
+  describe('extractLicenseField', () => {
+    it('extracts MIT', () => {
+      expect(extractLicenseField('license: MIT')).toBe('MIT');
+    });
+
+    it('extracts SPDX identifier style', () => {
+      expect(extractLicenseField('license: BSD-2-Clause')).toBe('BSD-2-Clause');
+    });
+
+    it('returns null when field is absent', () => {
+      expect(extractLicenseField('no license here')).toBeNull();
+    });
+  });
+
+  describe('checkRepoMetadata', () => {
+    it('warns on license mismatch', async () => {
+      const execImpl = async () =>
+        JSON.stringify({ license: { spdx_id: 'MIT' }, forks_count: 142, stargazers_count: 5000 });
+      const r = await checkRepoMetadata(makeContent('owner/repo', 'BSD-2-Clause'), { execImpl });
+      expect(r.warnings.some(w => w.includes('license-mismatch'))).toBe(true);
+      expect(r.warnings.some(w => w.includes('BSD-2-Clause') && w.includes('MIT'))).toBe(true);
+    });
+
+    it('no license-mismatch warning when licenses match', async () => {
+      const execImpl = async () =>
+        JSON.stringify({ license: { spdx_id: 'MIT' }, forks_count: 100, stargazers_count: 2000 });
+      const r = await checkRepoMetadata(makeContent('owner/repo', 'MIT'), { execImpl });
+      expect(r.warnings.some(w => w.includes('license-mismatch'))).toBe(false);
+    });
+
+    it('returns gh-api-warn on exec failure, does not throw', async () => {
+      const execImpl = async () => { throw new Error('network error'); };
+      const r = await checkRepoMetadata(makeContent('owner/repo', 'MIT'), { execImpl });
+      expect(r.warnings.some(w => w.includes('gh-api-warn'))).toBe(true);
+    });
+
+    it('returns empty warnings when no repo field', async () => {
+      const r = await checkRepoMetadata('no repo field here', {});
+      expect(r.warnings).toEqual([]);
+    });
+
+    it('handles null license in api response gracefully (no mismatch warning)', async () => {
+      const execImpl = async () =>
+        JSON.stringify({ license: null, forks_count: 0, stargazers_count: 0 });
+      const r = await checkRepoMetadata(makeContent('owner/repo', 'MIT'), { execImpl });
+      expect(r.warnings.some(w => w.includes('license-mismatch'))).toBe(false);
+    });
+
+    it('includes repo-info line with forks and stars', async () => {
+      const execImpl = async () =>
+        JSON.stringify({ license: { spdx_id: 'MIT' }, forks_count: 87, stargazers_count: 1234 });
+      const r = await checkRepoMetadata(makeContent('owner/repo', 'MIT'), { execImpl });
+      expect(r.warnings.some(w => w.includes('forks=87') && w.includes('stars=1234'))).toBe(true);
+    });
+
+    it('warns gh-api-warn on invalid JSON from api', async () => {
+      const execImpl = async () => 'not json at all';
+      const r = await checkRepoMetadata(makeContent('owner/repo', 'MIT'), { execImpl });
+      expect(r.warnings.some(w => w.includes('gh-api-warn'))).toBe(true);
+    });
+
+    it('does not warn license-mismatch when content has no license field', async () => {
+      const execImpl = async () =>
+        JSON.stringify({ license: { spdx_id: 'MIT' }, forks_count: 10, stargazers_count: 200 });
+      const content = '## github-spotlight\nrepo: owner/repo\nversion: 1.0\n';
+      const r = await checkRepoMetadata(content, { execImpl });
+      expect(r.warnings.some(w => w.includes('license-mismatch'))).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **Acceptance #1** (GitHub repo cross-check): `extractRepoField` + `extractLicenseField` + `checkRepoMetadata` added to `build-kuro-content.mjs`. On each run: extracts `repo:` field → calls `gh api repos/<owner>/<repo>` → warns on `license.spdx_id` mismatch + logs actual forks/stars for ±10 reviewability. API failure = warn-only, never blocks.
- **Acceptance #3** (cron heartbeat): `launchd-wrappers/build-kuro-content.sh` writes `[kuro-content] cron-tick <ISO>` to `$MINI_AGENT_MEMORY_DIR/logs/build-kuro-content-launchd.log` before the generator runs. `mkdir -p` ensures the directory always exists.
- Acceptance #2 (URL liveness) was completed in PR #440.

## Verification evidence

```
$ pnpm typecheck
✓ (0 errors)

$ pnpm test
Test Files  2 failed | 118 passed (120)
     Tests  2 failed | 982 passed | 2 skipped (986)
```

2 pre-existing failures in `feedback-loops-error-patterns-resolution.test.ts` and `auto-executor.test.ts` — unrelated to #436. 16 new tests added in `tests/build-kuro-content-repo-check.test.ts`, all pass.

## Test plan

- [x] `extractRepoField` — 5 tests (valid, missing, invalid, dots/hyphens, underscores)
- [x] `extractLicenseField` — 3 tests
- [x] `checkRepoMetadata` — 8 tests (license mismatch, match, api failure, no repo field, null license, forks/stars info, invalid JSON)
- [x] Wrapper script heartbeat format verified manually (`printf '[kuro-content] cron-tick %s\n'`)

Closes #436 (all 3 acceptance criteria addressed across PR #440 + this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)