### PR TITLE
fix(predicate-freshness): suppress kuro-agent monologue dispatch (#456)

### DIFF
--- a/src/predicate-freshness.ts
+++ b/src/predicate-freshness.ts
@@ -45,7 +45,40 @@ export interface FreshnessContext {
    * issue state (`OPEN` | `CLOSED`) or null when unavailable. Defaults to
    * a real `execFile('gh', ['issue', 'view', ...])` when not provided.
    */
-  ghIssueView?: (repo: string, issueNumber: number) => Promise<{ state: string } | null>;
+  ghIssueView?: (repo: string, issueNumber: number) => Promise<{ state: string; comments?: GitHubComment[] } | null>;
+}
+
+
+export interface GitHubComment {
+  author?: { login?: string | null } | null;
+}
+
+/**
+ * Issue #456: when the most recent kuro-agent comments form an unbroken
+ * monologue (≥ MONOLOGUE_THRESHOLD consecutive, no external interleave),
+ * the conversation is in a self-debate spiral. Skip dispatch until an
+ * external participant comments — re-spawning kuro-agent only piles more
+ * contradicting positions on top.
+ */
+export const KURO_AGENT_LOGIN = 'kuro-agent';
+export const MONOLOGUE_THRESHOLD = 3;
+
+export function hasKuroAgentMonologue(
+  comments: ReadonlyArray<GitHubComment> | undefined,
+): boolean {
+  if (!Array.isArray(comments) || comments.length === 0) return false;
+  let consecutive = 0;
+  for (let i = comments.length - 1; i >= 0; i--) {
+    const login = comments[i]?.author?.login;
+    if (login === KURO_AGENT_LOGIN) {
+      consecutive++;
+      if (consecutive >= MONOLOGUE_THRESHOLD) return true;
+    } else {
+      // Any non-kuro-agent comment breaks the monologue.
+      return false;
+    }
+  }
+  return false;
 }
 
 export type PredicateType =
@@ -258,7 +291,12 @@ export async function checkGitHubIssueOpen(ctx: FreshnessContext): Promise<boole
       ? await ctx.ghIssueView(meta.repo, meta.issueNumber)
       : await defaultGhIssueView(meta.repo, meta.issueNumber);
     if (!result || typeof result.state !== 'string') return null;
-    return result.state.toUpperCase() === 'OPEN';
+    if (result.state.toUpperCase() !== 'OPEN') return false;
+    // Issue #456: skip dispatch when conversation is a kuro-agent monologue.
+    // Re-spawning while no external signal exists piles up more contradicting
+    // positions instead of converging.
+    if (hasKuroAgentMonologue(result.comments)) return false;
+    return true;
   } catch {
     return null;
   }
@@ -279,14 +317,17 @@ function extractGitHubIssueMeta(
 async function defaultGhIssueView(
   repo: string,
   issueNumber: number,
-): Promise<{ state: string } | null> {
+): Promise<{ state: string; comments?: GitHubComment[] } | null> {
   const { stdout } = await execFileAsync(
     'gh',
-    ['issue', 'view', String(issueNumber), '--repo', repo, '--json', 'state'],
+    ['issue', 'view', String(issueNumber), '--repo', repo, '--json', 'state,comments'],
     { timeout: 5000 },
   );
-  const parsed = JSON.parse(stdout) as { state?: unknown };
+  const parsed = JSON.parse(stdout) as { state?: unknown; comments?: unknown };
   if (typeof parsed.state !== 'string') return null;
-  return { state: parsed.state };
+  const comments = Array.isArray(parsed.comments)
+    ? (parsed.comments as GitHubComment[])
+    : undefined;
+  return { state: parsed.state, comments };
 }
 

--- a/tests/predicate-freshness-github-issue.test.ts
+++ b/tests/predicate-freshness-github-issue.test.ts
@@ -53,3 +53,79 @@ describe('reverifyPredicate("github-issue-open")', () => {
     expect(result).toBeNull();
   });
 });
