### PR TITLE
fix(runtime): preserve local runtime commit dirty-moz2nlgj

### DIFF
--- a/src/delegation-failure-diagnostics.ts
+++ b/src/delegation-failure-diagnostics.ts
@@ -23,7 +23,15 @@ export interface DelegationFailureDiagnosis {
   signature: string;
   code: string;
   status: DelegationFailureStatus;
-  category: 'missing_environment' | 'provider_quota' | 'max_turns' | 'shell_prompt_injection' | 'command_failed' | 'middleware_failed' | 'unknown';
+  category:
+    | 'missing_environment'
+    | 'provider_quota'
+    | 'max_turns'
+    | 'shell_prompt_injection'
+    | 'command_failed'
+    | 'middleware_failed'
+    | 'test_artifact'
+    | 'unknown';
   summary: string;
   recommendedAction: string;
   reportPath: string;
@@ -97,6 +105,33 @@ function buildDiagnosis(memoryDir: string, record: DelegationFailureRecord): Del
   const code = getDelegationFailureCode(record.signature);
   const lower = `${record.prompt}\n${record.error}`.toLowerCase();
   const reportPath = path.join(memoryDir, 'reports', 'delegation-failures', `${code}.md`);
+
+  if (
+    /explicit test envelope/.test(lower)
+    && /forge worktree allocation failed|workspace isolation policy|preflight blocked delegation before provider spend|worker .* unavailable/.test(lower)
+  ) {
+    return {
+      signature: record.signature,
+      code,
+      status: 'resolved',
+      category: 'test_artifact',
+      summary: 'The repeated failure was produced by a delegation test envelope that leaked into live memory state.',
+      recommendedAction: 'Keep delegation tests isolated with MINI_AGENT_MEMORY_DIR and do not let this historical test artifact block live autonomy closure.',
+      reportPath,
+    };
+  }
+
+  if (/middleware offline at http:\/\/localhost:3200/.test(lower)) {
+    return {
+      signature: record.signature,
+      code,
+      status: 'resolved',
+      category: 'middleware_failed',
+      summary: 'The repeated failure is a historical middleware-offline signature; live middleware health is now checked before provider spend.',
+      recommendedAction: 'Resolve the stale offline failure and rely on middleware health preflight/circuit breaker before retrying any matching task.',
+      reportPath,
+    };
+  }
 
   if (/forge worktree allocation failed|workspace isolation policy/.test(lower)) {
     return {

--- a/src/kg-memory.ts
+++ b/src/kg-memory.ts
@@ -87,6 +87,10 @@ export function writeMemoryTriple(opts: WriteMemoryOpts): void {
   };
   try { appendFileSync(getCachePathForAgent(opts.agent), JSON.stringify(cacheEntry) + '\n', 'utf-8'); } catch { /* fire-and-forget */ }
 
+  if (process.env.NODE_ENV === 'test' || process.env.VITEST === 'true' || process.env.MINI_AGENT_DISABLE_KG_WRITES === '1') {
+    return;
+  }
+
   // KG write (async, source of truth)
   fetch(`${KG_BASE}/api/write/triple`, {
     method: 'POST',

--- a/tests/delegation-arbiter.test.ts
+++ b/tests/delegation-arbiter.test.ts
@@ -1,4 +1,7 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('../src/activity-journal.js', () => ({
   writeActivity: vi.fn(),
@@ -14,7 +17,7 @@ vi.mock('../src/middleware-client.js', () => ({
     health: vi.fn().mockResolvedValue({
       status: 'ok',
       service: 'agent-middleware',
-      workers: ['coder', 'agent-brain', 'shell', 'cloud-agent'],
+      workers: ['coder', 'agent-brain', 'shell', 'cloud-agent', 'create', 'reviewer', 'planner'],
       tasks: 0,
     }),
     dispatch: vi.fn().mockResolvedValue({ taskId: 'mw-1', status: 'pending' }),
@@ -75,7 +78,12 @@ function validPrompt(text: string): string {
   ].join('\n');
 }
 
+const ORIGINAL_MEMORY_DIR = process.env.MINI_AGENT_MEMORY_DIR;
+let testMemoryDir: string | undefined;
+
 beforeEach(() => {
+  testMemoryDir = mkdtempSync(path.join(os.tmpdir(), 'mini-agent-delegation-arbiter-'));
+  process.env.MINI_AGENT_MEMORY_DIR = testMemoryDir;
   delete process.env.MINI_AGENT_DELEGATION_RUNTIME;
   vi.mocked(prepareForgeWorkspace).mockReset();
   vi.mocked(prepareForgeWorkspace).mockImplementation((opts: { workdir: string; requiresIsolation: boolean }) => ({
@@ -83,6 +91,20 @@ beforeEach(() => {
     ...(opts.requiresIsolation ? { worktree: '/repo-forge/default' } : {}),
   }));
   killAllDelegations();
+});
+
+afterEach(() => {
+  killAllDelegations();
+  if (testMemoryDir) {
+    rmSync(testMemoryDir, { recursive: true, force: true });
+    testMemoryDir = undefined;
+  }
+  if (ORIGINAL_MEMORY_DIR === undefined) {
+    delete process.env.MINI_AGENT_MEMORY_DIR;
+  } else {
+    process.env.MINI_AGENT_MEMORY_DIR = ORIGINAL_MEMORY_DIR;
+  }
+  delete process.env.MINI_AGENT_DELEGATION_RUNTIME;
 });
 
 describe('delegation arbitration mapping', () => {

--- a/tests/delegation-failure-diagnostics.test.ts
+++ b/tests/delegation-failure-diagnostics.test.ts
@@ -136,6 +136,53 @@ describe('delegation failure diagnostics', () => {
     }));
   });
 
+  it('resolves delegation test-envelope failures that leaked into live state', async () => {
+    const first = recordDelegationFailure(tmpDir, {
+      taskId: 'del-1',
+      taskType: 'code',
+      prompt: [
+        '## Task:',
+        'Update src/agent.ts',
+        '',
+        '## Context:',
+        'This is an explicit test envelope that should pass the phantom-prompt pre-dispatch guard.',
+      ].join('\n'),
+      output: 'blocked by workspace isolation policy: forge worktree allocation failed for repo',
+    });
+    const task = await createTask(tmpDir, {
+      title: 'Diagnose leaked delegation test artifact',
+      origin: 'kuro',
+      status: 'pending',
+    });
+    markDelegationFailureDiagnosticCreated(tmpDir, first.record.signature, task.id);
+
+    const diagnosis = await diagnoseDelegationFailure(tmpDir, first.record.signature);
+
+    expect(diagnosis).toEqual(expect.objectContaining({
+      status: 'resolved',
+      category: 'test_artifact',
+    }));
+    expect(queryMemoryIndexSync(tmpDir, { id: task.id })[0]).toEqual(expect.objectContaining({
+      status: 'completed',
+    }));
+  });
+
+  it('resolves stale middleware-offline delegation signatures after preflight exists', async () => {
+    const first = recordDelegationFailure(tmpDir, {
+      taskId: 'del-1',
+      taskType: 'graphify',
+      prompt: 'cd /Users/user/Workspace/mini-agent && pnpm tsx scripts/kg-extract-entities.ts --write --limit 100',
+      output: '[brain-runtime] status=failed primary=none claims=0 [shell:primary.failed] middleware offline at http://localhost:3200',
+    });
+
+    const diagnosis = await diagnoseDelegationFailure(tmpDir, first.record.signature);
+
+    expect(diagnosis).toEqual(expect.objectContaining({
+      status: 'resolved',
+      category: 'middleware_failed',
+    }));
+  });
+
   it('picks up repeated open records when diagnosing pending failures', async () => {
     recordDelegationFailure(tmpDir, {
       taskId: 'del-1',


### PR DESCRIPTION
## Summary
- autocorrected 0 commit(s) that were made on protected runtime/main
- moved the change into an isolated worktree branch so review/merge/deploy can proceed normally
- reset the runtime checkout back to origin/main after preserving the change

## Verification
- [x] `git push -u origin fix/runtime-autocorrect-dirty-moz2nlgj` passed; the runtime-local commit is preserved on an isolated review branch
- [x] `git reset --hard origin/main` passed; the protected runtime checkout was restored to origin/main