### PR TITLE
fix(workspace-isolation): handle generic worktree dirs in inferRuntimeWorkspace

### DIFF
--- a/scripts/check-runtime-workspace.ts
+++ b/scripts/check-runtime-workspace.ts
@@ -66,6 +66,12 @@ function inferRuntimeWorkspace(root: string): string {
   const baseName = path.basename(root);
   if (baseName === 'mini-agent') return root;
   if (baseName.startsWith('mini-agent-')) return path.join(path.dirname(root), 'mini-agent');
+  // Generic worktree dirs (e.g. /tmp/wt-468) should not self-identify as the
+  // protected runtime root. Resolve to a sibling `mini-agent` checkout when
+  // present so isProtectedRuntime correctly returns false for the worktree.
+  if (baseName.startsWith('wt-') || baseName.startsWith('worktree-')) {
+    return path.join(path.dirname(root), 'mini-agent');
+  }
   return root;
 }
 


### PR DESCRIPTION
## Summary
- `inferRuntimeWorkspace(root)` only recognised `mini-agent` and `mini-agent-*` baseNames. Generic worktree paths (e.g. `/tmp/wt-468`, `/tmp/worktree-foo`) fell through to `return root`, so `isProtectedRuntime` became true inside the worktree itself and `pnpm precommit` (`scripts/check-runtime-workspace.ts`) blocked any commit.
- Workaround in PR #469 was to set `MINI_AGENT_RUNTIME_WORKSPACE=/Users/user/Workspace/mini-agent` on every shell. This patch makes `wt-*` / `worktree-*` baseNames resolve to a sibling `mini-agent` checkout instead, so `isProtectedRuntime === false` for the worktree and the real runtime checkout (baseName `mini-agent`) is still protected.

## Falsifier (machine-checkable)
`grep:/Users/user/Workspace/mini-agent/scripts/check-runtime-workspace.ts "wt-" >=1` — must match after merge.

## Test plan
- [x] Patch compiles (no new TS errors introduced; pre-existing `@types/node` warnings unrelated)
- [ ] Inside a fresh `/tmp/wt-*` worktree on a feature branch, `pnpm precommit` no longer reports `protected runtime workspace is on …; expected runtime/main`
- [ ] Real runtime checkout at `~/Workspace/mini-agent` still rejects code commits on a non-runtime branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)