### PR TITLE
fix(test): preserve scheduler task events in resolved-filter regression

### DIFF
--- a/tests/scheduler-dispatch-suppression.test.ts
+++ b/tests/scheduler-dispatch-suppression.test.ts
@@ -300,7 +300,7 @@ describe('schedulerPick — suppressed tasks excluded from dispatch', () => {
       payload: { priority: 0 },
     });
     fs.mkdirSync(path.join(tmpDir, 'state'), { recursive: true });
-    fs.writeFileSync(path.join(tmpDir, 'state', 'task-events.jsonl'), JSON.stringify({
+    fs.appendFileSync(path.join(tmpDir, 'state', 'task-events.jsonl'), JSON.stringify({
       kind: 'stack_rank',
       task: 'silent_exit_void_midprompt follow-up recovery recipe',
       to: 'resolved-phantom',


### PR DESCRIPTION
## Summary
- preserve existing task-events when testing stack-rank resolved-title suppression
- keeps the scheduler resolved-filter regression representative of real memory state

## Verification
- pnpm typecheck
- pnpm exec vitest run tests/scheduler-dispatch-suppression.test.ts
- pnpm build