### PR TITLE
feat: gate high-risk work on design governance

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "memory:repo:check": "tsx scripts/setup-memory-repo.ts --check",
     "memory:kg:promote": "tsx scripts/kg-promote-memory.ts",
     "guard:issue-evidence": "tsx scripts/guard-issue-evidence.ts",
+    "check:design-governance": "tsx scripts/check-design-governance.ts",
     "skill-promotion:autopilot": "tsx scripts/skill-promotion-autopilot.ts",
     "check:autonomy-closure": "tsx scripts/autonomy-closure-health.ts",
     "check:test-health": "tsx scripts/test-health-autopilot.ts",

--- a/scripts/check-design-governance.ts
+++ b/scripts/check-design-governance.ts
@@ -1,0 +1,21 @@
+#!/usr/bin/env tsx
+import { getMemoryRootDir } from '../src/memory-paths.js';
+import { evaluateDesignGovernance } from '../src/design-governance.js';
+import { queryMemoryIndexSync } from '../src/memory-index.js';
+
+const args = new Set(process.argv.slice(2));
+const memoryDir = getMemoryRootDir();
+const openTasks = queryMemoryIndexSync(memoryDir, {
+  type: ['task'],
+  status: ['pending', 'in_progress', 'needs-decomposition', 'blocked', 'hold'],
+});
+const report = evaluateDesignGovernance(memoryDir, openTasks);
+
+if (args.has('--json')) {
+  process.stdout.write(JSON.stringify(report, null, 2) + '\n');
+} else {
+  process.stdout.write(`design governance: ${report.status} — ${report.summary}\n`);
+  for (const line of report.evidence) process.stdout.write(`- ${line}\n`);
+}
+
+if (report.status === 'blocked') process.exit(1);

--- a/src/autonomy-closure-diagnostics.ts
+++ b/src/autonomy-closure-diagnostics.ts
@@ -180,6 +180,27 @@ function diagnoseStage(stage: AutonomyClosureStageResult, ts: string): AutonomyC
     };
   }
 
