### PR TITLE
fix(runtime): preserve local runtime commit dirty-moykl0kj

### DIFF
--- a/src/memory-index.ts
+++ b/src/memory-index.ts
@@ -1798,7 +1798,7 @@ export function getHighPriorityPendingCount(memDir: string): number {
  * the guard and re-injected verbatim every cycle even after a stack_rank
  * resolved-phantom event was written.
  */
-function loadResolvedTaskKeysFromEvents(memoryDir: string): {
+export function loadResolvedTaskKeysFromEvents(memoryDir: string): {
   ids: Set<string>;
   summaries: Set<string>;
 } {


### PR DESCRIPTION
## Summary
- autocorrected 0 commit(s) that were made on protected runtime/main
- moved the change into an isolated worktree branch so review/merge/deploy can proceed normally
- reset the runtime checkout back to origin/main after preserving the change

## Verification
- [x] `git push -u origin fix/runtime-autocorrect-dirty-moykl0kj` passed; the runtime-local commit is preserved on an isolated review branch
- [x] `git reset --hard origin/main` passed; the protected runtime checkout was restored to origin/main