### PR TITLE
fix(#439) step 1: shouldThrottleSlowBandWindow + readRecentSlowBandFailures

### DIFF
--- a/src/feedback-loops.ts
+++ b/src/feedback-loops.ts
@@ -410,6 +410,67 @@ export function readRecentFastBandFailures(stateDir: string): string[] {
 }
 
 /**
+ * Issue #439: outer caller-level rate gate for slow-band failures.
+ *
+ * Mirror of `shouldThrottleFastBandWindow` (#438) for the 10-59s slow-band tier.
+ * Slow-band attempts cost ~11s each with a 90s baseDelay between retries, so a
+ * single failed call burns ~5 minutes of wall-clock and budget. Without an outer
+ * gate, the loop retries the same shape every cycle and the bucket logs 10+
+ * occurrences in a 30-min window (observed UNKNOWN:transient_slow_band::callClaude
+ * 2026-05-09T00:08-00:37Z, issue #439).
+ *
+ * Returns true once the rolling-window count of recent slow-band failures
+ * crosses `maxInWindow`, signalling the loop to skip the call (route to delegate /
+ * pause with cooldown / surface a `slog('CIRCUIT', ...)` line) rather than
+ * paying for another 5-minute deterministic failure.
+ *
+ * Tunable via env:
+ *   - KURO_SLOW_BAND_WINDOW_MS  (default 5 * 60_000)
+ *   - KURO_SLOW_BAND_WINDOW_MAX (default 3, since each slow-band call costs ~5min
+ *     and 3 same-shape failures inside one window proves the upstream isn't
+ *     time-sensitive — "wait it out" doesn't apply).
+ */
+export function shouldThrottleSlowBandWindow(args: {
+  recentFailures: string[];
+  windowMs?: number;
+  maxInWindow?: number;
+  nowMs?: number;
+}): boolean {
+  const windowMs =
+    args.windowMs ?? (Number(process.env.KURO_SLOW_BAND_WINDOW_MS) || 5 * 60_000);
+  const maxInWindow =
+    args.maxInWindow ?? (Number(process.env.KURO_SLOW_BAND_WINDOW_MAX) || 3);
+  const now = args.nowMs ?? Date.now();
+  const cutoff = now - windowMs;
+  let inWindow = 0;
+  for (const ts of args.recentFailures) {
+    if (!ts) continue;
+    const t = Date.parse(ts);
+    if (!Number.isFinite(t)) continue;
+    if (t >= cutoff && t <= now) inWindow += 1;
+    if (inWindow >= maxInWindow) return true;
+  }
+  return false;
+}
+
+/**
+ * Read recent slow-band failure timestamps from error-patterns.json (#439).
+ * Mirror of readRecentFastBandFailures (#445) — pure helper so the gate
+ * read-path is unit-testable without booting AgentLoop.
+ * Returns [] on missing/malformed state — caller treats empty as "no throttle"
+ * (fail-safe to callClaude, matches fast-band gate semantics).
+ */
+export function readRecentSlowBandFailures(stateDir: string): string[] {
+  const epPath = path.join(stateDir, 'error-patterns.json');
+  if (!existsSync(epPath)) return [];
+  try {
+    const raw = JSON.parse(readFileSync(epPath, 'utf8'));
+    const entry = raw['UNKNOWN:transient_slow_band::callClaude'] as { occurrences?: string[] } | undefined;
+    return entry?.occurrences ?? [];
+  } catch { return []; }
+}
+
+/**
  * 掃描今天的 error log，按 (code + subtype + context) 分群。
  * 同模式 >= 3 次 → 寫入 HEARTBEAT.md 作為 P1 task。
  * 已建過的模式不重複建。

--- a/tests/read-recent-slow-band-failures.test.ts
+++ b/tests/read-recent-slow-band-failures.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { readRecentSlowBandFailures } from '../src/feedback-loops.js';
+
+// Issue #439: slow-band gate read-path, mirroring readRecentFastBandFailures (#445).
+// Helper extracted so the gate's "read recent failures" logic can be exercised
+// without booting AgentLoop. The gate consumes the timestamps from
+// error-patterns.json[UNKNOWN:transient_slow_band::callClaude].occurrences
+// and feeds them to shouldThrottleSlowBandWindow.
+describe('readRecentSlowBandFailures — slow-band gate read-path (#439)', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(tmpdir(), 'kuro-sb-gate-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('returns [] when error-patterns.json is missing', () => {
+    expect(readRecentSlowBandFailures(dir)).toEqual([]);
+  });
+
+  it('returns [] when error-patterns.json has no slow-band entry', () => {
+    writeFileSync(
+      path.join(dir, 'error-patterns.json'),
+      JSON.stringify({ 'UNKNOWN:transient_fast_band::callClaude': { occurrences: ['2026-05-09T01:00:00.000Z'] } }),
+    );
+    expect(readRecentSlowBandFailures(dir)).toEqual([]);
+  });
+
+  it('returns occurrences array when slow-band entry present', () => {
+    const occurrences = [
+      '2026-05-09T00:08:39.265Z',
+      '2026-05-09T00:18:00.000Z',
+      '2026-05-09T00:37:19.559Z',
+    ];
+    writeFileSync(
+      path.join(dir, 'error-patterns.json'),
+      JSON.stringify({ 'UNKNOWN:transient_slow_band::callClaude': { occurrences } }),
+    );
+    expect(readRecentSlowBandFailures(dir)).toEqual(occurrences);
+  });
+
+  it('returns [] when slow-band entry exists but has no occurrences field', () => {
+    writeFileSync(
+      path.join(dir, 'error-patterns.json'),
+      JSON.stringify({ 'UNKNOWN:transient_slow_band::callClaude': { count: 10 } }),
+    );
+    expect(readRecentSlowBandFailures(dir)).toEqual([]);
+  });
+
+  it('returns [] on malformed JSON (gate stays open, fail-safe to callClaude)', () => {
+    writeFileSync(path.join(dir, 'error-patterns.json'), '{not valid json');
+    expect(readRecentSlowBandFailures(dir)).toEqual([]);
+  });
+
+  it('returns [] when stateDir does not exist', () => {
+    expect(readRecentSlowBandFailures(path.join(dir, 'does-not-exist'))).toEqual([]);
+  });
+});

--- a/tests/should-throttle-slow-band-window.test.ts
+++ b/tests/should-throttle-slow-band-window.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vitest';
+import { shouldThrottleSlowBandWindow } from '../src/feedback-loops.js';
+
+// Issue #439: outer caller-level rate gate for slow-band, mirroring the
+// #438/#445 pattern for fast-band. Slow-band attempts are ~11s each with a 90s
+// baseDelay between retries, so 3 consecutive same-shape failures consume
+// ~5 minutes of wall-clock and ~5 minutes of budget. Without an outer gate,
+// the loop happily retries the next cycle and the bucket logs 10+ occurrences
+// in a 30-min window (observed 2026-05-09T00:08-00:37Z).
+//
+// Defaults are tuned to the observed cadence: ≥3 same-band failures inside a
+// 5-min wall-clock window indicates the upstream isn't time-sensitive and
+// "wait 90s" won't help — the caller should short-circuit the lane.
+describe('shouldThrottleSlowBandWindow — outer rate gate (#439)', () => {
+  const NOW = Date.parse('2026-05-09T01:00:00.000Z');
+  const ago = (ms: number) => new Date(NOW - ms).toISOString();
+
+  it('does NOT trip below maxInWindow', () => {
+    const recentFailures = [ago(60_000), ago(120_000)];
+    expect(
+      shouldThrottleSlowBandWindow({
+        recentFailures,
+        windowMs: 5 * 60_000,
+        maxInWindow: 3,
+        nowMs: NOW,
+      }),
+    ).toBe(false);
+  });
+
+  it('trips at maxInWindow within window', () => {
+    const recentFailures = [ago(10_000), ago(60_000), ago(120_000)];
+    expect(
+      shouldThrottleSlowBandWindow({
+        recentFailures,
+        windowMs: 5 * 60_000,
+        maxInWindow: 3,
+        nowMs: NOW,
+      }),
+    ).toBe(true);
+  });
+
+  it('ignores failures outside the window', () => {
+    const recentFailures = [
+      ago(10_000),
+      ago(6 * 60_000), // outside 5-min window
+      ago(7 * 60_000),
+    ];
+    expect(
+      shouldThrottleSlowBandWindow({
+        recentFailures,
+        windowMs: 5 * 60_000,
+        maxInWindow: 3,
+        nowMs: NOW,
+      }),
+    ).toBe(false);
+  });
+
+  it('handles empty list', () => {
+    expect(
+      shouldThrottleSlowBandWindow({
+        recentFailures: [],
+        windowMs: 5 * 60_000,
+        maxInWindow: 3,
+        nowMs: NOW,
+      }),
+    ).toBe(false);
+  });
+
+  it('respects KURO_SLOW_BAND_WINDOW_MS / KURO_SLOW_BAND_WINDOW_MAX env overrides', () => {
+    const origWindow = process.env.KURO_SLOW_BAND_WINDOW_MS;
+    const origMax = process.env.KURO_SLOW_BAND_WINDOW_MAX;
+    try {
+      process.env.KURO_SLOW_BAND_WINDOW_MS = String(2 * 60_000);
+      process.env.KURO_SLOW_BAND_WINDOW_MAX = '2';
+      const recentFailures = [ago(10_000), ago(60_000)];
+      expect(
+        shouldThrottleSlowBandWindow({ recentFailures, nowMs: NOW }),
+      ).toBe(true);
+      // 2nd is outside the 2-min override window — only 1 inside.
+      const recentFailuresOutside = [ago(10_000), ago(3 * 60_000)];
+      expect(
+        shouldThrottleSlowBandWindow({ recentFailures: recentFailuresOutside, nowMs: NOW }),
+      ).toBe(false);
+    } finally {
+      if (origWindow !== undefined) process.env.KURO_SLOW_BAND_WINDOW_MS = origWindow;
+      else delete process.env.KURO_SLOW_BAND_WINDOW_MS;
+      if (origMax !== undefined) process.env.KURO_SLOW_BAND_WINDOW_MAX = origMax;
+      else delete process.env.KURO_SLOW_BAND_WINDOW_MAX;
+    }
+  });
+
+  it('skips malformed timestamps without throwing', () => {
+    const recentFailures = [
+      ago(10_000),
+      'not-a-date',
+      ago(60_000),
+      '',
+      ago(120_000),
+    ];
+    expect(
+      shouldThrottleSlowBandWindow({
+        recentFailures,
+        windowMs: 5 * 60_000,
+        maxInWindow: 3,
+        nowMs: NOW,
+      }),
+    ).toBe(true); // 3 valid timestamps inside the window
+  });
+
+  it('default thresholds (no env, no args) hold a single same-shape burst <3', () => {
+    // Sanity: defaults are KURO_SLOW_BAND_WINDOW_MS=5*60_000, MAX=3.
+    // Two same-cycle attempts should not trip; the gate is for cross-cycle waste.
+    const recentFailures = [ago(10_000), ago(90_000)];
+    expect(shouldThrottleSlowBandWindow({ recentFailures, nowMs: NOW })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `shouldThrottleSlowBandWindow` + `readRecentSlowBandFailures` in `src/feedback-loops.ts` — the slow-band twin of the #438/#445 fast-band rate gate.
- 13 unit tests (7 + 6) covering threshold logic, env overrides, malformed input, fail-safe semantics. All green; 2 unrelated pre-existing failures on `main` (`auto-executor.test.ts`, `feedback-loops-error-patterns-resolution.test.ts`) are not touched by this PR.
- **No wire yet** — step 1 is the pure helpers. Step 2 will gate `callClaude` on slow-band-prone paths in `loop.ts` and emit a `slog('CIRCUIT', ...)` line on trip, mirroring `loop.ts:2790-2797`.

## Why

`error-patterns.json[UNKNOWN:transient_slow_band::callClaude]` logged **10 occurrences in 29 minutes** on 2026-05-09T00:08-00:37Z. All 10 shared the same shape: prompt 36599 chars, attempt 3/3, ~306s total, dur=11s. Each call burned ~5min of wall-clock + budget on a deterministic failure that 90s baseDelay couldn't fix — same anti-pattern as #333/#339, just one tier up.

Defaults are tuned tighter than fast-band (`MAX=3` vs `5`, same `WINDOW=5min`) because each slow-band call costs ~5min — 3 same-shape failures inside one window already proves "wait it out" doesn't apply.

## Test plan

- [x] `npx vitest run tests/should-throttle-slow-band-window.test.ts tests/read-recent-slow-band-failures.test.ts` — 13/13 pass
- [x] `pnpm typecheck` — clean
- [x] Full `pnpm test` — same 2 pre-existing failures as `main` baseline (unrelated)
- [ ] Step 2 (separate PR): wire into `loop.ts` before `callClaude` on slow-band-prone paths, then watch `error-patterns.json[UNKNOWN:transient_slow_band::callClaude].lastSeen` for 7 days post-ship per the #439 falsifier.

## Verification

- `grep:src/feedback-loops.ts "shouldThrottleSlowBandWindow" >=1`
- `grep:src/feedback-loops.ts "readRecentSlowBandFailures" >=1`
- `grep:src/feedback-loops.ts "UNKNOWN:transient_slow_band::callClaude" >=1`
- `file_exists:tests/should-throttle-slow-band-window.test.ts`
- `file_exists:tests/read-recent-slow-band-failures.test.ts`

Closes-step-of #439

🤖 Generated with [Claude Code](https://claude.com/claude-code)