+  if (stage.stage === 'design-governance') {
+    return {
+      ...base,
+      status: 'fallback-task',
+      rootCause: 'High-risk autonomous work lacks a versioned design artifact or executable invariant plan.',
+      evidence: stage.evidence,
+      probeCommands: [
+        'pnpm check:autonomy-closure -- --json',
+        'find "$MINI_AGENT_MEMORY_DIR/proposals/design-artifacts" -maxdepth 1 -type f -name "*.md" 2>/dev/null | sort | tail -n 20',
+        'rg -n "design_governance_required|design-depth|Constraint Texture|```mermaid" "$MINI_AGENT_MEMORY_DIR" src tests',
+      ],
+      constraintTexture: constraintTextureFor(stage, 'high-risk work must externalize the intended data flow, state machine, failure path, tests, and backtest before implementation proceeds'),
+      mechanicalAction: 'none',
+      fallbackTask: {
+        title: 'P1 diagnostic: create missing design-governance artifact',
+        verifyCommand: 'pnpm check:autonomy-closure -- --json',
+        acceptanceCriteria: 'Every high-risk active implementation task has a design artifact or an explicit trivial exemption; artifacts include Constraint Texture, Mermaid data flow/state/operator diagrams, failure path, acceptance/falsifier, test plan, review plan, and effect backtest.',
+      },
+    };
+  }
+
   return {
     ...base,
     status: 'fallback-task',

--- a/src/autonomy-closure-health.ts
+++ b/src/autonomy-closure-health.ts
@@ -13,6 +13,7 @@ import { readClassifiedMiddlewareTaskIds } from './middleware-failure-self-heali
 import { getFeature } from './features.js';
 import { evaluatePublicWriteIdentity } from './public-write-identity.js';
 import { readDelegationFailureRecordsSync } from './delegation-failure-guard.js';
+import { evaluateDesignGovernance } from './design-governance.js';
 
 export type AutonomyClosureStage =
   | 'runtime-workspace'
@@ -23,6 +24,7 @@ export type AutonomyClosureStage =
   | 'public-write-identity'
   | 'ship-and-deploy'
   | 'self-improvement'
+  | 'design-governance'
   | 'memory-context'
   | 'memory-state-truth'
   | 'kg-context-fabric'
@@ -70,8 +72,7 @@ export function evaluateAutonomyClosure(
   const repoRoot = options.repoRoot ?? process.cwd();
   const correction = evaluateCorrectionGate(memoryDir, repoRoot);
   const resolvedKeys = loadResolvedTaskKeysFromEvents(memoryDir);
-  const openTasks = queryMemoryIndexSync(memoryDir, { type: ['task'], status: ACTIVE_STATUSES })
-    .filter(task => !isAutonomyClosureTask(task))
+  const activeTasks = queryMemoryIndexSync(memoryDir, { type: ['task'], status: ACTIVE_STATUSES })
     .filter(task => {
       if (resolvedKeys.ids.has(task.id)) return false;
       const summary = task.summary?.trim() ?? '';
@@ -84,6 +85,7 @@ export function evaluateAutonomyClosure(
       }
       return true;
     });
+  const openTasks = activeTasks.filter(task => !isAutonomyClosureTask(task));
   const kgStage = kgContextFabricStage(memoryDir, options.now ?? new Date());
   const middlewareStage = middlewareQualityStage(memoryDir, options.now ?? new Date());
   const stages: AutonomyClosureStageResult[] = [
@@ -95,6 +97,7 @@ export function evaluateAutonomyClosure(
     publicWriteIdentityStage(memoryDir),
     shipAndDeployStage(correction),
     selfImprovementStage(openTasks),
+    designGovernanceStage(memoryDir, activeTasks),
     memoryContextStage(memoryDir, repoRoot),
     memoryStateTruthStage(memoryDir, repoRoot),
     kgStage,
@@ -526,6 +529,29 @@ function selfImprovementStage(openTasks: MemoryIndexEntry[]): AutonomyClosureSta
   };
 }
 
+function designGovernanceStage(memoryDir: string, openTasks: MemoryIndexEntry[]): AutonomyClosureStageResult {
+  const result = evaluateDesignGovernance(memoryDir, openTasks);
+  if (result.status !== 'ok') {
+    return {
+      stage: 'design-governance',
+      status: result.status,
+      summary: result.summary,
+      evidence: result.evidence,
+      repair: [
+        'Before implementation, create memory/proposals/design-artifacts/<task-id>.md with Constraint Texture, Mermaid data flow, state machine, user/operator flow, failure path, acceptance/falsifier, test plan, review plan, and effect backtest.',
+        'For trivial one-line work, mark the task design_depth=trivial or tag design-exempt with evidence.',
+        'Implementation should cite the design artifact, tests should enforce the critical invariants, and post-merge backtest should update KG/memory.',
+      ].join(' '),
+    };
+  }
+  return {
+    stage: 'design-governance',
+    status: 'ok',
+    summary: result.summary,
+    evidence: result.evidence,
+  };
+}
+
 function memoryContextStage(memoryDir: string, repoRoot: string): AutonomyClosureStageResult {
   const placement = evaluateRuntimeMemoryPlacement(repoRoot);
   const hasTaskEvents = existsSync(path.join(memoryDir, 'state', 'task-events.jsonl'));
@@ -684,6 +710,7 @@ function buildRecommendedTask(
       'Before retrying broad LLM work, read the latest state/autonomy-closure-diagnostics.jsonl case for this stage and run its probes.',
       'The fix must improve the operating process, not only the symptom: add a reusable classifier, probe, guardrail, or self-healing transition when the failure mode can recur.',
       'Do not leave unmanaged technical debt: either remove obsolete state/tasks, document a bounded hold with release criteria, or add a follow-up with a falsifiable acceptance check.',
+      'For high-risk autonomy/data-flow/state/workflow changes, pass design-governance first: Constraint Texture -> Mermaid/ASCII design artifact -> implementation -> review -> invariant tests -> deploy -> effect backtest -> KG/memory update.',
       'Expected loop: issue/task visible -> isolated worktree -> PR -> review consensus -> merge -> deploy -> runtime clean -> memory/KG context updated.',
     ].join(' '),
   };

--- a/src/delegation-failure-guard.ts
+++ b/src/delegation-failure-guard.ts
@@ -61,7 +61,8 @@ export function recordDelegationFailure(
   const signature = failureSignature(input.taskType, input.prompt, input.output);
   const existing = latest.get(signature);
   const timestamp = now.toISOString();
-  const reopened = existing ? shouldReopen(existing.status) : false;
+  const keepTerminalResolved = existing ? shouldKeepTerminalResolution(existing, input.output) : false;
+  const reopened = existing && !keepTerminalResolved ? shouldReopen(existing.status) : false;
   const record: DelegationFailureRecord = existing
     ? {
       ...existing,
@@ -70,7 +71,7 @@ export function recordDelegationFailure(
       prompt: input.prompt.slice(0, 500),
       error: failureError(input.output),
       frequency: existing.frequency + 1,
-      status: reopened ? 'open' : existing.status,
+      status: keepTerminalResolved ? existing.status : reopened ? 'open' : existing.status,
       lastSeen: timestamp,
       ...(reopened ? { resolution: undefined, resolvedAt: undefined } : {}),
     }
@@ -241,4 +242,13 @@ export function isActionableDelegationFailure(record: DelegationFailureRecord): 
 
 function shouldReopen(status: DelegationFailureStatus): boolean {
   return status === 'resolved' || status === 'ignored';
+}
+
+function shouldKeepTerminalResolution(existing: DelegationFailureRecord, output: string): boolean {
+  if (!['resolved', 'ignored'].includes(existing.status)) return false;
+  const resolution = (existing.resolution ?? '').toLowerCase();
+  const error = failureError(output).toLowerCase();
+  const isMaxTurns = /maximum number of turns|max turns|reached maximum number of turns/.test(error);
+  const terminalResolution = /terminal telemetry|do not retry the same prompt unchanged|split the origin task|decompose/.test(resolution);
+  return isMaxTurns && terminalResolution;
 }

--- a/src/design-governance.ts
+++ b/src/design-governance.ts
@@ -1,0 +1,259 @@
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import type { MemoryIndexEntry } from './memory-index.js';
+
+export type DesignGovernanceStatus = 'ok' | 'warn' | 'blocked';
+export type DesignGovernanceDepth = 'trivial' | 'standard' | 'deep';
+
+export interface DesignGovernanceTaskFinding {
+  taskId: string;
+  summary: string;
+  status: string;
+  depth: DesignGovernanceDepth;
+  reason: string;
+  artifactPath?: string;
+  missingSections: string[];
+}
+
+export interface DesignGovernanceReport {
+  status: DesignGovernanceStatus;
+  summary: string;
+  evidence: string[];
+  missingArtifacts: DesignGovernanceTaskFinding[];
+  incompleteArtifacts: DesignGovernanceTaskFinding[];
+}
+
+const DESIGN_ARTIFACT_ROOT = path.join('proposals', 'design-artifacts');
+const ACTIVE_IMPLEMENTATION_STATUSES = new Set(['in_progress', 'needs-decomposition', 'blocked']);
+const HIGH_RISK_TAGS = new Set([
+  'architecture',
+  'autonomy-closure',
+  'data-flow',
+  'design-governance',
+  'kg',
+  'middleware',
+  'multi-agent',
+  'skill',
+  'state-machine',
+  'workflow',
+]);
+
+const HIGH_RISK_SUMMARY_RE = /\b(?:autonomy closure|autonomy-closure|scheduler|middleware|delegation|multi-?brain|kg|knowledge graph|memory|state machine|state-machine|data flow|data-flow|workflow|skill|identity|auth|webhook|deploy|dashboard|api|provider|runtime workspace|runtime-workspace)\b/i;
+
+const REQUIRED_SECTIONS: Array<{ key: string; label: string; pattern: RegExp }> = [
+  { key: 'constraint-texture', label: 'Constraint Texture', pattern: /constraint\s+texture/i },
+  { key: 'data-flow', label: 'Data Flow', pattern: /data\s+flow|資料流/i },
+  { key: 'state-machine', label: 'State Machine', pattern: /state\s+machine|狀態機/i },
+  { key: 'operator-flow', label: 'User/Operator Flow', pattern: /(?:user|operator)\s+flow|用戶流程|操作流程/i },
+  { key: 'failure-path', label: 'Failure Path', pattern: /failure\s+path|fallback|rollback|失敗路徑|回退/i },
+  { key: 'acceptance', label: 'Acceptance/Falsifier', pattern: /acceptance|falsifier|驗收|反證/i },
+  { key: 'test-plan', label: 'Test Plan', pattern: /test\s+plan|verification|測試|驗證/i },
+  { key: 'backtest', label: 'Effect Backtest', pattern: /backtest|effect\s+backtest|效果回測|回測/i },
+  { key: 'mermaid', label: 'Mermaid Diagram', pattern: /```mermaid/i },
+];
+
+export function evaluateDesignGovernance(
+  memoryDir: string,
+  openTasks: MemoryIndexEntry[],
+): DesignGovernanceReport {
+  const risky = openTasks
+    .map(task => classifyDesignNeed(task))
+    .filter((finding): finding is DesignGovernanceTaskFinding => finding !== null);
+
+  const missingArtifacts: DesignGovernanceTaskFinding[] = [];
+  const incompleteArtifacts: DesignGovernanceTaskFinding[] = [];
+
+  for (const finding of risky) {
+    const artifact = findDesignArtifact(memoryDir, finding);
+    if (!artifact) {
+      missingArtifacts.push(finding);
+      continue;
+    }
+
+    const missingSections = missingDesignSections(artifact.content);
+    const enriched = {
+      ...finding,
+      artifactPath: artifact.relPath,
+      missingSections,
+    };
+    if (missingSections.length > 0) incompleteArtifacts.push(enriched);
+  }
+
+  const hasBlocking = [...missingArtifacts, ...incompleteArtifacts].some(finding =>
+    ACTIVE_IMPLEMENTATION_STATUSES.has(finding.status),
+  );
+  const status: DesignGovernanceStatus = hasBlocking
+    ? 'blocked'
+    : missingArtifacts.length > 0 || incompleteArtifacts.length > 0 ? 'warn' : 'ok';
+
+  const evidence = [
+    ...missingArtifacts.slice(0, 5).map(finding =>
+      `${finding.taskId} missing design artifact: ${finding.reason}`,
+    ),
+    ...incompleteArtifacts.slice(0, 5).map(finding =>
+      `${finding.taskId} incomplete ${finding.artifactPath}: missing ${finding.missingSections.join(', ')}`,
+    ),
+  ];
+
+  return {
+    status,
+    summary: status === 'ok'
+      ? `${risky.length} high-risk task(s) have design governance`
+      : `${missingArtifacts.length} missing and ${incompleteArtifacts.length} incomplete design artifact(s)`,
+    evidence,
+    missingArtifacts,
+    incompleteArtifacts,
+  };
+}
+
+export function buildDesignArtifactTemplate(task: Pick<MemoryIndexEntry, 'id' | 'summary' | 'refs' | 'tags'>): string {
+  const title = task.summary ?? task.id;
+  return [
+    `# Design Artifact: ${title}`,
+    '',
+    `Task: ${task.id}`,
+    `Refs: ${(task.refs ?? []).join(', ') || 'none'}`,
+    `Tags: ${(task.tags ?? []).join(', ') || 'none'}`,
+    '',
+    '## Constraint Texture',
+    '- Tension:',
+    '- Bottleneck:',
+    '- Waste mode:',
+    '- Convergence rule:',
+    '',
+    '## Data Flow',
+    '```mermaid',
+    'flowchart TD',
+    '  A[Input / signal] --> B[Classifier / planner]',
+    '  B --> C[Implementation]',
+    '  C --> D[Verifier]',
+    '  D --> E[KG / memory feedback]',
+    '```',
+    '',
+    '## State Machine',
+    '```mermaid',
+    'stateDiagram-v2',
+    '  [*] --> Planned',
+    '  Planned --> Implementing',
+    '  Implementing --> Reviewing',
+    '  Reviewing --> Testing',
+    '  Testing --> Deployed',
+    '  Testing --> Revising',
+    '  Revising --> Implementing',
+    '  Deployed --> Backtested',
+    '```',
+    '',
+    '## User/Operator Flow',
+    '```mermaid',
+    'sequenceDiagram',
+    '  participant User',
+    '  participant Agent',
+    '  participant Runtime',
+    '  participant KG',
+    '  User->>Agent: goal / issue / observation',
+    '  Agent->>Runtime: plan and execute',
+    '  Runtime->>KG: record context and result',
+    '  Agent-->>User: progress and completion summary',
+    '```',
+    '',
+    '## Failure Path',
+    '- Retry limit:',
+    '- Fallback strategy:',
+    '- Escalation / hold condition:',
+    '- Rollback:',
+    '',
+    '## Acceptance/Falsifier',
+    '- Acceptance:',
+    '- Falsifier:',
+    '',
+    '## Test Plan',
+    '- Unit:',
+    '- Integration:',
+    '- Verifier:',
+    '',
+    '## Review Plan',
+    '- Code review focus:',
+    '- Diagram/code consistency check:',
+    '',
+    '## Effect Backtest',
+    '- Metric:',
+    '- Observation window:',
+    '- KG/memory update:',
+    '',
+  ].join('\n');
+}
+
+function classifyDesignNeed(task: MemoryIndexEntry): DesignGovernanceTaskFinding | null {
+  const payload = (task.payload ?? {}) as Record<string, unknown>;
+  const explicitDepth = String(payload.design_depth ?? payload.designDepth ?? '').toLowerCase();
+  if (explicitDepth === 'trivial' || task.tags?.includes('design-exempt')) return null;
+  const explicitRequired = payload.design_governance_required === true || payload.designGovernanceRequired === true;
+  if (String(task.status) === 'hold' && !explicitRequired) return null;
+  if (payload.origin === 'autonomy-closure' && !explicitRequired) return null;
+
+  const summary = task.summary ?? '';
+  if (/autonomy closure:\s*repair design-governance/i.test(summary)) return null;
+  const tags = task.tags ?? [];
+  const tagRequired = tags.some(tag => HIGH_RISK_TAGS.has(tag));
+  const summaryRequired = HIGH_RISK_SUMMARY_RE.test(summary);
+  const highPriority = Number(payload.priority ?? 99) <= 1;
+  const implementationActive = ACTIVE_IMPLEMENTATION_STATUSES.has(String(task.status));
+
+  if (!explicitRequired && !tagRequired && !(summaryRequired && (highPriority || implementationActive))) return null;
+
+  const depth: DesignGovernanceDepth = explicitRequired || tagRequired || summaryRequired ? 'deep' : 'standard';
+  const reason = explicitRequired
+    ? 'explicit design_governance_required'
+    : tagRequired
+      ? `high-risk tag=${tags.find(tag => HIGH_RISK_TAGS.has(tag))}`
+      : 'high-risk summary touches autonomous workflow/data/state infrastructure';
+
+  return {
+    taskId: task.id,
+    summary,
+    status: String(task.status),
+    depth,
+    reason,
+    missingSections: [],
+  };
+}
+
+function findDesignArtifact(
+  memoryDir: string,
+  finding: Pick<DesignGovernanceTaskFinding, 'taskId' | 'summary'>,
+): { relPath: string; content: string } | null {
+  const candidates = candidateArtifactPaths(finding);
+  for (const relPath of candidates) {
+    const abs = path.join(memoryDir, relPath);
+    if (existsSync(abs)) return { relPath, content: readFileSync(abs, 'utf-8') };
+  }
+
+  const root = path.join(memoryDir, DESIGN_ARTIFACT_ROOT);
+  if (!existsSync(root)) return null;
+  for (const name of readdirSync(root)) {
+    if (!name.endsWith('.md')) continue;
+    const relPath = path.join(DESIGN_ARTIFACT_ROOT, name);
+    const content = readFileSync(path.join(memoryDir, relPath), 'utf-8');
+    if (content.includes(finding.taskId) || (finding.summary.length >= 32 && content.includes(finding.summary.slice(0, 64)))) {
+      return { relPath, content };
+    }
+  }
+  return null;
+}
+
+function candidateArtifactPaths(finding: Pick<DesignGovernanceTaskFinding, 'taskId'>): string[] {
+  return [
+    path.join(DESIGN_ARTIFACT_ROOT, `${safeFileName(finding.taskId)}.md`),
+    path.join(DESIGN_ARTIFACT_ROOT, `${finding.taskId}.md`),
+  ];
+}
+
+function missingDesignSections(content: string): string[] {
+  return REQUIRED_SECTIONS
+    .filter(section => !section.pattern.test(content))
+    .map(section => section.label);
+}
+
+function safeFileName(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9._-]+/g, '-').replace(/^-|-$/g, '').slice(0, 100);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -246,6 +246,16 @@ export type {
   AutonomyClosureStageStatus,
   AutonomyClosureStatus,
 } from './autonomy-closure-health.js';
+export {
+  buildDesignArtifactTemplate,
+  evaluateDesignGovernance,
+} from './design-governance.js';
+export type {
+  DesignGovernanceDepth,
+  DesignGovernanceReport,
+  DesignGovernanceStatus,
+  DesignGovernanceTaskFinding,
+} from './design-governance.js';
 export { MiddlewareProvider, createDefaultMiddlewareProviders } from './middleware-provider.js';
 export type { MiddlewareProviderOptions } from './middleware-provider.js';
 export { MiddlewarePeerAgent, createDefaultMiddlewarePeers } from './middleware-peer-agent.js';

--- a/tests/autonomy-closure-diagnostics.test.ts
+++ b/tests/autonomy-closure-diagnostics.test.ts
@@ -89,6 +89,28 @@ describe('autonomy closure diagnostics', () => {
 
     expect(first).toBe(second);
   });
+
+  it('diagnoses missing design artifacts as a bounded design-governance task', () => {
+    const cases = diagnoseAutonomyClosure(snapshotWithStage({
+      stage: 'design-governance',
+      status: 'blocked',
+      summary: '1 missing and 0 incomplete design artifact(s)',
+      evidence: ['idx-design missing design artifact: high-risk summary touches autonomous workflow/data/state infrastructure'],
+      repair: 'Create design artifact before implementation.',
+    }));
+
+    expect(cases[0]).toEqual(expect.objectContaining({
+      stage: 'design-governance',
+      rootCause: expect.stringContaining('High-risk autonomous work lacks'),
+      probeCommands: expect.arrayContaining([
+        expect.stringContaining('proposals/design-artifacts'),
+      ]),
+      fallbackTask: expect.objectContaining({
+        title: 'P1 diagnostic: create missing design-governance artifact',
+        acceptanceCriteria: expect.stringContaining('Mermaid data flow/state/operator diagrams'),
+      }),
+    }));
+  });
 });
 
 function snapshotWithStage(stage: AutonomyClosureSnapshot['stages'][number]): AutonomyClosureSnapshot {

--- a/tests/autonomy-closure-health.test.ts
+++ b/tests/autonomy-closure-health.test.ts
@@ -7,7 +7,7 @@ import {
   ensureAutonomyClosureTask,
   evaluateAutonomyClosure,
 } from '../src/autonomy-closure-health.js';
-import { queryMemoryIndexSync } from '../src/memory-index.js';
+import { invalidateIndexCache, queryMemoryIndexSync } from '../src/memory-index.js';
 import { writeOpenPrSnapshot } from '../src/pr-autopilot.js';
 import { appendPrReviewClaim, createPrReviewClaim } from '../src/pr-review-runner.js';
 
@@ -32,6 +32,7 @@ describe('autonomy closure health', () => {
   it('reports a healthy closed loop when observable memory has no blockers', () => {
     writeFileSync(path.join(tmpDir, 'state/task-events.jsonl'), '', 'utf-8');
     writeFileSync(path.join(tmpDir, 'index/relations.jsonl'), '', 'utf-8');
+    invalidateIndexCache();
 
     const snapshot = evaluateAutonomyClosure(tmpDir, { repoRoot });
 
@@ -127,6 +128,7 @@ describe('autonomy closure health', () => {
       'utf-8',
     );
     writeFileSync(path.join(tmpDir, 'index/relations.jsonl'), '', 'utf-8');
+    invalidateIndexCache();
 
     const snapshot = evaluateAutonomyClosure(tmpDir, { repoRoot });
 
@@ -140,6 +142,34 @@ describe('autonomy closure health', () => {
     const task = await ensureAutonomyClosureTask(tmpDir, snapshot);
     expect(task?.summary).toBe('P1 autonomy closure: repair operational-efficiency');
     expect(task?.payload?.closure_status).toBe('degraded');
+  });
+
+  it('blocks high-risk active implementation until design governance is explicit', () => {
+    writeFileSync(
+      path.join(tmpDir, 'state/task-events.jsonl'),
+      JSON.stringify({
+        id: 'idx-design-gate',
+        ts: '2026-05-10T00:00:00.000Z',
+        type: 'task',
+        status: 'in_progress',
+        summary: 'P1 autonomy closure: repair middleware data flow',
+        refs: [],
+        tags: ['autonomy-closure', 'middleware'],
+        payload: {
+          origin: 'github-issue',
+          priority: 1,
+        },
+      }) + '\n',
+      'utf-8',
+    );
+    writeFileSync(path.join(tmpDir, 'index/relations.jsonl'), '', 'utf-8');
+
+    const snapshot = evaluateAutonomyClosure(tmpDir, { repoRoot });
+
+    expect(snapshot.status).toBe('blocked');
+    expect(snapshot.blockingStages).toContain('design-governance');
+    expect(snapshot.recommendedTask?.title).toBe('P0 autonomy closure: repair design-governance');
+    expect(snapshot.recommendedTask?.acceptanceCriteria).toContain('Constraint Texture -> Mermaid/ASCII design artifact');
   });
 
   it('creates one repair task for exhausted autonomous execution', async () => {

--- a/tests/delegation-failure-guard.test.ts
+++ b/tests/delegation-failure-guard.test.ts
@@ -150,6 +150,35 @@ describe('delegation failure guard', () => {
     expect(second.record.resolvedAt).toBeUndefined();
   });
 
+  it('keeps terminal max-turns recurrences resolved as telemetry', () => {
+    const first = recordDelegationFailure(tmpDir, {
+      taskId: 'del-1',
+      taskType: 'code',
+      prompt: 'Fix broad autonomy closure task',
+      output: 'task task-123 failed: Claude Code returned an error result: Reached maximum number of turns (15)',
+    });
+    transitionDelegationFailureStatus(
+      tmpDir,
+      first.record.signature,
+      'resolved',
+      'Do not retry the same prompt unchanged; split the origin task into smaller probes.',
+      new Date('2026-05-05T00:01:00.000Z'),
+    );
+
+    const second = recordDelegationFailure(tmpDir, {
+      taskId: 'del-2',
+      taskType: 'code',
+      prompt: 'Fix broad autonomy closure task',
+      output: 'task task-456 failed: Claude Code returned an error result: Reached maximum number of turns (15)',
+    }, new Date('2026-05-05T00:02:00.000Z'));
+
+    expect(second.record.status).toBe('resolved');
+    expect(second.record.frequency).toBe(2);
+    expect(second.record.resolution).toContain('split the origin task');
+    expect(second.needsDiagnosticTask).toBe(false);
+    expect(isActionableDelegationFailure(second.record)).toBe(false);
+  });
+
   it('normalizes historical records that are open but already resolved', () => {
     const filePath = getDelegationFailureGuardPath(tmpDir);
     mkdirSync(path.dirname(filePath), { recursive: true });

--- a/tests/design-governance.test.ts
+++ b/tests/design-governance.test.ts
@@ -1,0 +1,127 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  buildDesignArtifactTemplate,
+  evaluateDesignGovernance,
+} from '../src/design-governance.js';
+import type { MemoryIndexEntry } from '../src/memory-index.js';
+
+describe('design governance', () => {
+  it('blocks active high-risk implementation without a design artifact', () => {
+    const memoryDir = mkdtempSync(path.join(os.tmpdir(), 'mini-agent-design-governance-'));
+    const report = evaluateDesignGovernance(memoryDir, [
+      task({
+        status: 'in_progress',
+        summary: 'P1 autonomy closure: repair scheduler data flow convergence',
+        payload: { priority: 1 },
+      }),
+    ]);
+
+    expect(report.status).toBe('blocked');
+    expect(report.missingArtifacts[0]).toEqual(expect.objectContaining({
+      taskId: 'idx-design-test',
+      depth: 'deep',
+    }));
+    expect(report.evidence[0]).toContain('missing design artifact');
+  });
+
+  it('warns pending high-risk work so planning happens before implementation', () => {
+    const memoryDir = mkdtempSync(path.join(os.tmpdir(), 'mini-agent-design-governance-'));
+    const report = evaluateDesignGovernance(memoryDir, [
+      task({
+        status: 'pending',
+        summary: 'P1 middleware workflow repair',
+        payload: { priority: 1 },
+      }),
+    ]);
+
+    expect(report.status).toBe('warn');
+    expect(report.summary).toBe('1 missing and 0 incomplete design artifact(s)');
+  });
+
+  it('accepts a complete design artifact with diagrams and executable closure sections', () => {
+    const memoryDir = mkdtempSync(path.join(os.tmpdir(), 'mini-agent-design-governance-'));
+    const artifactDir = path.join(memoryDir, 'proposals', 'design-artifacts');
+    mkdirSync(artifactDir, { recursive: true });
+    const entry = task({
+      status: 'in_progress',
+      summary: 'P1 KG context fabric state machine repair',
+      tags: ['kg', 'state-machine'],
+      payload: { priority: 1 },
+    });
+    writeFileSync(
+      path.join(artifactDir, `${entry.id}.md`),
+      buildDesignArtifactTemplate(entry),
+      'utf-8',
+    );
+
+    const report = evaluateDesignGovernance(memoryDir, [entry]);
+
+    expect(report.status).toBe('ok');
+    expect(report.summary).toBe('1 high-risk task(s) have design governance');
+  });
+
+  it('flags incomplete artifacts instead of treating any markdown as sufficient', () => {
+    const memoryDir = mkdtempSync(path.join(os.tmpdir(), 'mini-agent-design-governance-'));
+    const artifactDir = path.join(memoryDir, 'proposals', 'design-artifacts');
+    mkdirSync(artifactDir, { recursive: true });
+    const entry = task({
+      status: 'in_progress',
+      summary: 'P1 dashboard state machine redesign',
+      payload: { priority: 1 },
+    });
+    writeFileSync(path.join(artifactDir, `${entry.id}.md`), `# ${entry.summary}\n\nTask: ${entry.id}\n`, 'utf-8');
+
+    const report = evaluateDesignGovernance(memoryDir, [entry]);
+
+    expect(report.status).toBe('blocked');
+    expect(report.incompleteArtifacts[0].missingSections).toEqual(expect.arrayContaining([
+      'Constraint Texture',
+      'Mermaid Diagram',
+      'Effect Backtest',
+    ]));
+  });
+
+  it('allows explicit trivial exemptions for one-line work', () => {
+    const memoryDir = mkdtempSync(path.join(os.tmpdir(), 'mini-agent-design-governance-'));
+    const report = evaluateDesignGovernance(memoryDir, [
+      task({
+        status: 'in_progress',
+        summary: 'P1 scheduler typo fix',
+        payload: { priority: 1, design_depth: 'trivial' },
+      }),
+    ]);
+
+    expect(report.status).toBe('ok');
+    expect(report.missingArtifacts).toHaveLength(0);
+  });
+
+  it('does not treat bounded holds as active implementation unless explicitly required', () => {
+    const memoryDir = mkdtempSync(path.join(os.tmpdir(), 'mini-agent-design-governance-'));
+    const report = evaluateDesignGovernance(memoryDir, [
+      task({
+        status: 'hold',
+        summary: 'Hold middleware delegation until provider quota resets',
+        tags: ['middleware'],
+        payload: { priority: 1 },
+      }),
+    ]);
+
+    expect(report.status).toBe('ok');
+    expect(report.summary).toBe('0 high-risk task(s) have design governance');
+  });
+});
+
+function task(overrides: Partial<MemoryIndexEntry>): MemoryIndexEntry {
+  return {
+    id: 'idx-design-test',
+    ts: '2026-05-10T00:00:00.000Z',
+    type: 'task',
+    status: 'pending',
+    summary: 'test task',
+    refs: [],
+    ...overrides,
+  };
+}


### PR DESCRIPTION
## Summary
- add design-governance evaluator and CLI check for high-risk autonomous work
- require complete design artifacts with Constraint Texture, Mermaid flows/state, failure path, acceptance/falsifier, test/review plan, and effect backtest
- integrate design-governance into autonomy closure and diagnostics
- keep terminal max-turns delegation recurrences resolved as telemetry instead of reopening identical blockers

## Verification
- pnpm typecheck
- pnpm build
- pnpm test
- MINI_AGENT_MEMORY_DIR=/Users/user/Workspace/mini-agent-memory/memory pnpm --silent check:design-governance -- --json
- MINI_AGENT_MEMORY_DIR=/Users/user/Workspace/mini-agent-memory/memory pnpm --silent check:autonomy-closure -- --json