### PR TITLE
fix(preflight-drain): Path A' minimalMode — drain rebuilds effectivePrompt with task-signal continuity (issue #468)

### DIFF
--- a/src/loop.ts
+++ b/src/loop.ts
@@ -2696,7 +2696,7 @@ export class AgentLoop {
         slog('LOOP', `[telemetry] trueNoopStreak=${this.trueNoopStreak} — no prompt injection, trusting SOUL`);
       }
 
-      const prompt = priorityPrefix + schedulerTaskPrefix + promptResult.prompt + triageHint + triggerSuffix + previousCycleSuffix + interruptedSuffix + foregroundReplySuffix + hesitationReviewSuffix + workJournalSuffix;
+      let prompt = priorityPrefix + schedulerTaskPrefix + promptResult.prompt + triageHint + triggerSuffix + previousCycleSuffix + interruptedSuffix + foregroundReplySuffix + hesitationReviewSuffix + workJournalSuffix;
 
       // Phase 1c: Save checkpoint before calling Claude
       saveCycleCheckpoint({
@@ -2790,18 +2790,33 @@ export class AgentLoop {
       if (effectivePrompt.length >= PREFLIGHT_SIZE_THRESHOLD) {
         // Phase-2 drain (issue #414): rebuild context in minimal mode to reduce total token load
         // and avoid the HTTP-stall pattern (25K+ prompt × 800s+ duration → CLI silent exit).
+        // Issue #468 Path A′: after rebuilding context, also re-run buildAutonomousPromptFn with
+        // minimalMode:true so prompt and effectivePrompt actually shrink. The minimal build keeps
+        // commitment gate + ledger + delegationReviewGate for task-signal continuity, skipping
+        // rumination/threads/innerVoice/backgroundLane/verifiedRoutes (the expensive sections).
+        // This replaces the Path B stopgap (buildIdlePrompt) that discarded task context entirely.
         const contextBefore = context.length;
         try {
           context = await memory.buildContext({ mode: 'minimal', cycleCount: this.cycleCount, trigger: currentTriggerReason ?? undefined });
-          // Issue #468: drain previously rebuilt only `context`; effectivePrompt stayed at the original
-          // pre-drain size, so callClaude still sent a 30K+ prompt → silent_exit_void_http TIMEOUT.
-          // Path B stopgap: replace effectivePrompt with the lightweight idle prompt during drain so
-          // the call actually shrinks. We accept temporary loss of full task-signal continuity in
-          // exchange for unblocking the cycle; Path A′ (re-run buildAutonomousPromptFn with
-          // minimalMode) remains the proper fix tracked in #468.
+          const drainPromptResult = await buildAutonomousPromptFn({
+            lastAutonomousActions: this.lastAutonomousActions,
+            consecutiveLearnCycles: this.consecutiveLearnCycles,
+            lastValidConfig: this.lastValidConfig,
+            hasPendingTasks,
+            cycleCount: this.cycleCount,
+            minimalMode: true,
+          });
           const promptBefore = effectivePrompt.length;
-          effectivePrompt = buildIdlePrompt();
-          slog('LOOP', `[preflight.drain] effectivePrompt ${promptBefore} >= ${PREFLIGHT_SIZE_THRESHOLD} — context ${contextBefore} → ${context.length}, prompt ${promptBefore} → ${effectivePrompt.length} (idle)`);
+          prompt = priorityPrefix + schedulerTaskPrefix + drainPromptResult.prompt + triageHint + triggerSuffix + previousCycleSuffix + interruptedSuffix + foregroundReplySuffix + hesitationReviewSuffix + workJournalSuffix;
+          effectivePrompt = cycleMode === 'idle'
+            ? buildIdlePrompt()
+            : prompt + (selectedSkillPrompt ? `\n\n${selectedSkillPrompt}` : '');
+          // Safety guard: if the rebuilt prompt still exceeds the threshold (e.g. suffix-heavy),
+          // log a warning and proceed — do not recurse.
+          if (effectivePrompt.length >= PREFLIGHT_SIZE_THRESHOLD) {
+            slog('LOOP', `[preflight.drain.guard] rebuilt effectivePrompt still ${effectivePrompt.length} >= ${PREFLIGHT_SIZE_THRESHOLD} — proceeding with minimal payload`);
+          }
+          slog('LOOP', `[preflight.drain] effectivePrompt ${promptBefore} >= ${PREFLIGHT_SIZE_THRESHOLD} — context ${contextBefore} → ${context.length}, prompt ${promptBefore} → ${effectivePrompt.length} (minimal)`);
           eventBus.emit('action:loop', { event: 'preflight.drain', promptSize: promptBefore, promptAfter: effectivePrompt.length, threshold: PREFLIGHT_SIZE_THRESHOLD, contextBefore, contextAfter: context.length, cycleMode, trigger: currentTriggerReason ?? null });
         } catch (drainErr) {
           // Drain failed — fall back to observability-only; call proceeds with original context.

--- a/src/prompt-builder.ts
+++ b/src/prompt-builder.ts
@@ -592,6 +592,11 @@ export interface PromptBuilderState {
   hasPendingTasks?: boolean;
   controlMode?: 'calm' | 'reserved' | 'autonomous' | 'custom';
   cycleCount?: number;
+  /** Issue #468 Path A′: when true, skip expensive sections (rumination, threads,
+   *  innerVoice, backgroundLane, verifiedRoutes, pendingFetchArrivals) to produce a
+   *  compact prompt during preflight drain. Commitment gate + ledger are retained so
+   *  task-signal continuity is preserved across the drained cycle. */
+  minimalMode?: boolean;
 }
 
 /** Autonomous Mode: 無任務時根據 SOUL 主動行動 */
@@ -616,6 +621,23 @@ export async function buildAutonomousPrompt(
     );
 
   const memory = getMemory();
+
+  // Issue #468 Path A′: in minimalMode, skip all expensive I/O sections — rumination,
+  // threads, innerVoice, backgroundLane, verifiedRoutes, pendingFetchArrivals — and
+  // keep only base + commitment gate + ledger + delegationReviewGate so the resulting
+  // prompt is small enough to unblock a drained cycle while preserving task continuity.
+  if (state.minimalMode) {
+    const commitmentGateSectionMin = buildCommitmentSection(memory.getMemoryDir());
+    const ledgerSectionMin = state.cycleCount != null ? buildLedgerSection(state.cycleCount) : '';
+    const delegationReviewGateMin = buildDelegationReviewGate();
+    const parts = [base];
+    if (commitmentGateSectionMin) parts.push(commitmentGateSectionMin);
+    if (ledgerSectionMin) parts.push(ledgerSectionMin);
+    if (delegationReviewGateMin) parts.push(delegationReviewGateMin);
+    const prompt = parts.join('\n\n');
+    slog('PROMPT', `prompt size (minimal): ${prompt.length} chars (${parts.length} sections)`);
+    return { prompt, lastValidConfig, researchLoopActive: false };
+  }
 
   // Conversation threads already injected by buildContext() as <conversation-threads> section.
   // Only inject chat-mode time awareness here.

--- a/tests/preflight-threshold-414.test.ts
+++ b/tests/preflight-threshold-414.test.ts
@@ -108,4 +108,31 @@ describe('preflight threshold — issue #414', () => {
     expect(loopSrc).toContain("mode: 'minimal'");
     expect(loopSrc).toContain("event: 'preflight.drain'");
   });
+
+  // Issue #468 Path A′: drain must re-derive prompt and effectivePrompt from a
+  // minimalMode buildAutonomousPromptFn call so the actual HTTP payload shrinks,
+  // not just the context string. Task-signal continuity is preserved (vs Path B
+  // buildIdlePrompt stopgap which discarded scheduler task context entirely).
+  it('loop.ts drain re-runs buildAutonomousPromptFn with minimalMode:true (issue #468 Path A′)', () => {
+    const loopSrc = readFileSync(resolve(import.meta.dirname!, '../src/loop.ts'), 'utf8');
+    expect(loopSrc).toContain('minimalMode: true');
+  });
+
+  it('loop.ts drain rebuilds prompt and effectivePrompt from minimal result (issue #468 Path A′)', () => {
+    const loopSrc = readFileSync(resolve(import.meta.dirname!, '../src/loop.ts'), 'utf8');
+    expect(loopSrc).toContain('drainPromptResult');
+    expect(loopSrc).toContain('(minimal)');
+  });
+
+  it('prompt-builder.ts PromptBuilderState declares minimalMode field (issue #468 Path A′)', () => {
+    const pbSrc = readFileSync(resolve(import.meta.dirname!, '../src/prompt-builder.ts'), 'utf8');
+    expect(pbSrc).toContain('minimalMode?: boolean');
+  });
+
+  it('prompt-builder.ts buildAutonomousPrompt honours minimalMode early-return (issue #468 Path A′)', () => {
+    const pbSrc = readFileSync(resolve(import.meta.dirname!, '../src/prompt-builder.ts'), 'utf8');
+    const hits = (pbSrc.match(/minimalMode/g) ?? []).length;
+    expect(hits).toBeGreaterThanOrEqual(2);
+    expect(pbSrc).toContain('state.minimalMode');
+  });
 });


### PR DESCRIPTION
## Summary

- Upgrades the #468 Path B stopgap (PR #469) to the proper Path A' fix: re-run `buildAutonomousPromptFn` with `minimalMode: true` in the preflight drain block so that `effectivePrompt` shrinks to a compact prompt that retains task context (commitment gate + ledger + delegation review gate), not just the idle prompt.
- Adds `minimalMode?: boolean` to `PromptBuilderState` interface in `prompt-builder.ts` with an early-return branch that skips expensive I/O sections (rumination, threads, innerVoice, backgroundLane, verifiedRoutes, pendingFetchArrivals).
- Changes `const prompt` → `let prompt` in `loop.ts` drain block so the drain can reassign both `prompt` and `effectivePrompt`.
- Adds 4 new tests to `preflight-threshold-414.test.ts` covering Path A' invariants (interface field, minimalMode consumer hit count, drainPromptResult usage, `(minimal)` slog tag).

## Verification

- [x] `pnpm exec vitest run tests/preflight-threshold-414.test.ts` — 16/16 pass (12 pre-existing + 4 new)
- [x] Full suite passes (1039 tests, scheduler.ts pre-existing error unrelated)
- [ ] Post-deploy: `grep '[preflight.drain]' $LOG` should show `prompt N → M` with M substantially below 25K (task-signal retained, not empty idle prompt)
- [ ] Post-deploy: `TIMEOUT:silent_exit_void_http::callClaude.lastSeen` halts advancing

Refs: #468 (root issue), #414 (original recurrence triage), PR #469 (Path B stopgap, merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)