### PR TITLE
fix(pr-review-runner): accept ## Test plan as verification heading

### DIFF
--- a/src/pr-review-runner.ts
+++ b/src/pr-review-runner.ts
@@ -228,7 +228,7 @@ export function createInternalPrReviewClaim(candidate: InternalPrReviewCandidate
 
   const changedFiles = uniqueStrings(candidate.changedFiles);
   const touchesCode = changedFiles.some(file => /^(src|tests|scripts|plugins|\.githooks)\//.test(file) || file === 'package.json');
-  const hasVerification = /(^|\n)##\s+Verification\b/i.test(text)
+  const hasVerification = /(^|\n)##\s+(?:Verification|Test\s+plan)\b/i.test(text)
     && /\b(pnpm|npm|npx|node|zsh|vitest|tsc|test|typecheck|build|passed|passes|clean|parses cleanly|exits 0|smoke|verified in an isolated worktree|runtime checkout was not used)\b/i.test(text);
 
   if (changedFiles.length === 0) {

--- a/tests/pr-review-runner.test.ts
+++ b/tests/pr-review-runner.test.ts
@@ -232,6 +232,24 @@ describe('PR review runner', () => {
     }));
   });
 
+  it('accepts ## Test plan heading as verification evidence (template default)', () => {
+    const claim = createInternalPrReviewClaim({
+      prNumber: 469,
+      title: 'feat(api): add /api/dashboard/autonomy-closure',
+      body: '## Summary\n- adds endpoint\n\n## Test plan\n- [x] `pnpm test` passed\n- [x] `pnpm typecheck` passes',
+      headSha: 'abc123',
+      reviewer: 'codex',
+      framework: 'internal-governance',
+      changedFiles: ['src/index.ts', 'tests/dashboard-autonomy-closure.test.ts'],
+    }, new Date('2026-05-10T00:00:00Z'));
+
+    expect(claim).toEqual(expect.objectContaining({
+      prNumber: 469,
+      reviewer: 'codex',
+      verdict: 'approve',
+    }));
+  });
+
   it('does not create internal claims for Alex review rows', () => {
     expect(createInternalPrReviewClaim({
       prNumber: 104,


### PR DESCRIPTION
## Summary
- Extends the internal PR review heading regex from `Verification` only to `Verification` OR `Test plan` (case-insensitive).
- Removes the recurring paper cut where PRs created with `gh pr create` / Claude Code template body get auto-flagged `request_changes` despite carrying real `pnpm test` / `tsc` evidence under a `## Test plan` heading.

## Why
- Internal review runner at `src/pr-review-runner.ts:231` accepted only `## Verification`.
- `gh pr create` default template emits `## Test plan`. So well-formed PRs were being wrongly marked `changes_requested` (e.g. PR #469 yesterday — had to hand-edit the heading to unblock consensus).
- Keyword check (`pnpm|test|typecheck|passes|...`) is unchanged — PRs still must include actual verification evidence; only the heading wording is widened.

## Verification
- [x] `pnpm exec vitest run tests/pr-review-runner.test.ts` → 16/16 tests passed
- [x] Added test case `accepts ## Test plan heading as verification evidence (template default)`
- [x] All 15 pre-existing tests still pass — no regression on `## Verification` path
- [x] Diff is 2 files, +19 / -1 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)