+
+describe('reverifyPredicate("github-issue-open") — kuro-agent monologue (issue #456)', () => {
+  const meta = {
+    id: 'idx-github-issue-miles990-mini-agent-456',
+    payload: { repo: 'miles990/mini-agent', issue_number: 456 },
+  };
+
+  it('returns false (skip dispatch) when last 3+ comments are all kuro-agent', async () => {
+    const result = await reverifyPredicate('github-issue-open', baseCtx({
+      entry: meta,
+      ghIssueView: async () => ({
+        state: 'OPEN',
+        comments: [
+          { author: { login: 'kuro-agent' } },
+          { author: { login: 'kuro-agent' } },
+          { author: { login: 'kuro-agent' } },
+        ],
+      }),
+    }));
+    expect(result).toBe(false);
+  });
+
+  it('returns true (dispatch) when an external comment interleaves kuro-agent', async () => {
+    const result = await reverifyPredicate('github-issue-open', baseCtx({
+      entry: meta,
+      ghIssueView: async () => ({
+        state: 'OPEN',
+        comments: [
+          { author: { login: 'kuro-agent' } },
+          { author: { login: 'kuro-agent' } },
+          { author: { login: 'miles990' } },
+          { author: { login: 'kuro-agent' } },
+        ],
+      }),
+    }));
+    expect(result).toBe(true);
+  });
+
+  it('returns true (dispatch) when fewer than 3 consecutive kuro-agent comments at tail', async () => {
+    const result = await reverifyPredicate('github-issue-open', baseCtx({
+      entry: meta,
+      ghIssueView: async () => ({
+        state: 'OPEN',
+        comments: [
+          { author: { login: 'kuro-agent' } },
+          { author: { login: 'kuro-agent' } },
+        ],
+      }),
+    }));
+    expect(result).toBe(true);
+  });
+
+  it('returns true (dispatch) when comments field is omitted', async () => {
+    const result = await reverifyPredicate('github-issue-open', baseCtx({
+      entry: meta,
+      ghIssueView: async () => ({ state: 'OPEN' }),
+    }));
+    expect(result).toBe(true);
+  });
+
+  it('treats trailing non-kuro-agent comment as breaking the monologue (3 kuro then 1 external)', async () => {
+    const result = await reverifyPredicate('github-issue-open', baseCtx({
+      entry: meta,
+      ghIssueView: async () => ({
+        state: 'OPEN',
+        comments: [
+          { author: { login: 'kuro-agent' } },
+          { author: { login: 'kuro-agent' } },
+          { author: { login: 'kuro-agent' } },
+          { author: { login: 'miles990' } },
+        ],
+      }),
+    }));
+    expect(result).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Closes #456: scheduler kept respawning kuro-agent on issues where 3+ consecutive kuro-agent comments already existed without external interleaving (5x self-debate on #455 in 16min).
- Extends existing `checkGitHubIssueOpen` predicate to also detect kuro-agent monologue and return `false` (skip dispatch). External comment automatically unblocks the queue.
- Single-predicate change; no new scheduler state, no new dispatch path.

## Why this approach (Option 1 from #456 body)
Option 1 was the cheap structural fix proposed in the issue. The freshness predicate is already the choke point for github-issue tasks (PR #467 wired it for OPEN/CLOSED), so adding the monologue gate here means zero new infrastructure. Threshold = 3 matches the issue's own falsifier (`≥ 1` kuro-agent comment OR external interleaving between any two).

## Verification
- [x] `pnpm exec vitest run tests/predicate-freshness-github-issue.test.ts` → **11/11 pass** (6 existing + 5 new)
- [x] Tests injected via `ctx.ghIssueView` — no real `gh` calls
- [x] New tests cover: 3-monologue suppresses, external interleave proceeds, sub-threshold proceeds, omitted comments proceeds, trailing external comment proceeds
- [x] Strict superset of prior behavior (when `comments` undefined → unchanged)
- [x] Pre-existing tsc error in `src/scheduler.ts` (resolvedKeys redeclare) is on origin/main and unrelated

## Falsifier (per #456)
After merge, a future issue showing 3+ consecutive kuro-agent comments without external interleaving = fix not effective. Self-discipline note from #456 still applies — no further kuro-agent comments on #455 / #456 until external response.

🤖 by kuro-agent (autonomous, agent-middleware cycle 03bbc29a)