### PR TITLE
fix(#491): split upstream_quickreject_cn from transient_fast_band

### DIFF
--- a/src/feedback-loops.ts
+++ b/src/feedback-loops.ts
@@ -270,6 +270,16 @@ export function extractErrorSubtype(errorMsg: string): string {
     // the bucket never silently disappears from the recurring-errors panel.
     if (durMatch) {
       const dur = Number(durMatch[1]);
+      // Issue #491: split off upstream_quickreject_cn from transient_fast_band.
+      // Signature: 處理訊息時發生錯誤 + dur<20s + attempt 1/N — fires on the FIRST
+      // call before any prior call exists for the caller-side fast-band gate
+      // (#443/#446 damper) to throttle against. Different remediation lane
+      // (back-off seconds-to-minutes vs. classic transient retry); keeping it
+      // mixed into transient_fast_band pollutes circuit-breaker telemetry and
+      // spawns false [REGRESSION] tasks for upstream events the breaker can't
+      // influence. Attempt 2-3/N retry-storm fires stay as transient_fast_band
+      // (genuine fast-band the damper applies to).
+      if (dur < 20 && /attempt 1\//.test(lower)) return 'upstream_quickreject_cn';
       if (dur < 10) return 'transient_fast_band';
       if (dur < 60) return 'transient_slow_band';
     }
@@ -374,7 +384,11 @@ export function shouldFastFailFastBand(args: {
     args.thresholdMs ?? (Number(process.env.KURO_FAST_FAIL_THRESHOLD_MS) || 10_000);
   if (args.attempt !== 0) return false;
   if (args.attemptDurationMs >= threshold) return false;
-  return extractErrorSubtype(args.errorMsg) === 'transient_fast_band';
+  // Issue #491: upstream_quickreject_cn is a refinement of transient_fast_band
+  // (attempt 1/N + dur<20s + 處理訊息時發生錯誤). Same fail-fast remediation lane —
+  // the bucket split is for telemetry / spawn-loop control, not action change.
+  const subtype = extractErrorSubtype(args.errorMsg);
+  return subtype === 'transient_fast_band' || subtype === 'upstream_quickreject_cn';
 }
 
 /**

--- a/tests/extract-error-subtype.test.ts
+++ b/tests/extract-error-subtype.test.ts
@@ -37,6 +37,41 @@ describe('extractErrorSubtype — transient band split (#318)', () => {
   });
 });
 
+describe('extractErrorSubtype — upstream_quickreject_cn split (#491)', () => {
+  // Real fire format observed in error-patterns.json (UNKNOWN:transient_fast_band::callClaude):
+  //   "claude CLI UNKNOWN (exit N/A, 8100ms this attempt, 8100ms total, attempt 1/3,
+  //    prompt 36402 chars, loop lane): 處理訊息時發生錯誤 [dur=8s]。請稍後再試..."
+  // Discriminator: attempt 1/N + dur<20s + 處理訊息時發生錯誤 → upstream rejects
+  // before the caller-side fast-band gate has any prior call to throttle against.
+  const mkUpstreamMsg = (durSec: number, attempt: number, totalAttempts = 3) =>
+    `claude CLI UNKNOWN (exit N/A, ${durSec * 1000}ms this attempt, ${durSec * 1000}ms total, ` +
+    `attempt ${attempt}/${totalAttempts}, prompt 36402 chars, loop lane): 處理訊息時發生錯誤 [dur=${durSec}s]。請稍後再試。`;
+
+  it('classifies attempt 1/N + dur<20s as upstream_quickreject_cn', () => {
+    expect(extractErrorSubtype(mkUpstreamMsg(8, 1))).toBe('upstream_quickreject_cn');
+    expect(extractErrorSubtype(mkUpstreamMsg(1, 1))).toBe('upstream_quickreject_cn');
+    expect(extractErrorSubtype(mkUpstreamMsg(19, 1))).toBe('upstream_quickreject_cn');
+  });
+
+  it('keeps attempt 2-3/N retry-storm fires as transient_fast_band (existing #318 path)', () => {
+    // Genuine retry-storm: caller has prior call to gate against; #443/#446 damper applies.
+    expect(extractErrorSubtype(mkUpstreamMsg(8, 2))).toBe('transient_fast_band');
+    expect(extractErrorSubtype(mkUpstreamMsg(8, 3))).toBe('transient_fast_band');
+  });
+
+  it('does not over-match attempt 1 with dur>=20s (slow-band stays transient_slow_band)', () => {
+    // dur=20s should fall through to transient_slow_band, not upstream_quickreject_cn.
+    expect(extractErrorSubtype(mkUpstreamMsg(20, 1))).toBe('transient_slow_band');
+    expect(extractErrorSubtype(mkUpstreamMsg(59, 1))).toBe('transient_slow_band');
+  });
+
+  it('preserves no_diag fallback when 處理訊息時發生錯誤 has no dur= suffix', () => {
+    // Sanity: existing fallback path untouched even with attempt 1/N present.
+    const msg = 'attempt 1/3 處理訊息時發生錯誤 some text without duration';
+    expect(extractErrorSubtype(msg)).toBe('no_diag');
+  });
+});
+
 describe('extractErrorSubtype — silent_exit_void 4-class typed-failure schema (#370 + arxiv 2605.05724)', () => {
   // Format from agent.ts:249 + extractErrorSubtype regex:
   //   "CLI 靜默中斷（exit N/A，{durSec}s 無 stderr）. stdout=empty"


### PR DESCRIPTION
Closes #491.

## Summary
- Split `UNKNOWN:transient_fast_band::callClaude` to extract upstream Chinese-localized 400s into their own `upstream_quickreject_cn` bucket.
- Discriminator: `處理訊息時發生錯誤 + dur<20s + attempt 1/N` — the first-call signature where caller-side circuit-breaker (#333) is structurally incapable of gating (no prior call to throttle against).
- `shouldFastFailFastBand` updated so the new subtype still fail-fasts (same remediation lane); the split is purely for telemetry/spawn-loop control to stop polluting circuit-breaker metrics and spawning false `[REGRESSION]` tasks for upstream events.

## Why discriminator changed from issue body
Issue #491 proposed `/exit N\/A/` regex; verified at `agent.ts:2022` that the outer wrapper does emit `exit N/A` when `exitCode` is null, so it would have worked — but `attempt 1/` is a more direct signature for the actual bug (first-call upstream rejection vs retry-storm fast-band) and aligns with the 19:54Z smoking-gun evidence in the issue body (`attempt 1/3, total 8100ms`).

## Verification
- `pnpm vitest run tests/extract-error-subtype.test.ts` → 18/18 pass (3 new cases for the split).
- After merge + ~24h soak: `UPSTREAM:upstream_quickreject_cn::callClaude.count >= 1` and `UNKNOWN:transient_fast_band::callClaude` growth slows for first-call/Chinese-localized fires (issue #491 falsifier).

— Kuro autonomous loop, instance 03bbc29a