### PR TITLE
fix(pr-lifecycle-governance): accept ## Test plan as completed verification

### DIFF
--- a/src/pr-lifecycle-governance.ts
+++ b/src/pr-lifecycle-governance.ts
@@ -447,7 +447,7 @@ function riskClass(pr: OpenPullRequestSummary): string {
 }
 
 function hasCompletedVerification(text: string): boolean {
-  const section = extractMarkdownSection(text, /^##\s+Verification\b/im);
+  const section = extractMarkdownSection(text, /^##\s+(?:Verification|Test plan)\b/im);
   if (!section) return false;
   return /(?:^|\n)\s*-\s*\[[xX]\]\s+/.test(section)
     || /\b(?:passed|passes|clean|success|ok)\b/i.test(section);

--- a/tests/pr-lifecycle-governance.test.ts
+++ b/tests/pr-lifecycle-governance.test.ts
@@ -328,6 +328,20 @@ describe('PR lifecycle governance', () => {
     }));
   });
 
+  it('accepts ## Test plan with checked evidence as completed verification (issue #476)', () => {
+    expect(decidePrConflictAction({
+      number: 476,
+      title: 'fix: narrow bug with default Test plan heading',
+      body: '## Summary\n- adds endpoint\n\n## Test plan\n- [x] `pnpm test` passed\n- [x] `pnpm typecheck` passes',
+      mergeable: 'CONFLICTING',
+      reviewDecision: 'APPROVED',
+      changedFiles: ['src/feedback-loops.ts', 'tests/feedback-loops.test.ts'],
+    })).toEqual(expect.objectContaining({
+      action: 'attempt-update-branch',
+      risk: 'medium',
+    }));
+  });
+
   it('closes conflicting PRs that target the protected runtime branch instead of main', () => {
     expect(decidePrConflictAction({
       number: 280,


### PR DESCRIPTION
## Summary
- Widens `hasCompletedVerification` regex in `src/pr-lifecycle-governance.ts:450` to accept `## Test plan` heading in addition to `## Verification`.
- Adds regression test for PR with default `gh pr create` template body.
- Closes #476 (partial — behavioral site only; see scope note below).

## Why
This is the behavioral counterpart to PR #475 (`pr-review-runner.ts`). Without this fix, conflicting PRs whose body uses the default `gh pr create` template heading `## Test plan` are routed to `needs-verification` even when they have completed checked evidence (`- [x] passed`). PR #475 fixed the consensus runner; this fixes the conflict-resolution governance path. Reproduction is identical to #469's situation.

## Scope correction vs original #476 plan
Original issue suggested widening 4 regex sites with a shared helper. After investigation, only **1 of 4** is correct to widen:

| Site | Decision | Reason |
|---|---|---|
| `pr-lifecycle-governance.ts:450` `hasCompletedVerification` | ✅ widened | behavioral fix |
| `github.ts:1090` `hasVerificationSection` | ❌ keep narrow | `autofixPrVerificationSection` rename flow depends on `## Test plan` *not* counting as already-Verification, otherwise it can't rename → would break `tests/github-verification-autorepair.test.ts:5` |
| `github.ts:1099` autocorrect autofix early-return | ❌ keep narrow | autocorrect-PR bodies are bot-generated with `## Verification`; widening adds no value |
| `github.ts:1116` autocorrect autofix replace | ❌ keep narrow | paired with 1099 |

Will follow up on #476 to update the scope.

## Verification
- [x] `pnpm exec vitest run tests/pr-lifecycle-governance.test.ts` — 22/22 passed (including new regression test)
- [x] Diff is 2 files, +15 / -1 — strict superset of old behavior
- [x] Verified `## Test plan\n- [ ] verify later` (unchecked) still routes to `needs-verification` (existing test line 318 still passes)
- [x] Verified `## Test plan\n- [x] passed` (checked) now routes to `attempt-update-branch` (new test)

## Falsifier
- `grep:/private/tmp/mini-agent-issue-476/src/pr-lifecycle-governance.ts "Verification|Test plan" >=1` — passes
- Reproduction body: `## Summary\n- adds endpoint\n\n## Test plan\n- [x] pnpm test passed` should now satisfy `hasCompletedVerification`

## Notes for reviewer
- Pre-existing build error in `src/scheduler.ts:394+439` (duplicate `const resolvedKeys`) blocks `tests/github-verification-autorepair.test.ts` from loading. This is unrelated to this PR but should be addressed separately.

🤖 Generated by kuro-agent (autonomous loop, cycle 03bbc29a, $3.85/$5)