### PR TITLE
fix(#438) step 1: outer caller-level rate gate for fast-band

### DIFF
--- a/src/feedback-loops.ts
+++ b/src/feedback-loops.ts
@@ -353,6 +353,48 @@ export function shouldFastFailFastBand(args: {
 }
 
 /**
+ * Issue #438: outer caller-level rate gate for fast-band failures.
+ *
+ * PR #339's `shouldFastFailFastBand` is a per-call breaker: it stops the in-call
+ * exp-backoff sleep when the upstream rejects in <10s. But it does not throttle
+ * the loop. When upstream is genuinely down for 30-60min the loop keeps invoking
+ * callClaude every cycle, every call hits fast-band, every call logs a separate
+ * occurrence (observed: 20 occurrences in a 72-min burst window 2026-05-09).
+ *
+ * This helper is meant to be checked by the caller BEFORE invoking callClaude on
+ * fast-band-prone paths. Returns true once the rolling-window count of recent
+ * fast-band failures crosses `maxInWindow`, signalling the loop to skip the call,
+ * surface a `slog('CIRCUIT', ...)` line, and back off (route to delegate / pause
+ * with cooldown / switch model).
+ *
+ * Tunable via env:
+ *   - KURO_FAST_BAND_WINDOW_MS  (default 5 * 60_000)
+ *   - KURO_FAST_BAND_WINDOW_MAX (default 5)
+ */
+export function shouldThrottleFastBandWindow(args: {
+  recentFailures: string[];
+  windowMs?: number;
+  maxInWindow?: number;
+  nowMs?: number;
+}): boolean {
+  const windowMs =
+    args.windowMs ?? (Number(process.env.KURO_FAST_BAND_WINDOW_MS) || 5 * 60_000);
+  const maxInWindow =
+    args.maxInWindow ?? (Number(process.env.KURO_FAST_BAND_WINDOW_MAX) || 5);
+  const now = args.nowMs ?? Date.now();
+  const cutoff = now - windowMs;
+  let inWindow = 0;
+  for (const ts of args.recentFailures) {
+    if (!ts) continue;
+    const t = Date.parse(ts);
+    if (!Number.isFinite(t)) continue;
+    if (t >= cutoff && t <= now) inWindow += 1;
+    if (inWindow >= maxInWindow) return true;
+  }
+  return false;
+}
+
+/**
  * 掃描今天的 error log，按 (code + subtype + context) 分群。
  * 同模式 >= 3 次 → 寫入 HEARTBEAT.md 作為 P1 task。
  * 已建過的模式不重複建。

--- a/tests/should-throttle-fast-band-window.test.ts
+++ b/tests/should-throttle-fast-band-window.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest';
+import { shouldThrottleFastBandWindow } from '../src/feedback-loops.js';
+
+// Issue #438: outer caller-level rate gate. PR #339's per-call breaker stops
+// in-call exp-backoff but does not throttle the loop, so a 30-60min upstream
+// outage produces 20+ separate fast-band occurrences (1 per cycle). This gate
+// is checked by the caller BEFORE invoking callClaude on fast-band-prone paths.
+describe('shouldThrottleFastBandWindow — outer rate gate (#438)', () => {
+  const NOW = Date.parse('2026-05-09T01:00:00.000Z');
+  const ago = (ms: number) => new Date(NOW - ms).toISOString();
+
+  it('does NOT trip below maxInWindow', () => {
+    const recentFailures = [ago(60_000), ago(120_000), ago(180_000)];
+    expect(
+      shouldThrottleFastBandWindow({
+        recentFailures,
+        windowMs: 5 * 60_000,
+        maxInWindow: 5,
+        nowMs: NOW,
+      }),
+    ).toBe(false);
+  });
+
+  it('trips at maxInWindow within window', () => {
+    const recentFailures = [
+      ago(10_000),
+      ago(60_000),
+      ago(120_000),
+      ago(180_000),
+      ago(240_000),
+    ];
+    expect(
+      shouldThrottleFastBandWindow({
+        recentFailures,
+        windowMs: 5 * 60_000,
+        maxInWindow: 5,
+        nowMs: NOW,
+      }),
+    ).toBe(true);
+  });
+
+  it('ignores failures outside the window', () => {
+    const recentFailures = [
+      ago(10_000),
+      ago(60_000),
+      ago(6 * 60_000), // outside 5-min window
+      ago(7 * 60_000),
+      ago(8 * 60_000),
+    ];
+    expect(
+      shouldThrottleFastBandWindow({
+        recentFailures,
+        windowMs: 5 * 60_000,
+        maxInWindow: 5,
+        nowMs: NOW,
+      }),
+    ).toBe(false);
+  });
+
+  it('handles empty list', () => {
+    expect(
+      shouldThrottleFastBandWindow({
+        recentFailures: [],
+        windowMs: 5 * 60_000,
+        maxInWindow: 5,
+        nowMs: NOW,
+      }),
+    ).toBe(false);
+  });
+
+  it('respects KURO_FAST_BAND_WINDOW_MS / KURO_FAST_BAND_WINDOW_MAX env overrides', () => {
+    const origWindow = process.env.KURO_FAST_BAND_WINDOW_MS;
+    const origMax = process.env.KURO_FAST_BAND_WINDOW_MAX;
+    try {
+      process.env.KURO_FAST_BAND_WINDOW_MS = String(2 * 60_000);
+      process.env.KURO_FAST_BAND_WINDOW_MAX = '3';
+      const recentFailures = [ago(10_000), ago(60_000), ago(90_000)];
+      expect(
+        shouldThrottleFastBandWindow({ recentFailures, nowMs: NOW }),
+      ).toBe(true);
+      // 4th & 5th outside the 2-min override window — only 2 inside.
+      const recentFailuresOutside = [
+        ago(10_000),
+        ago(60_000),
+        ago(3 * 60_000),
+      ];
+      expect(
+        shouldThrottleFastBandWindow({ recentFailures: recentFailuresOutside, nowMs: NOW }),
+      ).toBe(false);
+    } finally {
+      if (origWindow !== undefined) process.env.KURO_FAST_BAND_WINDOW_MS = origWindow;
+      else delete process.env.KURO_FAST_BAND_WINDOW_MS;
+      if (origMax !== undefined) process.env.KURO_FAST_BAND_WINDOW_MAX = origMax;
+      else delete process.env.KURO_FAST_BAND_WINDOW_MAX;
+    }
+  });
+
+  it('skips malformed timestamps without throwing', () => {
+    const recentFailures = [
+      ago(10_000),
+      'not-a-date',
+      ago(60_000),
+      '',
+      ago(120_000),
+    ];
+    expect(
+      shouldThrottleFastBandWindow({
+        recentFailures,
+        windowMs: 5 * 60_000,
+        maxInWindow: 5,
+        nowMs: NOW,
+      }),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `shouldThrottleFastBandWindow()` — pure helper, rolling 5-min / 5-failure window
- Step 1 of 2: helper + tests only. Step 2 wires it into the loop with `slog('CIRCUIT', ...)` + cooldown
- Unblocks #438 acceptance criterion 1

## Why
PR #339 (`shouldFastFailFastBand`) is a per-call breaker — stops the in-call 90s exp-backoff sleep when upstream rejects in <10s. It does **not** throttle the loop. When upstream is genuinely down for 30-60min, the loop keeps invoking `callClaude` every cycle, every call hits fast-band, every call logs a separate occurrence. Observed: 20 occurrences in a 72-min burst window 2026-05-09T00:04→01:16Z.

## Behavior
- Default: 5 failures in 5 minutes → throttle
- Tunable: `KURO_FAST_BAND_WINDOW_MS`, `KURO_FAST_BAND_WINDOW_MAX`
- Skips malformed/empty timestamps without throwing
- Pure function — caller passes recent failure timestamps + `nowMs`

## Verification
- [x] 6 unit tests pass: under-threshold no-trip, at-threshold trip, outside-window ignore, empty list, env overrides, malformed timestamp safety
- [x] `pnpm typecheck` clean
- [ ] Step 2 (separate PR): wire into caller, emit `slog('CIRCUIT', ...)`, ensure throttled-skip does not increment fast-band counter
- [ ] Step 2 falsifier: simulate 6 fast-band failures within 5min → 6th call returns throttled error without invoking child process

Refs #438 #339 #333

🤖 Generated with [Claude Code](https://claude.com/claude-code)