### PR TITLE
fix(prompt): #78 drop unparseable 'manual:' falsifier — stop expired-unverified spiral

### DIFF
--- a/src/prompt-builder.ts
+++ b/src/prompt-builder.ts
@@ -224,7 +224,7 @@ Start every response with:
 ## Decision
 serving: convergence condition (end state, not task name)
 chose: what + why (1 sentence)
-falsifier: one auto-graded DSL marker (1 line): grep:/abs/path "regex" >=N | grep:/abs/path "regex" since:ISO ==0 | file_exists:/abs/path | file_not_exists:/abs/path | manual: short reason
+falsifier: one auto-graded DSL marker (1 line, no prose): grep:/abs/path "regex" >=N | grep:/abs/path "regex" since:ISO ==0 | file_exists:/abs/path | file_not_exists:/abs/path  (Prose like "manual:..." or "abs_path X >=N" silently no-ops — parser at commitment-ledger.ts:308 returns undefined → resolver skips → entry expires unverified, see #78)
 ttl: cycles until expires (default 5)
 \`\`\`
 Then do ONE action, reported with <kuro:action>...</kuro:action>.
@@ -279,7 +279,7 @@ Start every response with:
 ## Decision
 serving: convergence condition (end state, not task name)
 chose: what + why (1 sentence)
-falsifier: one auto-graded DSL marker (1 line): grep:/abs/path "regex" >=N | grep:/abs/path "regex" since:ISO ==0 | file_exists:/abs/path | file_not_exists:/abs/path | manual: short reason
+falsifier: one auto-graded DSL marker (1 line, no prose): grep:/abs/path "regex" >=N | grep:/abs/path "regex" since:ISO ==0 | file_exists:/abs/path | file_not_exists:/abs/path  (Prose like "manual:..." or "abs_path X >=N" silently no-ops — parser at commitment-ledger.ts:308 returns undefined → resolver skips → entry expires unverified, see #78)
 ttl: cycles until expires (default 5)
 \`\`\`
 Then do ONE action, reported with <kuro:action>...</kuro:action>.


### PR DESCRIPTION
## Summary

Removes `manual: short reason` from the falsifier DSL list in both `buildAutonomousPrompt` and `buildFallbackAutonomousPrompt`. The parser at `commitment-ledger.ts:308` (`parseFalsifierToQuery`) only handles `grep:/file_exists:/file_not_exists:` — `manual:` always falls through to `undefined`, so `falsifier_query` is never populated, the resolver in `buildLedgerSection` skips the entry, and it expires unverified on TTL.

## Evidence (live ledger today)

Probed `mini-agent-memory/memory/state/commitments.jsonl` via the actual `getMemoryStateDir()` resolver this cycle (2026-05-09):

```
UNIQUE_IDS: 2011  LINES: 5766
STATUS: {expired: 686, abandoned: 1312, kept: 2, resolved: 3, refuted: 6}
LAST20_KEPT_OR_REFUTED: 2/20
LAST20_STATUSES: 18× expired, 2× refuted (all created today)
```

Sampled today's expired entries — 9 out of 10 use the same `manual: GET /api/dashboard/autonomy-closure shows no blocking stages` prose. This is the **direct source of the `PERFORMATIVE SKEPTICISM: execution rate <30%` warning** appearing in every cycle prompt.

## Why removal vs. parser extension

`manual:` semantically means "I'll check by hand" — even if the parser accepted it, the resolver has no way to auto-resolve it. Adding it to the parser would just make the no-op explicit. Removing it from the prompt forces the agent to either commit to a parseable DSL form or admit no falsifier was set.

## Verification

- Falsifier (eating own dogfood):
  ```
  grep:/Users/user/Workspace/mini-agent/src/prompt-builder.ts "manual: short reason" ==0
  ```
- Backtest: next 20 commitments after this lands should drop expired-rate from 90% to <30% (auto-graded by `auditCommitments`).

## Test plan

- [ ] CI passes (no logic change — string literal only)
- [ ] `grep "manual: short reason" src/prompt-builder.ts` returns 0 hits
- [ ] After deploy, watch ledger for next 20 entries: expected expired-rate <30%

Closes part of #78 (prompt side; resolver/parser side may need follow-up if `cl-11`-style directory-grep DSL also fails to resolve).

🤖 Generated with [Claude Code](https://claude.com/claude-code)