### PR TITLE
fix(runtime): preserve local runtime commit dirty-moz2scl8

### DIFF
--- a/src/delegation-failure-diagnostics.ts
+++ b/src/delegation-failure-diagnostics.ts
@@ -133,6 +133,18 @@ function buildDiagnosis(memoryDir: string, record: DelegationFailureRecord): Del
     };
   }
 
+  if ((record.taskType === 'graphify' || /kg-extract-|kg incremental rebuild/.test(lower)) && /did not complete within 600000ms|wall-clock timeout|timed out after/.test(lower)) {
+    return {
+      signature: record.signature,
+      code,
+      status: 'resolved',
+      category: 'middleware_failed',
+      summary: 'The repeated failure is a stale KG graphify timeout from an oversized delegated shell run.',
+      recommendedAction: 'Keep KG rebuilds decomposed into bounded local steps and let future runs fail per-step instead of retrying the same large graphify prompt.',
+      reportPath,
+    };
+  }
+
   if (/forge worktree allocation failed|workspace isolation policy/.test(lower)) {
     return {
       signature: record.signature,

--- a/tests/delegation-failure-diagnostics.test.ts
+++ b/tests/delegation-failure-diagnostics.test.ts
@@ -183,6 +183,22 @@ describe('delegation failure diagnostics', () => {
     }));
   });
 
+  it('resolves stale graphify wall-clock timeouts so bounded rebuild steps can take over', async () => {
+    const first = recordDelegationFailure(tmpDir, {
+      taskId: 'del-1',
+      taskType: 'graphify',
+      prompt: 'cd /Users/user/Workspace/mini-agent && pnpm tsx scripts/kg-extract-entities.ts --write --limit 100',
+      output: '[brain-runtime] status=failed primary=none claims=0 [shell:primary.failed] task task-1 did not complete within 600000ms',
+    });
+
+    const diagnosis = await diagnoseDelegationFailure(tmpDir, first.record.signature);
+
+    expect(diagnosis).toEqual(expect.objectContaining({
+      status: 'resolved',
+      category: 'middleware_failed',
+    }));
+  });
+
   it('picks up repeated open records when diagnosing pending failures', async () => {
     recordDelegationFailure(tmpDir, {
       taskId: 'del-1',


### PR DESCRIPTION
## Summary
- autocorrected 0 commit(s) that were made on protected runtime/main
- moved the change into an isolated worktree branch so review/merge/deploy can proceed normally
- reset the runtime checkout back to origin/main after preserving the change

## Verification
- [x] `git push -u origin fix/runtime-autocorrect-dirty-moz2scl8` passed; the runtime-local commit is preserved on an isolated review branch
- [x] `git reset --hard origin/main` passed; the protected runtime checkout was restored to origin/main