### PR TITLE
fix(loop): drain block also resets effectivePrompt to idle (#468)

### DIFF
--- a/src/loop.ts
+++ b/src/loop.ts
@@ -2728,7 +2728,7 @@ export class AgentLoop {
       }
 
       // Idle mode: replace prompt entirely with a lightweight idle prompt to avoid noop spirals
-      const effectivePrompt = cycleMode === 'idle'
+      let effectivePrompt = cycleMode === 'idle'
         ? buildIdlePrompt()
         : prompt + (selectedSkillPrompt ? `\n\n${selectedSkillPrompt}` : '');
 
@@ -2760,8 +2760,16 @@ export class AgentLoop {
         const contextBefore = context.length;
         try {
           context = await memory.buildContext({ mode: 'minimal', cycleCount: this.cycleCount, trigger: currentTriggerReason ?? undefined });
-          slog('LOOP', `[preflight.drain] effectivePrompt ${effectivePrompt.length} >= ${PREFLIGHT_SIZE_THRESHOLD} — context rebuilt minimal: ${contextBefore} → ${context.length}`);
-          eventBus.emit('action:loop', { event: 'preflight.drain', promptSize: effectivePrompt.length, threshold: PREFLIGHT_SIZE_THRESHOLD, contextBefore, contextAfter: context.length, cycleMode, trigger: currentTriggerReason ?? null });
+          // Issue #468: drain previously rebuilt only `context`; effectivePrompt stayed at the original
+          // pre-drain size, so callClaude still sent a 30K+ prompt → silent_exit_void_http TIMEOUT.
+          // Path B stopgap: replace effectivePrompt with the lightweight idle prompt during drain so
+          // the call actually shrinks. We accept temporary loss of full task-signal continuity in
+          // exchange for unblocking the cycle; Path A′ (re-run buildAutonomousPromptFn with
+          // minimalMode) remains the proper fix tracked in #468.
+          const promptBefore = effectivePrompt.length;
+          effectivePrompt = buildIdlePrompt();
+          slog('LOOP', `[preflight.drain] effectivePrompt ${promptBefore} >= ${PREFLIGHT_SIZE_THRESHOLD} — context ${contextBefore} → ${context.length}, prompt ${promptBefore} → ${effectivePrompt.length} (idle)`);
+          eventBus.emit('action:loop', { event: 'preflight.drain', promptSize: promptBefore, promptAfter: effectivePrompt.length, threshold: PREFLIGHT_SIZE_THRESHOLD, contextBefore, contextAfter: context.length, cycleMode, trigger: currentTriggerReason ?? null });
         } catch (drainErr) {
           // Drain failed — fall back to observability-only; call proceeds with original context.
           slog('LOOP', `[preflight.observe] context rebuild failed, proceeding with original context: ${String(drainErr)}`);


### PR DESCRIPTION
## Summary
- Path B stopgap for issue #468 — pre-flight drain rebuilt `context` minimal but left `effectivePrompt` at original pre-drain size, so callClaude still received 30K+ char prompts that triggered `silent_exit_void_http` TIMEOUT.
- Drain block now also reassigns `effectivePrompt = buildIdlePrompt()` and logs both pre/post prompt size for observability.
- 11 insertions / 3 deletions in `src/loop.ts`. Typecheck clean.

## Why Path B and not Path A'
Path A' (add `minimalMode?: boolean` to `PromptBuilderState`, conditionally skip rumination/threads/innerVoice/backgroundLane/verifiedRoutes sections, then re-call `buildAutonomousPromptFn` with `{...state, minimalMode: true}`) is the structurally correct fix that preserves scheduler-task signal continuity, but requires ~60 LoC across `prompt-builder.ts:587-694` and `loop.ts:2757`. Path B is the bleeding-edge stopgap to actually unblock cycles in the next deploy. Path A' tracked separately in #468.

## Verification
- [ ] `pnpm typecheck` — already passing locally
- [ ] After deploy, observe one cycle that hits the drain threshold (≥35K, or ≥25K when recent silent_exit pattern is fresh)
- [ ] Verify `[preflight.drain]` slog line shows `prompt N → M` with `M < 5_000`
- [ ] Verify `error-patterns.json` `TIMEOUT:silent_exit_void_http::callClaude.lastSeen` stops advancing once a real drained cycle goes through
- [ ] Confirm scheduler still picks up tasks in the cycle AFTER the drained one (single-cycle signal loss is the accepted tradeoff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
