### PR TITLE
fix(#445) step 2: wire fast-band gate before callClaude (+ test seam)

### DIFF
--- a/src/feedback-loops.ts
+++ b/src/feedback-loops.ts
@@ -395,6 +395,21 @@ export function shouldThrottleFastBandWindow(args: {
 }
 
 /**
+ * Read recent fast-band failure timestamps from error-patterns.json (#445).
+ * Pure helper extracted from loop.ts wire so the gate read-path is unit-testable.
+ * Returns [] on missing/malformed state — caller should treat empty as "no throttle".
+ */
+export function readRecentFastBandFailures(stateDir: string): string[] {
+  const epPath = path.join(stateDir, 'error-patterns.json');
+  if (!existsSync(epPath)) return [];
+  try {
+    const raw = JSON.parse(readFileSync(epPath, 'utf8'));
+    const entry = raw['UNKNOWN:transient_fast_band::callClaude'] as { occurrences?: string[] } | undefined;
+    return entry?.occurrences ?? [];
+  } catch { return []; }
+}
+
+/**
  * 掃描今天的 error log，按 (code + subtype + context) 分群。
  * 同模式 >= 3 次 → 寫入 HEARTBEAT.md 作為 P1 task。
  * 已建過的模式不重複建。

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -2781,6 +2781,23 @@ export class AgentLoop {
         slog('MODEL', `→ Sonnet (${modelRoute.reason})`);
       }
 
+      // Issue #438 step 2: outer caller-level fast-band rate gate.
+      // Checked before callClaude so a sustained upstream outage (20+ fast-band hits in 72 min)
+      // does not produce a separate error-pattern occurrence per cycle.
+      // Throttled-skip returns null WITHOUT touching error-patterns.json, so the counter
+      // stays accurate (only real callClaude invocations count).
+      try {
+        const epPath = path.join(getMemoryStateDir(), 'error-patterns.json');
+        const epRaw = fs.existsSync(epPath) ? JSON.parse(fs.readFileSync(epPath, 'utf8')) : {};
+        const fastBandEntry = epRaw['UNKNOWN:transient_fast_band::callClaude'] as { occurrences?: string[] } | undefined;
+        const recentFailures = fastBandEntry?.occurrences ?? [];
+        if (shouldThrottleFastBandWindow({ recentFailures })) {
+          slog('CIRCUIT', `[fast-band-window] throttle tripped — skipping callClaude this cycle (${recentFailures.length} recent failures in ring buffer)`);
+          eventBus.emit('action:loop', { event: 'circuit.fast_band_throttled', cycleCount: this.cycleCount, recentFailuresCount: recentFailures.length });
+          return null;
+        }
+      } catch { /* best-effort: if state unreadable, proceed with callClaude normally */ }
+
       // Phase 2: Concurrent Action — run perception refresh + housekeeping during Claude await
       const concurrentPromise = isEnabled('concurrent-action')
         ? (() => {

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -26,7 +26,7 @@ import type { AgentEvent } from './event-bus.js';
 import { perceptionStreams, IMPORTANT_PERCEPTION_NAMES } from './perception-stream.js';
 import { getCurrentInstanceId, getInstanceDir, loadInstanceConfig } from './instance.js';
 import { githubAutoActions } from './github.js';
-import { runFeedbackLoops, flushFeedbackState, shouldThrottleFastBandWindow, extractErrorSubtype } from './feedback-loops.js';
+import { runFeedbackLoops, flushFeedbackState, shouldThrottleFastBandWindow, readRecentFastBandFailures, extractErrorSubtype } from './feedback-loops.js';
 import { runPulseCheck } from './pulse.js';
 import { runDailyPruning } from './context-pruner.js';
 import { mushiTriage, mushiContinuationCheck } from './mushi-client.js';
@@ -2787,10 +2787,7 @@ export class AgentLoop {
       // Throttled-skip returns null WITHOUT touching error-patterns.json, so the counter
       // stays accurate (only real callClaude invocations count).
       try {
-        const epPath = path.join(getMemoryStateDir(), 'error-patterns.json');
-        const epRaw = fs.existsSync(epPath) ? JSON.parse(fs.readFileSync(epPath, 'utf8')) : {};
-        const fastBandEntry = epRaw['UNKNOWN:transient_fast_band::callClaude'] as { occurrences?: string[] } | undefined;
-        const recentFailures = fastBandEntry?.occurrences ?? [];
+        const recentFailures = readRecentFastBandFailures(getMemoryStateDir());
         if (shouldThrottleFastBandWindow({ recentFailures })) {
           slog('CIRCUIT', `[fast-band-window] throttle tripped — skipping callClaude this cycle (${recentFailures.length} recent failures in ring buffer)`);
           eventBus.emit('action:loop', { event: 'circuit.fast_band_throttled', cycleCount: this.cycleCount, recentFailuresCount: recentFailures.length });

--- a/tests/read-recent-fast-band-failures.test.ts
+++ b/tests/read-recent-fast-band-failures.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { readRecentFastBandFailures } from '../src/feedback-loops.js';
+
+// Issue #445 step 2 acceptance #4: outer fast-band gate read-path is unit-testable.
+// Helper extracted from loop.ts wire so the gate's "read recent failures" logic
+// can be exercised without booting AgentLoop. Wire test (loop.ts:2789-2797) calls
+// this helper, then passes result to shouldThrottleFastBandWindow (already tested).
+describe('readRecentFastBandFailures — fast-band gate read-path (#445)', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(tmpdir(), 'kuro-fb-gate-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('returns [] when error-patterns.json is missing', () => {
+    expect(readRecentFastBandFailures(dir)).toEqual([]);
+  });
+
+  it('returns [] when error-patterns.json has no fast-band entry', () => {
+    writeFileSync(
+      path.join(dir, 'error-patterns.json'),
+      JSON.stringify({ 'TIMEOUT:dns_lookup_failed::callClaude': { occurrences: ['2026-05-09T01:00:00.000Z'] } }),
+    );
+    expect(readRecentFastBandFailures(dir)).toEqual([]);
+  });
+
+  it('returns occurrences array when fast-band entry present', () => {
+    const occurrences = [
+      '2026-05-09T01:00:00.000Z',
+      '2026-05-09T01:01:00.000Z',
+      '2026-05-09T01:02:00.000Z',
+    ];
+    writeFileSync(
+      path.join(dir, 'error-patterns.json'),
+      JSON.stringify({ 'UNKNOWN:transient_fast_band::callClaude': { occurrences } }),
+    );
+    expect(readRecentFastBandFailures(dir)).toEqual(occurrences);
+  });
+
+  it('returns [] when fast-band entry exists but has no occurrences field', () => {
+    writeFileSync(
+      path.join(dir, 'error-patterns.json'),
+      JSON.stringify({ 'UNKNOWN:transient_fast_band::callClaude': { count: 5 } }),
+    );
+    expect(readRecentFastBandFailures(dir)).toEqual([]);
+  });
+
+  it('returns [] on malformed JSON (gate stays open, fail-safe to callClaude)', () => {
+    writeFileSync(path.join(dir, 'error-patterns.json'), '{not valid json');
+    expect(readRecentFastBandFailures(dir)).toEqual([]);
+  });
+
+  it('returns [] when stateDir does not exist', () => {
+    expect(readRecentFastBandFailures(path.join(dir, 'does-not-exist'))).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Wire `shouldThrottleFastBandWindow` (#438 step 1, PR #443) into `AgentLoop` BEFORE `callClaude` (loop.ts:2789-2797). 20+ fast-band hits within 72 min no longer produce a separate error-pattern occurrence per cycle.
- Throttled-skip returns `null` WITHOUT mutating `error-patterns.json` (only real `callClaude` invocations count → no double-counting).
- Emits `slog('CIRCUIT', ...)` + `eventBus 'circuit.fast_band_throttled'` so the throttle is observable.
- Extract `readRecentFastBandFailures(stateDir)` seam from inline wire to make the read-path unit-testable.

## Acceptance (Issue #445)
- [x] Gate runs before `callClaude` — loop.ts:2789-2797 inside `AgentLoop` method (verified: `grep "shouldThrottleFastBandWindow(" src/loop.ts` → 2 hits: import + wire call)
- [x] Emits `slog('CIRCUIT', '[fast-band-window] throttle tripped — ...')` and `eventBus.emit('action:loop', { event: 'circuit.fast_band_throttled', ... })`
- [x] Throttled path returns `null` without touching `error-patterns.json` (avoids double-count)
- [x] Test coverage — `tests/read-recent-fast-band-failures.test.ts` (6 cases) covers all read-path branches: missing file, no entry, full entry, malformed JSON, missing occurrences field, non-existent stateDir

## Verification
- `pnpm build` → clean (tsc no errors)
- `pnpm vitest run tests/read-recent-fast-band-failures.test.ts` → 6/6 pass
- Regression: `pnpm vitest run tests/should-throttle-fast-band-window.test.ts tests/extract-error-subtype.test.ts` → 20/20 pass
- Branch ahead of `main` by 2 commits: `3b2880f6` (wire) + `eb39853f` (seam + test)

## Test plan
- [ ] Maintainer reviews wire placement (before `concurrent-action` block, after model routing — placed early so throttled cycle skips both Claude call AND concurrent action)
- [ ] Confirm `null` return from throttle path is handled by callers without raising "missing decision" alarms (existing `null` return paths in same method establish the contract)
- [ ] Optional: dry-run on prod by setting `KURO_FAST_BAND_WINDOW_MAX=2` to force trip on 2 recent failures, observe `[CIRCUIT]` log + `circuit.fast_band_throttled` event

Refs #445, follows #438 step 1 (PR #443)

🤖 Generated with [Claude Code](https://claude.com/claude-code)