### PR TITLE
fix(runtime): preserve local runtime commit dirty-moyz0i43

### DIFF
--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -429,35 +429,21 @@ export function schedulerPick(
         slog('SCHED', `dispatch-resolved: skipping task=${t.id.slice(0, 12)} ${summary.slice(0, 50)} (stack_rank summary match)`);
         return false;
       }
+      // Mirror memory-index.getP0TaskPreviews: stack_rank events sometimes
+      // store a longer/shorter title variant. Require >=24 chars to avoid
+      // suppressing unrelated generic work.
+      if (summary.length >= 24) {
+        for (const resolvedSummary of resolvedKeys.summaries) {
+          if (resolvedSummary.length < 24) continue;
+          if (summary.includes(resolvedSummary) || resolvedSummary.includes(summary)) {
+            slog('SCHED', `dispatch-resolved: skipping task=${t.id.slice(0, 12)} ${summary.slice(0, 50)} (stack_rank substring match)`);
+            return false;
+          }
+        }
+      }
       return true;
     });
 
-  // Issue #P0-stack-rank: filter tasks whose latest stack_rank event marks them
-  // resolved. Mirrors memory-index.getP0TaskPreviews logic so scheduler dispatch
-  // stays consistent with prompt display — without this, resolved-phantom tasks
-  // re-dispatch every cycle despite being hidden from the heartbeat.
-  const resolvedKeys = loadResolvedTaskKeysFromEvents(memoryDir);
-  const tasksAfterResolved = tasks.filter(t => {
-    if (resolvedKeys.ids.has(t.id)) {
-      slog('SCHED', `dispatch-stack-rank-resolved: skipping task=${t.id.slice(0, 12)} ${t.summary.slice(0, 50)} (resolved via stack_rank)`);
-      return false;
-    }
-    const summary = t.summary.trim();
-    if (summary && resolvedKeys.summaries.has(summary)) {
-      slog('SCHED', `dispatch-stack-rank-resolved: skipping task=${t.id.slice(0, 12)} ${t.summary.slice(0, 50)} (resolved via stack_rank summary match)`);
-      return false;
-    }
-    if (summary.length >= 24) {
-      for (const resolvedSummary of resolvedKeys.summaries) {
-        if (resolvedSummary.length < 24) continue;
-        if (summary.includes(resolvedSummary) || resolvedSummary.includes(summary)) {
-          slog('SCHED', `dispatch-stack-rank-resolved: skipping task=${t.id.slice(0, 12)} ${t.summary.slice(0, 50)} (resolved via stack_rank substring)`);
-          return false;
-        }
-      }
-    }
-    return true;
-  });
   // Issue #316: drop correction tasks whose hold is still active. Mirrors the
   // filter already applied in memory-index.getP0TaskPreviews so the dispatch
   // path stays consistent with the prompt-header preview path. Without this,

--- a/tests/scheduler-dispatch-suppression.test.ts
+++ b/tests/scheduler-dispatch-suppression.test.ts
@@ -286,6 +286,33 @@ describe('schedulerPick — suppressed tasks excluded from dispatch', () => {
     expect(decision.taskId).not.toBe(correction.id);
   });
 
+  it('does not pick a task whose stack-rank resolved summary is a title variant', async () => {
+    const resolved = await appendMemoryIndexEntry(tmpDir, {
+      type: 'task',
+      status: 'pending',
+      summary: 'P0 GitHub issue #453: silent_exit_void_midprompt follow-up recovery recipe',
+      payload: { priority: 0 },
+    });
+    const active = await appendMemoryIndexEntry(tmpDir, {
+      type: 'task',
+      status: 'pending',
+      summary: 'P0 active fallback work',
+      payload: { priority: 0 },
+    });
+    fs.mkdirSync(path.join(tmpDir, 'state'), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, 'state', 'task-events.jsonl'), JSON.stringify({
+      kind: 'stack_rank',
+      task: 'silent_exit_void_midprompt follow-up recovery recipe',
+      to: 'resolved-phantom',
+    }) + '\n');
+    invalidateIndexCache();
+
+    const decision = schedulerPick(tmpDir, []);
+
+    expect(decision.taskId).toBe(active.id);
+    expect(decision.taskId).not.toBe(resolved.id);
+  });
+
   it('resets suppression on a human-directed scheduler event', async () => {
     const task = await appendMemoryIndexEntry(tmpDir, {
       type: 'task',


### PR DESCRIPTION
## Summary
- autocorrected 0 commit(s) that were made on protected runtime/main
- moved the change into an isolated worktree branch so review/merge/deploy can proceed normally
- reset the runtime checkout back to origin/main after preserving the change

## Verification
- [x] `git push -u origin fix/runtime-autocorrect-dirty-moyz0i43` passed; the runtime-local commit is preserved on an isolated review branch
- [x] `git reset --hard origin/main` passed; the protected runtime checkout was restored to origin/main