### PR TITLE
fix(scheduler): re-verify github-issue tasks before dispatch (#465)

### DIFF
--- a/src/predicate-freshness.ts
+++ b/src/predicate-freshness.ts
@@ -34,6 +34,18 @@ const execFileAsync = promisify(execFile);
 export interface FreshnessContext {
   repoRoot: string;
   memoryDir: string;
+  /**
+   * Optional task entry being re-verified. Predicates that need
+   * task-specific metadata (e.g. github-issue-open needs repo + issue number)
+   * read it from here. Other predicates ignore it.
+   */
+  entry?: { id?: string; summary?: string; payload?: Record<string, unknown> };
+  /**
+   * Test injection: override the live `gh issue view` call. Returns the
+   * issue state (`OPEN` | `CLOSED`) or null when unavailable. Defaults to
+   * a real `execFile('gh', ['issue', 'view', ...])` when not provided.
+   */
+  ghIssueView?: (repo: string, issueNumber: number) => Promise<{ state: string } | null>;
 }
 
 export type PredicateType =
@@ -42,6 +54,7 @@ export type PredicateType =
   | 'low-responsiveness'
   | 'memory-state-truth'
   | 'ship-truth'
+  | 'github-issue-open'
   | string;
 
 /**
@@ -64,6 +77,8 @@ export async function reverifyPredicate(
       return checkMemoryStateTruth(ctx);
     case 'ship-truth':
       return checkShipTruth(ctx);
+    case 'github-issue-open':
+      return checkGitHubIssueOpen(ctx);
     default:
       return null;
   }
@@ -217,3 +232,61 @@ function isCorrectionTask(entry: Pick<MemoryIndexEntry, 'summary' | 'payload'>):
   const payload = (entry.payload ?? {}) as Record<string, unknown>;
   return (entry.summary ?? '').includes('correction gate') || payload.origin === 'correction-gate';
 }
+
+/**
+ * Source-of-truth: `gh issue view N --repo R --json state` against GitHub.
+ *
+ * Used for heartbeat-derived `idx-github-issue-*` tasks. Without this
+ * predicate the scheduler dispatches an issue-task whose underlying
+ * issue was already closed (autopilot reconciliation may not have run
+ * yet between snapshot and dispatch), producing phantom P0 cycles —
+ * the failure mode reported in mini-agent#465.
+ *
+ * Stale (true) when the live issue state is `OPEN` (matches snapshot →
+ * proceed with dispatch). Fresh (false) when the live state is `CLOSED`
+ * (snapshot was lagging → caller skips dispatch). Fail-open (null) when:
+ *   - ctx.entry is missing or lacks `repo`/`issue_number` payload fields;
+ *   - the `gh` call throws or returns malformed JSON.
+ *
+ * Test injection via `ctx.ghIssueView` bypasses the real `gh` binary.
+ */
+export async function checkGitHubIssueOpen(ctx: FreshnessContext): Promise<boolean | null> {
+  const meta = extractGitHubIssueMeta(ctx.entry);
+  if (!meta) return null;
+  try {
+    const result = ctx.ghIssueView
+      ? await ctx.ghIssueView(meta.repo, meta.issueNumber)
+      : await defaultGhIssueView(meta.repo, meta.issueNumber);
+    if (!result || typeof result.state !== 'string') return null;
+    return result.state.toUpperCase() === 'OPEN';
+  } catch {
+    return null;
+  }
+}
+
+function extractGitHubIssueMeta(
+  entry: FreshnessContext['entry'],
+): { repo: string; issueNumber: number } | null {
+  if (!entry) return null;
+  const payload = (entry.payload ?? {}) as Record<string, unknown>;
+  const repo = typeof payload.repo === 'string' ? payload.repo.trim() : '';
+  const issueNumber = Number(payload.issue_number);
+  if (!repo || !/^[^/\s]+\/[^/\s]+$/.test(repo)) return null;
+  if (!Number.isInteger(issueNumber) || issueNumber <= 0) return null;
+  return { repo, issueNumber };
+}
+
+async function defaultGhIssueView(
+  repo: string,
+  issueNumber: number,
+): Promise<{ state: string } | null> {
+  const { stdout } = await execFileAsync(
+    'gh',
+    ['issue', 'view', String(issueNumber), '--repo', repo, '--json', 'state'],
+    { timeout: 5000 },
+  );
+  const parsed = JSON.parse(stdout) as { state?: unknown };
+  if (typeof parsed.state !== 'string') return null;
+  return { state: parsed.state };
+}
+

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -481,23 +481,38 @@ export async function schedulerPickAsync(
 ): Promise<SchedulingDecision> {
   const decision = schedulerPick(memoryDir, events);
 
-  // Only correction tasks need predicate re-verification.
+  // Re-verify the dispatch decision against live source-of-truth.
+  // Two paths:
+  //   (a) correction-gate tasks (origin: correction-gate) — original Layer 1/2 path.
+  //   (b) heartbeat-derived github-issue tasks (id prefix idx-github-issue-) —
+  //       added for #465 to skip dispatch when the issue is already closed
+  //       on GitHub but autopilot reconciliation hasn't run yet.
   if (!decision.taskId) return decision;
 
   const entries = queryMemoryIndexSync(memoryDir, { type: ['task'], status: ['pending', 'in_progress'] });
   const entry = entries.find(e => e.id === decision.taskId);
-  if (!entry || !isCorrectionTask(entry)) return decision;
+  if (!entry) return decision;
 
-  // Extract the predicate type from payload or summary.
   const payload = (entry.payload ?? {}) as Record<string, unknown>;
-  const predicateType: string =
-    (typeof payload.correction_reason_type === 'string' ? payload.correction_reason_type : null)
-    ?? parseCorrectionReasonFromSummaryExported(entry.summary ?? '')
-    ?? '';
+
+  // Decide predicate type by task family. Order matters: github-issue tasks
+  // are handled before the correction-task gate because they are heartbeat-
+  // derived (not correction tasks) and the previous gate skipped them.
+  let predicateType: string = '';
+  if (typeof entry.id === 'string' && entry.id.startsWith('idx-github-issue-')) {
+    predicateType = 'github-issue-open';
+  } else if (isCorrectionTask(entry)) {
+    predicateType =
+      (typeof payload.correction_reason_type === 'string' ? payload.correction_reason_type : null)
+      ?? parseCorrectionReasonFromSummaryExported(entry.summary ?? '')
+      ?? '';
+  } else {
+    return decision; // Not a re-verifiable task family — fail-open.
+  }
 
   if (!predicateType) return decision; // Unknown type — fail-open.
 
-  const ctx = { repoRoot, memoryDir };
+  const ctx = { repoRoot, memoryDir, entry };
   let stillStale: boolean | null;
   try {
     stillStale = await reverifyPredicate(predicateType, ctx);

--- a/tests/predicate-freshness-github-issue.test.ts
+++ b/tests/predicate-freshness-github-issue.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { reverifyPredicate, checkGitHubIssueOpen, type FreshnessContext } from '../src/predicate-freshness.js';
+
+const baseCtx = (overrides: Partial<FreshnessContext> = {}): FreshnessContext => ({
+  repoRoot: '/tmp/repo-doesnt-matter',
+  memoryDir: '/tmp/mem-doesnt-matter',
+  ...overrides,
+});
+
+describe('reverifyPredicate("github-issue-open")', () => {
+  it('returns false (fresh = skip dispatch) when live state is CLOSED', async () => {
+    const result = await reverifyPredicate('github-issue-open', baseCtx({
+      entry: { id: 'idx-github-issue-miles990-mini-agent-999', payload: { repo: 'miles990/mini-agent', issue_number: 999 } },
+      ghIssueView: async () => ({ state: 'CLOSED' }),
+    }));
+    expect(result).toBe(false);
+  });
+
+  it('returns true (stale = dispatch) when live state is OPEN', async () => {
+    const result = await reverifyPredicate('github-issue-open', baseCtx({
+      entry: { id: 'idx-github-issue-miles990-mini-agent-465', payload: { repo: 'miles990/mini-agent', issue_number: 465 } },
+      ghIssueView: async () => ({ state: 'OPEN' }),
+    }));
+    expect(result).toBe(true);
+  });
+
+  it('fail-opens (null) when entry is missing', async () => {
+    const result = await reverifyPredicate('github-issue-open', baseCtx({ ghIssueView: async () => ({ state: 'CLOSED' }) }));
+    expect(result).toBeNull();
+  });
+
+  it('fail-opens (null) when payload lacks repo/issue_number', async () => {
+    const result = await reverifyPredicate('github-issue-open', baseCtx({
+      entry: { id: 'idx-github-issue-foo-1', payload: { issue_number: 1 } }, // no repo
+      ghIssueView: async () => ({ state: 'CLOSED' }),
+    }));
+    expect(result).toBeNull();
+  });
+
+  it('fail-opens (null) when ghIssueView throws', async () => {
+    const result = await reverifyPredicate('github-issue-open', baseCtx({
+      entry: { id: 'idx-github-issue-x-1', payload: { repo: 'a/b', issue_number: 1 } },
+      ghIssueView: async () => { throw new Error('gh: not found'); },
+    }));
+    expect(result).toBeNull();
+  });
+
+  it('rejects malformed repo strings', async () => {
+    const result = await checkGitHubIssueOpen(baseCtx({
+      entry: { payload: { repo: 'no-slash', issue_number: 1 } },
+      ghIssueView: async () => ({ state: 'CLOSED' }),
+    }));
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `github-issue-open` predicate to `predicate-freshness.ts` — at task resume, checks live issue state via `gh issue view`
- Scheduler now detects `idx-github-issue-*` tasks and routes them through the new predicate before dispatch
- When the underlying issue is CLOSED, dispatch is skipped as `stale-signal-skip`, preventing phantom P0 re-spawns

## Root cause
Heartbeat-derived `idx-github-issue-*` tasks captured closure predicates at decompose time. On resume, the scheduler never re-checked the issue state, so tasks for already-closed issues kept re-spawning as P0.

## Test plan
- [ ] `tests/predicate-freshness-github-issue.test.ts` passes
- [ ] Verify no `idx-github-issue-*` tasks with `status=spawned` appear for closed issues over 24h window

Closes #465

🤖 Generated with [Claude Code](https://claude.com/claude-code)