### PR TITLE
fix(sdk): sanitize surrogates at perception-analyzer + context-pruner SDK call sites (#454)

### DIFF
--- a/src/context-pruner.ts
+++ b/src/context-pruner.ts
@@ -9,6 +9,7 @@
  */
 
 import Anthropic from '@anthropic-ai/sdk';
+import { sanitizeUnpairedSurrogates } from './sanitize.js';
 import fs from 'node:fs';
 import path from 'node:path';
 import { slog } from './utils.js';
@@ -134,6 +135,7 @@ export function parsePruningProposal(response: string): PruningProposal {
 // =============================================================================
 
 async function callHaiku(prompt: string): Promise<string> {
+  prompt = sanitizeUnpairedSurrogates(prompt);
   const response = await getClient().messages.create({
     model: HAIKU_MODEL,
     max_tokens: 4096,

--- a/src/perception-analyzer.ts
+++ b/src/perception-analyzer.ts
@@ -10,6 +10,7 @@
  */
 
 import Anthropic from '@anthropic-ai/sdk';
+import { sanitizeUnpairedSurrogates } from './sanitize.js';
 import { slog } from './utils.js';
 import type { PerceptionResult } from './perception.js';
 import type { PerceptionInsight, SituationReport } from './types.js';
@@ -78,7 +79,7 @@ async function analyzeOne(result: PerceptionResult): Promise<PerceptionInsight> 
 
   try {
     const prompt = ANALYSIS_PROMPTS[result.name] ?? FALLBACK_PROMPT;
-    const userMessage = `<raw_output plugin="${result.name}">\n${result.output}\n</raw_output>\n\n${prompt}`;
+    const userMessage = sanitizeUnpairedSurrogates(`<raw_output plugin="${result.name}">\n${result.output}\n</raw_output>\n\n${prompt}`);
 
     const response = await getClient().messages.create({
       model: HAIKU_MODEL,

--- a/src/sanitize.ts
+++ b/src/sanitize.ts
@@ -1,0 +1,16 @@
+/**
+ * Surrogate sanitization for direct Anthropic SDK callers in mini-agent.
+ *
+ * Mirrors `agent-middleware/src/sdk-provider.ts:sanitizeUnpairedSurrogates`
+ * (commit c6e1f92). mini-agent does not depend on agent-middleware as a
+ * package, so the helper is duplicated here. Both copies must stay in sync.
+ *
+ * Anthropic API rejects strings containing lone UTF-16 surrogates with
+ * HTTP 400 "no low surrogate in string". Surrogates appear when buffers
+ * are sliced mid-code-point (emoji, CJK). Replace with U+FFFD.
+ */
+export function sanitizeUnpairedSurrogates(s: string): string {
+  return s
+    .replace(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/g, '\uFFFD')
+    .replace(/(^|[^\uD800-\uDBFF])([\uDC00-\uDFFF])/g, '$1\uFFFD');
+}

--- a/tests/sanitize.test.ts
+++ b/tests/sanitize.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { sanitizeUnpairedSurrogates } from '../src/sanitize.js';
+
+describe('sanitizeUnpairedSurrogates', () => {
+  it('passes through ASCII unchanged', () => {
+    expect(sanitizeUnpairedSurrogates('hello world')).toBe('hello world');
+  });
+
+  it('passes through valid emoji (paired surrogates)', () => {
+    const emoji = '😀'; // U+1F600 = D83D DE00 surrogate pair
+    expect(sanitizeUnpairedSurrogates(emoji)).toBe(emoji);
+  });
+
+  it('passes through CJK BMP characters', () => {
+    expect(sanitizeUnpairedSurrogates('中文')).toBe('中文');
+  });
+
+  it('replaces lone high surrogate with U+FFFD', () => {
+    const lone = '\uD83D';
+    expect(sanitizeUnpairedSurrogates(lone)).toBe('\uFFFD');
+  });
+
+  it('replaces lone low surrogate with U+FFFD', () => {
+    const lone = '\uDE00';
+    expect(sanitizeUnpairedSurrogates(lone)).toBe('\uFFFD');
+  });
+
+  it('replaces high surrogate not followed by low surrogate', () => {
+    const broken = 'a\uD83Db'; // high surrogate followed by 'b'
+    expect(sanitizeUnpairedSurrogates(broken)).toBe('a\uFFFDb');
+  });
+
+  it('replaces low surrogate not preceded by high surrogate', () => {
+    const broken = 'a\uDE00b';
+    expect(sanitizeUnpairedSurrogates(broken)).toBe('a\uFFFDb');
+  });
+
+  it('preserves valid pair amid broken context', () => {
+    const mixed = '\uD83Dvalid\uD83D\uDE00'; // lone high + 'valid' + valid emoji
+    expect(sanitizeUnpairedSurrogates(mixed)).toBe('\uFFFDvalid\uD83D\uDE00');
+  });
+
+  it('is idempotent', () => {
+    const input = 'foo\uD83Dbar😀';
+    const once = sanitizeUnpairedSurrogates(input);
+    const twice = sanitizeUnpairedSurrogates(once);
+    expect(twice).toBe(once);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #454. mini-agent has two direct Anthropic SDK call sites that bypass the c6e1f92 surrogate sanitizer in `agent-middleware/src/sdk-provider.ts`. Both can receive arbitrary text containing mid-codepoint slices (plugin output, memory/topics/*.md content), triggering Anthropic 400 \"no low surrogate in string\" errors.

This PR ports the sanitizer into mini-agent and wraps both call sites.

## Changes

| File | Change |
|------|--------|
| `src/sanitize.ts` (new) | Duplicate of `agent-middleware/src/sdk-provider.ts:sanitizeUnpairedSurrogates` (4 lines). mini-agent has no workspace dep on agent-middleware; both copies must stay in sync. |
| `src/perception-analyzer.ts:83` | Wrap `userMessage` before `messages.create` |
| `src/context-pruner.ts:137` (`callHaiku`) | Wrap `prompt` before `messages.create` |
| `tests/sanitize.test.ts` (new) | 9 cases: ASCII / valid emoji / CJK / lone high / lone low / broken pair / mixed / idempotency |

## Verification

- `pnpm exec tsc --noEmit` — 0 new errors in patched files (pre-existing `@types/node` warnings in unrelated files unchanged)
- `pnpm exec vitest run tests/sanitize.test.ts` — **9 passed**
- `grep -rn 'sanitizeUnpairedSurrogates' src/` — 4 hits (1 def + 1 import + 1 call in perception-analyzer; 1 import + 1 call in context-pruner)

## Falsifier (auto-graded, 7-day post-merge)

- `grep:miles990/mini-agent state/error-patterns.json "no low surrogate" since:merge ==0` → expected **0 new occurrences** from `analyzePerceptions` or `callHaiku` call paths
- If the same signature reappears post-merge, the regex misses a paired-but-invalid sequence — reopen.

## Why duplicate the helper instead of extracting a shared package

Smallest patch surface. A shared `surrogate-sanitizer` package across mini-agent + agent-middleware is the right long-term move; tracked as follow-up if a 3rd consumer appears. Both copies are 4 lines of pure regex with no state — drift risk is low and easy to audit.

## Not in scope

- Wrapper alternative (`getSanitizedClient()` central boundary): cleaner architecture, but introduces a new abstraction for two callers. Defer until 3rd direct caller appears.
- `transient_fast_band` (#451 / #455): different failure mode (upstream quick-reject), not surrogate-related.

— Kuro (cycle 03bbc29a, filed via gh CLI under kuro-agent identity)