### PR TITLE
fix(dispatcher): #452 invert commitment ledger gate to default-allow

### DIFF
--- a/src/dispatcher.ts
+++ b/src/dispatcher.ts
@@ -1064,9 +1064,10 @@ export async function postProcess(
   const tagsProcessed: string[] = [];
 
   // 2a. Soft falsifier gate — extract ## Decision block and write to commitment ledger.
-  // Only runs for loop/foreground lanes. Never blocks postProcess (fire-and-forget, wrapped in try/catch).
+  // Runs for all lanes except background/silent. Never blocks postProcess (fire-and-forget, wrapped in try/catch).
+  // Fix #452: previously whitelisted only loop/foreground, silently dropping middleware-driven instances.
   try {
-    const isLedgerLane = meta.source === 'loop' || meta.source === 'foreground';
+    const isLedgerLane = meta.source !== 'background' && meta.source !== 'silent';
     if (isLedgerLane) {
       const decision = extractDecisionBlock(mappedResponse);
       if (decision?.chose) {


### PR DESCRIPTION
## Summary

- Flips `isLedgerLane` from a whitelist (`'loop' | 'foreground'`) to a blacklist (`!== 'background'` && `!== 'silent'`) so middleware-driven, `'ask'`, `'cli'`, and `'cron'` lanes also write to the commitment ledger.
- Resolves #452 — `commitments.jsonl` had been silently dark since 2026-05-07; falsifier-driven self-correction was no-op for ~2 days; discipline metrics (`analysisParalysis`, `performativeSkepticism`, `noopSpiral`) were computed off the frozen `state.archived-2026-05-07-pre-isolation/commitments.jsonl` archive.
- Two-line predicate change in `src/dispatcher.ts` exactly as proposed in the issue body. No behavioral change for the previously-allowed `'loop'`/`'foreground'` paths; previously-silenced lanes (`'cli'`, `'ask'`, `'cron'`, middleware-driven, `undefined`) now correctly emit.

## Why default-allow is correct

The original gate was added defensively before middleware existed. Today, the ledger should reflect every instance's commitments by default; only paths that explicitly should not contribute (`'background'` long-running tasks, `'silent'` introspective probes) opt out. Default-deny is the wrong polarity once the surface is broader than two lanes.

## Verification

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 125 files / 1020 passed / 2 skipped (no regressions)
- [x] `gh issue view 452 --repo miles990/mini-agent` — issue OPEN, will close on merge
- [ ] After merge: confirm `memory/state/commitments.jsonl` accumulates new `cycle_id` entries (issue's auto-graded falsifier: `grep:.../commitments.jsonl "cycle_id" >=1`)
- [ ] After merge: confirm header discipline metrics reflect *current* cycle counts, not the frozen 2026-05-07 archive

## Risk

Low. Fail-closed try/catch around the gate is preserved (`// fire-and-forget — ledger errors must never surface to callers`); worst case a previously-silenced lane now writes a malformed entry, which is logged and swallowed exactly like the existing path. No new dependencies, no schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)