### PR TITLE
fix(retry): #350 rebuild priorityPrefix on TIMEOUT to drop stale P0 banner

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -1809,6 +1809,10 @@ export async function callClaude(
     triggerReason?: string | null;
     /** Whether there are pending tasks — used by small model prompt builder */
     hasPendingTasks?: boolean;
+    /** #350: original priorityPrefix snapshot — used as boundary for retry-time refresh */
+    priorityPrefix?: string;
+    /** #350: callback to re-derive priorityPrefix on TIMEOUT retry, dropping stale P0/delegation banner */
+    rebuildPriorityPrefix?: () => Promise<string>;
   },
 ): Promise<{ response: string; systemPrompt: string; fullPrompt: string; duration: number; preempted?: boolean; error?: ErrorClassification }> {
   const source = options?.source ?? 'loop';
@@ -2062,9 +2066,21 @@ export async function callClaude(
             const minimalSystemPrompt = getSystemPrompt(prompt, options?.cycleMode, 'minimal');
             const minimalBudget = PROMPT_HARD_CAP - minimalSystemPrompt.length - prompt.length - 20;
             currentContext = await options.rebuildContext('minimal', minimalBudget);
+            // #350: swap stale priorityPrefix banner with freshly-derived one (drops post-resolution P0 items + cleared delegations).
+            // Static Alex/room front carries through; only the dynamic dynamic-banner suffix is re-derived.
+            let retryPrompt = prompt;
+            if (options?.priorityPrefix && options?.rebuildPriorityPrefix && prompt.startsWith(options.priorityPrefix)) {
+              try {
+                const fresh = await options.rebuildPriorityPrefix();
+                retryPrompt = fresh + prompt.slice(options.priorityPrefix.length);
+                slog('RETRY', `priorityPrefix refreshed ${options.priorityPrefix.length}→${fresh.length} chars (#350 fix)`);
+              } catch (rebuildPrefixErr) {
+                slog('RETRY', `rebuildPriorityPrefix failed: ${rebuildPrefixErr}, keeping stale prefix`);
+              }
+            }
             // Error trace retention: models avoid repeating mistakes when they see what went wrong
             const errorTrace = `## Previous Attempt Failed\nType: ${classified.type} | Duration: ${attemptDuration}ms | Tool calls: ${errToolCount}\nGuidance: ${classified.modelGuidance}\nContext reduced from ${prevLen} to ${currentContext.length} chars for retry.`;
-            fullPrompt = `${minimalSystemPrompt}\n\n${currentContext}\n\n${errorTrace}\n\n---\n\nUser: ${prompt}`;
+            fullPrompt = `${minimalSystemPrompt}\n\n${currentContext}\n\n${errorTrace}\n\n---\n\nUser: ${retryPrompt}`;
             slog('RETRY', `TIMEOUT tools=${errToolCount} on attempt ${attempt + 1}, prompt reduced ${prevLen + systemPrompt.length} → ${fullPrompt.length} chars (minimal + error trace, sysPrompt ${minimalSystemPrompt.length}), retrying in ${delay / 1000}s`);
           } catch (rebuildErr) {
             // Emergency fallback: even if rebuildContext fails, at least strip the system prompt

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -2325,6 +2325,9 @@ export class AgentLoop {
 
       }
 
+      // #350: capture pre-dynamic snapshot for rebuildPriorityPrefix on retry
+      const staticPriorityPrefix = priorityPrefix;
+
       // Fix 3: Pending foreground delegations — OODA must follow up, not reflect/learn
       const pendingFgDelegations = getPendingForegroundDelegations();
       if (pendingFgDelegations.length > 0) {
@@ -2362,6 +2365,36 @@ export class AgentLoop {
         const p0Preview = p0Previews.slice(0, 3).map(i => `  「${i.slice(0, 100)}」`).join('\n');
         priorityPrefix += `\nP0 items pending:\n${p0Preview}\n\n`;
       }
+
+      // #350: re-derive dynamic banner (foreground delegations + P0 items) for retry path.
+      // Static front (Alex/room/chat banner) doesn't drift in 30s retry; only dynamic part does.
+      const rebuildPriorityPrefixFn = async (): Promise<string> => {
+        let fresh = staticPriorityPrefix;
+        const fgPendingNow = getPendingForegroundDelegations();
+        if (fgPendingNow.length > 0) {
+          const fgPreview = fgPendingNow.map(d =>
+            `  - [${d.source}] "${d.text.slice(0, 120)}" (delegated at ${new Date(d.delegatedAt).toLocaleTimeString()})`
+          ).join('\n');
+          fresh += `\n背景委派待跟進：\n${fgPreview}\n收斂條件：委派結果被吸收，原始發問者得到回覆。\n\n`;
+        }
+        const rawPreviews = getP0TaskPreviews(memDir);
+        const ctxLocal = { repoRoot: path.resolve(memDir, '..', '..'), memoryDir: memDir };
+        const previews: string[] = [];
+        for (const preview of rawPreviews) {
+          const m = preview.match(/correction gate: resolve ([a-z-]+)/i);
+          if (!m) { previews.push(preview); continue; }
+          let stillStale: boolean | null = null;
+          try { stillStale = await reverifyPredicate(m[1] as PredicateType, ctxLocal); }
+          catch { stillStale = null; /* fail-open */ }
+          if (stillStale === false) continue;
+          previews.push(preview);
+        }
+        if (previews.length > 0) {
+          const p0Preview = previews.slice(0, 3).map(i => `  「${i.slice(0, 100)}」`).join('\n');
+          fresh += `\nP0 items pending:\n${p0Preview}\n\n`;
+        }
+        return fresh;
+      };
 
       // ── Agent OS Scheduler: deterministic task selection ──
       const schedulerEvents: SchedulerEvent[] = [];
@@ -2855,6 +2888,9 @@ export class AgentLoop {
           `cycle#${this.cycleCount}.callClaude`,
           () => callClaude(effectivePrompt, context, 2, {
             rebuildContext: (mode, budget) => memory.buildContext({ mode, cycleCount: this.cycleCount, trigger: currentTriggerReason ?? undefined, contextBudget: budget }),
+            // #350: enable retry-time priorityPrefix refresh to drop stale P0/delegation banner
+            priorityPrefix,
+            rebuildPriorityPrefix: rebuildPriorityPrefixFn,
             source: 'loop',
             onPartialOutput,
             cycleMode,


### PR DESCRIPTION
Closes #350.

## Root cause
`agent.ts` TIMEOUT-retry captured `prompt` by value at the original `callClaude` call. `rebuildContext` refreshed `currentContext`, but the user prompt — including the `priorityPrefix` banner snapshot — replayed verbatim. Layer 1.7-cleared P0 items kept re-emerging on retry.

## Patch (~50 LoC, 2 files)
- **loop.ts**: capture `staticPriorityPrefix` (Alex/room/chat front, doesn't drift in 30s retry); define `rebuildPriorityPrefixFn` closure that re-runs foreground delegations + P0 reverify against current memDir; pass both into callClaude options.
- **agent.ts**: extend options with `priorityPrefix?: string` + `rebuildPriorityPrefix?: () => Promise<string>`. In TIMEOUT/rebuildContext branch, when `prompt` starts with the original priorityPrefix, slice it out and prepend the fresh one. Errors fall back to stale prefix (no regression).

## Boundary
Only the dynamic banner suffix is re-derived. Static front (Alex/room/chat) carries through. Avoids fragile regex-strip across 5 mutually-exclusive top-level prefix shapes.

## Falsifier
```
grep:/Users/user/Workspace/mini-agent/logs/server.log "priorityPrefix refreshed" since:<post-merge> >=1
```
AND replicated TIMEOUT retry with cleared P0 produces 0-item banner in retry prompt.

## Verification

- [x] `pnpm run build` clean
- [x] No schema migration; backward-compatible (callers without options work as before)
- [ ] Live falsifier check post-merge (next 5 cycles)

— autonomous Kuro cycle, instance 03bbc29a, 2026-05-10