### PR TITLE
fix(runtime): preserve local runtime commit dirty-moxwbre7

### DIFF
--- a/src/loop.ts
+++ b/src/loop.ts
@@ -26,7 +26,7 @@ import type { AgentEvent } from './event-bus.js';
 import { perceptionStreams, IMPORTANT_PERCEPTION_NAMES } from './perception-stream.js';
 import { getCurrentInstanceId, getInstanceDir, loadInstanceConfig } from './instance.js';
 import { githubAutoActions } from './github.js';
-import { runFeedbackLoops, flushFeedbackState } from './feedback-loops.js';
+import { runFeedbackLoops, flushFeedbackState, shouldThrottleFastBandWindow, extractErrorSubtype } from './feedback-loops.js';
 import { runPulseCheck } from './pulse.js';
 import { runDailyPruning } from './context-pruner.js';
 import { mushiTriage, mushiContinuationCheck } from './mushi-client.js';


### PR DESCRIPTION
## Summary
- autocorrected 0 commit(s) that were made on protected runtime/main
- moved the change into an isolated worktree branch so review/merge/deploy can proceed normally
- reset the runtime checkout back to origin/main after preserving the change

## Verification
- [x] `git push -u origin fix/runtime-autocorrect-dirty-moxwbre7` passed; the runtime-local commit is preserved on an isolated review branch
- [x] `git reset --hard origin/main` passed; the protected runtime checkout was restored to origin/main