### PR TITLE
fix(runtime): preserve local runtime commit dirty-moz7vt8m

### DIFF
--- a/src/design-governance.ts
+++ b/src/design-governance.ts
@@ -189,7 +189,8 @@ function classifyDesignNeed(task: MemoryIndexEntry): DesignGovernanceTaskFinding
   if (explicitDepth === 'trivial' || task.tags?.includes('design-exempt')) return null;
   const explicitRequired = payload.design_governance_required === true || payload.designGovernanceRequired === true;
   if (String(task.status) === 'hold' && !explicitRequired) return null;
-  if (payload.origin === 'autonomy-closure' && !explicitRequired) return null;
+  const OPERATIONAL_ORIGINS = ['autonomy-closure', 'middleware-self-healing'];
+  if (OPERATIONAL_ORIGINS.includes(String(payload.origin)) && !explicitRequired) return null;
 
   const summary = task.summary ?? '';
   if (/autonomy closure:\s*repair design-governance/i.test(summary)) return null;

--- a/tests/design-governance.test.ts
+++ b/tests/design-governance.test.ts
@@ -98,6 +98,21 @@ describe('design governance', () => {
     expect(report.missingArtifacts).toHaveLength(0);
   });
 
+  it('exempts middleware-self-healing origin tasks from design governance', () => {
+    const memoryDir = mkdtempSync(path.join(os.tmpdir(), 'mini-agent-design-governance-'));
+    const report = evaluateDesignGovernance(memoryDir, [
+      task({
+        status: 'pending',
+        summary: 'Create fallback for middleware task after provider budget hold',
+        tags: ['middleware', 'self-healing', 'budget-or-quota'],
+        payload: { origin: 'middleware-self-healing', priority: 1 },
+      }),
+    ]);
+
+    expect(report.status).toBe('ok');
+    expect(report.missingArtifacts).toHaveLength(0);
+  });
+
   it('does not treat bounded holds as active implementation unless explicitly required', () => {
     const memoryDir = mkdtempSync(path.join(os.tmpdir(), 'mini-agent-design-governance-'));
     const report = evaluateDesignGovernance(memoryDir, [


### PR DESCRIPTION
## Summary
- autocorrected 0 commit(s) that were made on protected runtime/main
- moved the change into an isolated worktree branch so review/merge/deploy can proceed normally
- reset the runtime checkout back to origin/main after preserving the change

## Verification
- [x] `git push -u origin fix/runtime-autocorrect-dirty-moz7vt8m` passed; the runtime-local commit is preserved on an isolated review branch
- [x] `git reset --hard origin/main` passed; the protected runtime checkout was restored to origin/main