### PR TITLE
fix(scheduler): honor phantom closure markers

### DIFF
--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -328,6 +328,23 @@ const phantomCache: { mtimeMs: number; titles: Set<string> } = {
   titles: new Set<string>(),
 };
 
+interface PhantomClosureEntry {
+  task?: string;
+  summary?: string;
+  title?: string;
+  task_id?: string;
+  taskId?: string;
+  code?: string;
+  failureCode?: string;
+  signature?: string;
+  artifact?: string;
+}
+
+const phantomClosureCache: { mtimeMs: number; keys: Set<string> } = {
+  mtimeMs: 0,
+  keys: new Set<string>(),
+};
+
 function loadPhantomTaskTitles(memoryDir: string): Set<string> {
   const filePath = join(memoryDir, 'state', 'phantom-tasks.jsonl');
   if (!existsSync(filePath)) {
@@ -369,6 +386,62 @@ function isPhantomTask(summary: string, phantomTitles: Set<string>): boolean {
   return false;
 }
 
+function loadPhantomClosureKeys(memoryDir: string): Set<string> {
+  const filePath = join(memoryDir, 'state', 'phantom-closures.jsonl');
+  if (!existsSync(filePath)) {
+    if (phantomClosureCache.mtimeMs !== 0) {
+      phantomClosureCache.mtimeMs = 0;
+      phantomClosureCache.keys = new Set();
+    }
+    return phantomClosureCache.keys;
+  }
+  let mtimeMs = 0;
+  try { mtimeMs = statSync(filePath).mtimeMs; } catch { return phantomClosureCache.keys; }
+  if (mtimeMs === phantomClosureCache.mtimeMs) return phantomClosureCache.keys;
+  const keys = new Set<string>();
+  try {
+    const raw = readFileSync(filePath, 'utf8');
+    for (const line of raw.split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try {
+        const obj = JSON.parse(trimmed) as PhantomClosureEntry;
+        for (const value of [
+          obj.task,
+          obj.summary,
+          obj.title,
+          obj.task_id,
+          obj.taskId,
+          obj.code,
+          obj.failureCode,
+          obj.signature,
+          obj.artifact,
+        ]) {
+          if (typeof value === 'string' && value.trim().length >= 8) {
+            keys.add(value.trim());
+          }
+        }
+      } catch { /* skip malformed line */ }
+    }
+  } catch { return phantomClosureCache.keys; }
+  phantomClosureCache.mtimeMs = mtimeMs;
+  phantomClosureCache.keys = keys;
+  return keys;
+}
+
+function isClosedByPhantomClosure(task: TaskSnapshot, closureKeys: Set<string>): boolean {
+  if (closureKeys.size === 0) return false;
+  const summary = task.summary.trim();
+  if (closureKeys.has(task.id) || closureKeys.has(summary)) return true;
+  for (const key of closureKeys) {
+    if (key === task.id) return true;
+    if (key.length >= 24 && (summary.includes(key) || key.includes(summary))) return true;
+    if (/^fail-[a-z0-9]+$/i.test(key) && summary.includes(key)) return true;
+    if (/^(idx|task|del)-[a-z0-9-]+$/i.test(key) && (task.id.includes(key) || summary.includes(key))) return true;
+  }
+  return false;
+}
+
 export function schedulerPick(
   memoryDir: string,
   events: IncomingEvent[] = [],
@@ -391,6 +464,7 @@ export function schedulerPick(
   resetSuppressionsForExternalEvents(events);
 
   const phantomTitles = loadPhantomTaskTitles(memoryDir);
+  const phantomClosureKeys = loadPhantomClosureKeys(memoryDir);
   const resolvedKeys = loadResolvedTaskKeysFromEvents(memoryDir);
 
   const tasks: TaskSnapshot[] = entries.map(entryToSnapshot)
@@ -408,6 +482,13 @@ export function schedulerPick(
     .filter(t => {
       if (isPhantomTask(t.summary, phantomTitles)) {
         slog('SCHED', `dispatch-phantom: skipping task=${t.id.slice(0, 12)} ${t.summary.slice(0, 50)} (phantom-tasks.jsonl)`);
+        return false;
+      }
+      return true;
+    })
+    .filter(t => {
+      if (isClosedByPhantomClosure(t, phantomClosureKeys)) {
+        slog('SCHED', `dispatch-phantom-closure: skipping task=${t.id.slice(0, 12)} ${t.summary.slice(0, 50)} (phantom-closures.jsonl)`);
         return false;
       }
       return true;

--- a/tests/scheduler-dispatch-suppression.test.ts
+++ b/tests/scheduler-dispatch-suppression.test.ts
@@ -19,6 +19,7 @@ import {
   recordTaskTerminalSignal,
   resetTaskSuppression,
   resetAllSuppressions,
+  resetCurrentTask,
   isTaskSuppressed,
   getSuppressedTaskIds,
   getTerminalSignalCount,
@@ -31,12 +32,14 @@ beforeEach(() => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dispatch-suppress-'));
   invalidateIndexCache();
   resetAllSuppressions();
+  resetCurrentTask();
 });
 
 afterEach(() => {
   fs.rmSync(tmpDir, { recursive: true, force: true });
   invalidateIndexCache();
   resetAllSuppressions();
+  resetCurrentTask();
 });
 
 // ─── Constants ────────────────────────────────────────────────────────────────
@@ -311,6 +314,34 @@ describe('schedulerPick — suppressed tasks excluded from dispatch', () => {
 
     expect(decision.taskId).toBe(active.id);
     expect(decision.taskId).not.toBe(resolved.id);
+  });
+
+  it('does not pick a task matched by a phantom closure marker', async () => {
+    const phantom = await appendMemoryIndexEntry(tmpDir, {
+      type: 'task',
+      status: 'pending',
+      summary: 'Diagnose fail-8wyvhk: repeated delegation failure from an explicit test envelope',
+      payload: { priority: 0 },
+    });
+    const active = await appendMemoryIndexEntry(tmpDir, {
+      type: 'task',
+      status: 'pending',
+      summary: 'P0 active incident that still exists',
+      payload: { priority: 0 },
+    });
+    fs.mkdirSync(path.join(tmpDir, 'state'), { recursive: true });
+    fs.appendFileSync(path.join(tmpDir, 'state', 'phantom-closures.jsonl'), JSON.stringify({
+      code: 'fail-8wyvhk',
+      task: 'Diagnose fail-8wyvhk',
+      resolved_at: new Date().toISOString(),
+      evidence: 'delegation failure record is resolved as test_artifact',
+    }) + '\n');
+    invalidateIndexCache();
+
+    const decision = schedulerPick(tmpDir, []);
+
+    expect(decision.taskId).toBe(active.id);
+    expect(decision.taskId).not.toBe(phantom.id);
   });
 
   it('resets suppression on a human-directed scheduler event', async () => {


### PR DESCRIPTION
## Summary
- Add scheduler guard for memory/state/phantom-closures.jsonl markers
- Match stale tasks by task id, summary/title, fail-code, signature, or artifact marker
- Add regression coverage that skips a stale fail-8wyvhk task and dispatches real active work

## Verification
- pnpm vitest run tests/scheduler-dispatch-suppression.test.ts
- pnpm typecheck