### PR TITLE
fix(error-patterns): resolver writes mitigationKind, killing false [REGRESSION] flags

### DIFF
--- a/scripts/error-patterns-resolve.ts
+++ b/scripts/error-patterns-resolve.ts
@@ -4,6 +4,8 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { getMemoryStateDir } from '../src/memory.js';
 
+type MitigationKind = 'circuit_breaker' | 'retry' | 'fallback' | 'expected_steady_state';
+
 type ErrorPattern = {
   count: number;
   taskCreated: boolean;
@@ -12,19 +14,29 @@ type ErrorPattern = {
   resolved?: boolean;
   resolvedAt?: string;
   resolvedBy?: string;
+  mitigationKind?: MitigationKind;
 };
 
+const VALID_MITIGATIONS: ReadonlySet<MitigationKind> = new Set([
+  'circuit_breaker', 'retry', 'fallback', 'expected_steady_state',
+]);
+
 function usage(): never {
-  process.stderr.write('usage: pnpm error-patterns:resolve <key> --commit <sha-or-url> [--at <iso>] [--json]\n');
+  process.stderr.write(
+    'usage: pnpm error-patterns:resolve <key> --commit <sha-or-url> [--at <iso>] ' +
+    '[--mitigation <circuit_breaker|retry|fallback|expected_steady_state>] [--json]\n'
+  );
   process.exit(2);
 }
 
-function parseArgs(argv: string[]): { key: string; commit: string; at: string; json: boolean } {
+function parseArgs(argv: string[]): {
+  key: string; commit: string; at: string; mitigation?: MitigationKind; json: boolean;
+} {
   const json = argv.includes('--json');
   const positional: string[] = [];
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
-    if (arg === '--commit' || arg === '--at') {
+    if (arg === '--commit' || arg === '--at' || arg === '--mitigation') {
       i += 1;
       continue;
     }
@@ -33,13 +45,19 @@ function parseArgs(argv: string[]): { key: string; commit: string; at: string; j
   const key = positional[0];
   const commitIdx = argv.indexOf('--commit');
   const atIdx = argv.indexOf('--at');
+  const mitIdx = argv.indexOf('--mitigation');
   const commit = commitIdx >= 0 ? argv[commitIdx + 1] : '';
   const at = atIdx >= 0 ? argv[atIdx + 1] : new Date().toISOString();
+  const mitigationRaw = mitIdx >= 0 ? argv[mitIdx + 1] : undefined;
+  if (mitigationRaw && !VALID_MITIGATIONS.has(mitigationRaw as MitigationKind)) {
+    process.stderr.write(`invalid --mitigation: ${mitigationRaw}\n`);
+    usage();
+  }
   if (!key || !commit || !Number.isFinite(Date.parse(at))) usage();
-  return { key, commit, at, json };
+  return { key, commit, at, mitigation: mitigationRaw as MitigationKind | undefined, json };
 }
 
-const { key, commit, at, json } = parseArgs(process.argv.slice(2));
+const { key, commit, at, mitigation, json } = parseArgs(process.argv.slice(2));
 const stateDir = getMemoryStateDir();
 const statePath = path.join(stateDir, 'error-patterns.json');
 const state: Record<string, ErrorPattern> = existsSync(statePath)
@@ -55,14 +73,15 @@ state[key] = {
   ...state[key],
   resolvedAt: at,
   resolvedBy: commit,
+  ...(mitigation ? { mitigationKind: mitigation } : {}),
 };
 
 mkdirSync(stateDir, { recursive: true });
 writeFileSync(statePath, `${JSON.stringify(state, null, 2)}\n`, 'utf-8');
 
-const result = { key, resolvedAt: at, resolvedBy: commit };
+const result = { key, resolvedAt: at, resolvedBy: commit, ...(mitigation ? { mitigationKind: mitigation } : {}) };
 if (json) {
   process.stdout.write(`${JSON.stringify(result)}\n`);
 } else {
-  process.stdout.write(`resolved ${key} at ${at} by ${commit}\n`);
+  process.stdout.write(`resolved ${key} at ${at} by ${commit}${mitigation ? ` (mitigation=${mitigation})` : ''}\n`);
 }


### PR DESCRIPTION
## Problem
`prompt-builder.ts:457` uses `!v.mitigationKind && lastSeenTs > resolvedTs + GRACE` to flag `[REGRESSION]` in the recurring-errors panel. But **`mitigationKind` was never written anywhere in src/ or scripts/** — only the type was declared. So every resolved error pattern with re-occurrences past the 24h grace was permanently labeled `[REGRESSION]`, falsely.

Observed live (in this cycle's heartbeat):
- `UNKNOWN:transient_fast_band::callClaude` — 38×, circuit-breaker shipped via #333 (`agent.ts:2024-2038`)
- `TIMEOUT:silent_exit_void_midprompt::callClaude` — 19×, retry path active

Both have functioning mitigations; the panel was lying.

## Fix
`scripts/error-patterns-resolve.ts` now accepts an optional `--mitigation <kind>` flag (validated against `circuit_breaker | retry | fallback | expected_steady_state`) and writes it alongside `resolvedAt` / `resolvedBy`.

## Verification
- [x] `pnpm tsc --noEmit` clean (no new errors for this file)
- [x] Live data hand-patched for the two affected entries — next prompt build should drop `[REGRESSION]` labels
- [ ] Backfill: re-run resolver with `--mitigation` for any other historically resolved entries (separate PR)

## Test plan
- [ ] Run `pnpm error-patterns:resolve <key> --commit <sha> --mitigation circuit_breaker` against a test fixture
- [ ] Confirm `mitigationKind` lands in `error-patterns.json`
- [ ] Confirm `buildErrorPatternsHint()` no longer renders `[REGRESSION]` for that entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)