### PR TITLE
fix(#439) step 2: wire shouldThrottleSlowBandWindow gate before callClaude

### DIFF
--- a/src/loop.ts
+++ b/src/loop.ts
@@ -26,7 +26,7 @@ import type { AgentEvent } from './event-bus.js';
 import { perceptionStreams, IMPORTANT_PERCEPTION_NAMES } from './perception-stream.js';
 import { getCurrentInstanceId, getInstanceDir, loadInstanceConfig } from './instance.js';
 import { githubAutoActions } from './github.js';
-import { runFeedbackLoops, flushFeedbackState, shouldThrottleFastBandWindow, readRecentFastBandFailures, extractErrorSubtype } from './feedback-loops.js';
+import { runFeedbackLoops, flushFeedbackState, shouldThrottleFastBandWindow, readRecentFastBandFailures, shouldThrottleSlowBandWindow, readRecentSlowBandFailures, extractErrorSubtype } from './feedback-loops.js';
 import { runPulseCheck } from './pulse.js';
 import { runDailyPruning } from './context-pruner.js';
 import { mushiTriage, mushiContinuationCheck } from './mushi-client.js';
@@ -2791,6 +2791,22 @@ export class AgentLoop {
         if (shouldThrottleFastBandWindow({ recentFailures })) {
           slog('CIRCUIT', `[fast-band-window] throttle tripped — skipping callClaude this cycle (${recentFailures.length} recent failures in ring buffer)`);
           eventBus.emit('action:loop', { event: 'circuit.fast_band_throttled', cycleCount: this.cycleCount, recentFailuresCount: recentFailures.length });
+          return null;
+        }
+      } catch { /* best-effort: if state unreadable, proceed with callClaude normally */ }
+
+      // Issue #439 step 2: outer caller-level slow-band rate gate.
+      // Mirror of #438/#445 fast-band gate, tighter defaults (MAX=3 vs 5) because each
+      // slow-band call costs ~11s + 90s baseDelay × 3 retries ≈ 5min wall-clock. 3
+      // same-shape failures in 5min already proves the upstream isn't time-sensitive
+      // — "wait it out" doesn't apply (issue #439, observed 10× burst 2026-05-09).
+      // Throttled-skip returns null WITHOUT touching error-patterns.json so the counter
+      // stays accurate (only real callClaude invocations count).
+      try {
+        const recentSlowFailures = readRecentSlowBandFailures(getMemoryStateDir());
+        if (shouldThrottleSlowBandWindow({ recentFailures: recentSlowFailures })) {
+          slog('CIRCUIT', `[slow-band-window] throttle tripped — skipping callClaude this cycle (${recentSlowFailures.length} recent failures in ring buffer)`);
+          eventBus.emit('action:loop', { event: 'circuit.slow_band_throttled', cycleCount: this.cycleCount, recentFailuresCount: recentSlowFailures.length });
           return null;
         }
       } catch { /* best-effort: if state unreadable, proceed with callClaude normally */ }


### PR DESCRIPTION
## Summary

- Wires the slow-band gate (`shouldThrottleSlowBandWindow` + `readRecentSlowBandFailures`, shipped in PR #447) into `loop.ts` right after the fast-band gate (`loop.ts:2798-2811`).
- Pure mirror of the fast-band step 2 wire (commit 3b2880f6 / PR #446) with tighter defaults (MAX=3 vs 5).
- No new tests — pure helpers were tested in step 1 (#447, 13 tests). Wire is a 17-line copy of an already-deployed pattern.

## Why

Step 1 (#447) shipped the helpers; step 2 closes the loop. Without the wire, `transient_slow_band` still re-fires every cycle on the same deterministic shape, burning ~5min/call. This is the second tier of the #333/#339 "wait it out doesn't apply" pattern.

Defaults: `KURO_SLOW_BAND_WINDOW_MS=300_000` (5min) / `KURO_SLOW_BAND_WINDOW_MAX=3`. Tighter MAX than fast-band because each slow-band call already costs ~5min.

## Throttled-skip semantics

Returns `null` from `callClaudeWithRetry` WITHOUT touching `error-patterns.json` — only real callClaude invocations count, so the gate doesn't loop on its own counter (matches fast-band).

## Test plan

- [x] `npx vitest run tests/should-throttle-slow-band-window.test.ts tests/read-recent-slow-band-failures.test.ts tests/should-throttle-fast-band-window.test.ts tests/read-recent-fast-band-failures.test.ts` — 25/25 pass
- [x] `pnpm typecheck` — clean
- [ ] Post-ship monitoring: `error-patterns.json[UNKNOWN:transient_slow_band::callClaude].lastSeen` does not advance past 2026-05-16, per #439 falsifier.

## Verification

- `grep:src/loop.ts "shouldThrottleSlowBandWindow" >=1`
- `grep:src/loop.ts "readRecentSlowBandFailures" >=1`
- `grep:src/loop.ts "circuit.slow_band_throttled" >=1`
- `grep:src/loop.ts "slow-band-window" >=1`

Closes-step-of #439

🤖 Generated with [Claude Code](https://claude.com/claude-code)