### PR TITLE
fix(verification-heading): widen ## Test plan acceptance to 3 remaining sites (#476)

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -50,6 +50,10 @@ import {
 import { assertKuroGithubIdentity, expectedKuroGithubLogin, kuroGithubCliEnv } from './github-identity.js';
 import { recordPublicWriteProvenance } from './public-write-identity.js';
 import { evaluateIssueEvidenceGuard } from './issue-evidence-guard.js';
+import {
+  VERIFICATION_HEADING_REGEX_LINE_START,
+  hasVerificationHeadingLineStart,
+} from './verification-heading.js';
 
 const execFileAsync = promisify(execFile);
 let loggedReviewRequestsDegrade = false;
@@ -1087,7 +1091,7 @@ export async function githubAutoActions(): Promise<void> {
 }
 
 function hasVerificationSection(body: string): boolean {
-  return /^##\s+Verification\b/im.test(body);
+  return hasVerificationHeadingLineStart(body);
 }
 
 function hasForgeVerificationClaim(body: string): boolean {
@@ -1096,7 +1100,7 @@ function hasForgeVerificationClaim(body: string): boolean {
 }
 
 function autofixRuntimeAutocorrectVerification(body: string): PrVerificationAutofixResult {
-  if (!/^##\s+Verification\b/im.test(body)) {
+  if (!hasVerificationHeadingLineStart(body)) {
     return { changed: false, body, reason: 'no verification section present' };
   }
   if (!/pending isolated PR review/i.test(body)) {
@@ -1113,7 +1117,7 @@ function autofixRuntimeAutocorrectVerification(body: string): PrVerificationAuto
   ].join('\n');
   return {
     changed: true,
-    body: replaceMarkdownSection(body, /^##\s+Verification\b/im, replacement),
+    body: replaceMarkdownSection(body, VERIFICATION_HEADING_REGEX_LINE_START, replacement),
     reason: 'replaced pending runtime-autocorrect verification with completed preservation evidence',
   };
 }

--- a/src/pr-lifecycle-governance.ts
+++ b/src/pr-lifecycle-governance.ts
@@ -1,3 +1,5 @@
+import { VERIFICATION_HEADING_REGEX_LINE_START } from './verification-heading.js';
+
 export interface CommitSummary {
   sha: string;
   subject: string;
@@ -447,7 +449,7 @@ function riskClass(pr: OpenPullRequestSummary): string {
 }
 
 function hasCompletedVerification(text: string): boolean {
-  const section = extractMarkdownSection(text, /^##\s+Verification\b/im);
+  const section = extractMarkdownSection(text, VERIFICATION_HEADING_REGEX_LINE_START);
   if (!section) return false;
   return /(?:^|\n)\s*-\s*\[[xX]\]\s+/.test(section)
     || /\b(?:passed|passes|clean|success|ok)\b/i.test(section);

--- a/src/pr-review-runner.ts
+++ b/src/pr-review-runner.ts
@@ -2,6 +2,7 @@ import { appendFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } fr
 import path from 'node:path';
 import { createHash, randomUUID } from 'node:crypto';
 import { requiresHumanPrReview, type PrReviewFramework, type PrReviewer } from './pr-lifecycle-governance.js';
+import { hasVerificationHeadingAny } from './verification-heading.js';
 
 export type PrReviewVerdict = 'approve' | 'request_changes' | 'comment';
 export type PrReviewConsensusStatus = 'pending' | 'approved' | 'changes_requested' | 'commented' | 'disputed';
@@ -228,7 +229,7 @@ export function createInternalPrReviewClaim(candidate: InternalPrReviewCandidate
 
   const changedFiles = uniqueStrings(candidate.changedFiles);
   const touchesCode = changedFiles.some(file => /^(src|tests|scripts|plugins|\.githooks)\//.test(file) || file === 'package.json');
-  const hasVerification = /(^|\n)##\s+(?:Verification|Test\s+plan)\b/i.test(text)
+  const hasVerification = hasVerificationHeadingAny(text)
     && /\b(pnpm|npm|npx|node|zsh|vitest|tsc|test|typecheck|build|passed|passes|clean|parses cleanly|exits 0|smoke|verified in an isolated worktree|runtime checkout was not used)\b/i.test(text);
 
   if (changedFiles.length === 0) {

--- a/src/verification-heading.ts
+++ b/src/verification-heading.ts
@@ -1,0 +1,34 @@
+/**
+ * Shared verification-heading regex used across PR-body gates.
+ *
+ * History:
+ * - PR #475 widened the pr-review-runner regex to accept `## Test plan`
+ *   (the default `gh pr create` / Claude Code template heading) in addition
+ *   to `## Verification`.
+ * - Issue #476 promoted that fix to a single source of truth so the same
+ *   widening also applies to `src/github.ts` (autofix gates) and
+ *   `src/pr-lifecycle-governance.ts:hasCompletedVerification` (the latter
+ *   was the highest-impact miss: it mis-classified conflicting PRs with
+ *   `## Test plan` evidence as `needs-verification`).
+ *
+ * Use `VERIFICATION_HEADING_REGEX_*` flavors based on call-site need:
+ * - `_LINE_START` requires the heading at line-start (multi-line mode) —
+ *   mirrors the original `^##\s+Verification\b/im` semantics for autofix
+ *   and section-extraction call sites that look up section boundaries.
+ * - `_ANY` allows the heading anywhere (start of string OR after a newline)
+ *   — mirrors the `(^|\n)##\s+...` semantics in pr-review-runner where
+ *   the PR title is concatenated before the body.
+ *
+ * Both flavors are case-insensitive and accept either heading. The `\b`
+ * guard prevents over-matching `## Test plans` or `## Verifications`.
+ */
+export const VERIFICATION_HEADING_REGEX_LINE_START = /^##\s+(?:Verification|Test\s+plan)\b/im;
+export const VERIFICATION_HEADING_REGEX_ANY = /(^|\n)##\s+(?:Verification|Test\s+plan)\b/i;
+
+export function hasVerificationHeadingLineStart(text: string): boolean {
+  return VERIFICATION_HEADING_REGEX_LINE_START.test(text);
+}
+
+export function hasVerificationHeadingAny(text: string): boolean {
+  return VERIFICATION_HEADING_REGEX_ANY.test(text);
+}

--- a/tests/pr-lifecycle-governance.test.ts
+++ b/tests/pr-lifecycle-governance.test.ts
@@ -358,4 +358,33 @@ describe('PR lifecycle governance', () => {
       risk: 'high',
     }));
   });
+
+  // Issue #476: hasCompletedVerification must accept ## Test plan as a verification heading,
+  // matching the gh pr create / Claude Code default template (PR #475 widened the same regex
+  // in pr-review-runner; this site is the higher-impact gate because it changes the routed action).
+  it('accepts a completed `## Test plan` block as verification evidence on conflicting PRs (issue #476)', () => {
+    expect(decidePrConflictAction({
+      number: 476,
+      title: 'fix: narrow conflict with test-plan heading',
+      body: '## Test plan\n- [x] `pnpm test` passed',
+      mergeable: 'CONFLICTING',
+      reviewDecision: 'APPROVED',
+      changedFiles: ['src/feedback-loops.ts'],
+    })).toEqual(expect.objectContaining({
+      action: 'attempt-update-branch',
+    }));
+  });
+
+  it('still rejects PRs with neither verification heading (no over-acceptance)', () => {
+    expect(decidePrConflictAction({
+      number: 477,
+      title: 'fix: missing both headings',
+      body: '## Summary\n- [x] some checked task but no verification heading',
+      mergeable: 'CONFLICTING',
+      reviewDecision: 'APPROVED',
+      changedFiles: ['src/feedback-loops.ts'],
+    })).toEqual(expect.objectContaining({
+      action: 'needs-verification',
+    }));
+  });
 });


### PR DESCRIPTION
## Summary
Follow-up to PR #475. Extracts the verification-heading regex into a shared `src/verification-heading.ts` helper, then widens `## Test plan` acceptance at the 3 remaining sites identified in #476.

## Why
`gh pr create` / Claude Code default template emits `## Test plan`, but 4 separate gates hardcoded `## Verification`. PR #475 fixed the consensus-runner gate inline; this PR completes the cleanup with a single source of truth — no drift next time we add a third accepted heading.

Sites patched:
- `src/pr-review-runner.ts:231` (already widened by #475 → now uses helper)
- `src/github.ts:1090` `hasVerificationSection` — autofix gate (cosmetic)
- `src/github.ts:1099 + 1116` `autofixRuntimeAutocorrectVerification` — early-return guard + replacement target widened together (otherwise replacement no-ops on Test plan PRs)
- `src/pr-lifecycle-governance.ts:450` `hasCompletedVerification` — **highest-impact miss**: gates `decidePrConflictAction`, was misrouting conflicting PRs with `## Test plan` evidence to `needs-verification`

## Verification
- [x] `pnpm exec tsc --noEmit` clean (zero errors in patched files; pre-existing `@types/node` warnings unrelated)
- [x] `pnpm exec vitest run tests/pr-review-runner.test.ts tests/pr-lifecycle-governance.test.ts` → **39/39 pass** (16 + 23, +2 new regression tests)
- [x] New positive test: conflicting PR with `## Test plan\n- [x] pnpm test passed` → `attempt-update-branch` (was `needs-verification` before fix)
- [x] New negative test: PR with neither heading still routes to `needs-verification` (no over-acceptance)
- [x] `\b` guard prevents false matches on `## Test plans` / `## Verifications`

Closes #476.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4 <noreply@anthropic.com>