### PR TITLE
fix(scheduler): gate empty open cycles

### DIFF
--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -95,12 +95,18 @@ export class DefaultScheduler implements SchedulerPolicy {
     events: IncomingEvent[],
   ): SchedulingDecision {
     const activeTasks = tasks.filter(t => t.status === 'pending' || t.status === 'in_progress');
+    const hasP0Event = events.some(e => e.priority === 0 || e.isAlexDirectMessage);
+    const isDiscoverySlot = state.totalTicks > 0 && state.totalTicks % DISCOVERY_INTERVAL === 0;
 
     if (activeTasks.length === 0) {
-      return { taskId: null, reason: 'open-cycle: no tasks, agent chooses', action: 'discovery', suspended: null };
+      if (hasP0Event) {
+        return { taskId: null, reason: 'event-driven open-cycle: no tasks, direct signal needs attention', action: 'discovery', suspended: null };
+      }
+      if (isDiscoverySlot) {
+        return { taskId: null, reason: 'discovery slot: no tasks, free exploration', action: 'discovery', suspended: null };
+      }
+      return { taskId: null, reason: 'idle: no schedulable tasks until next discovery slot', action: 'idle', suspended: null };
     }
-
-    const hasP0Event = events.some(e => e.priority === 0 || e.isAlexDirectMessage);
 
     // Rule 1: P0 event preempts non-P0 current task
     if (hasP0Event && state.currentTaskId) {
@@ -148,7 +154,7 @@ export class DefaultScheduler implements SchedulerPolicy {
     }
 
     // Rule 3: Discovery slot
-    if (state.totalTicks > 0 && state.totalTicks % DISCOVERY_INTERVAL === 0) {
+    if (isDiscoverySlot) {
       return { taskId: null, reason: 'discovery slot: free exploration', action: 'discovery', suspended: null };
     }
 
@@ -244,6 +250,15 @@ export function advanceTick(): void {
 export function resetCurrentTask(): void {
   schedulerState.currentTaskId = null;
   schedulerState.ticksOnCurrent = 0;
+}
+
+export function resetSchedulerStateForTest(): void {
+  schedulerState = {
+    currentTaskId: null,
+    ticksOnCurrent: 0,
+    totalTicks: 0,
+    lastDiscoveryTick: 0,
+  };
 }
 
 export function setCurrentTask(taskId: string): void {

--- a/tests/scheduler-dispatch-suppression.test.ts
+++ b/tests/scheduler-dispatch-suppression.test.ts
@@ -20,6 +20,8 @@ import {
   resetTaskSuppression,
   resetAllSuppressions,
   resetCurrentTask,
+  resetSchedulerStateForTest,
+  advanceTick,
   isTaskSuppressed,
   getSuppressedTaskIds,
   getTerminalSignalCount,
@@ -33,6 +35,7 @@ beforeEach(() => {
   invalidateIndexCache();
   resetAllSuppressions();
   resetCurrentTask();
+  resetSchedulerStateForTest();
 });
 
 afterEach(() => {
@@ -40,6 +43,7 @@ afterEach(() => {
   invalidateIndexCache();
   resetAllSuppressions();
   resetCurrentTask();
+  resetSchedulerStateForTest();
 });
 
 // ─── Constants ────────────────────────────────────────────────────────────────
@@ -186,6 +190,30 @@ describe('resetAllSuppressions', () => {
 // ─── schedulerPick integration — suppressed tasks are excluded ────────────────
 
 describe('schedulerPick — suppressed tasks excluded from dispatch', () => {
+  it('idles instead of opening a full discovery cycle when no tasks are schedulable', () => {
+    advanceTick();
+    const decision = schedulerPick(tmpDir, []);
+
+    expect(decision.action).toBe('idle');
+    expect(decision.reason).toContain('next discovery slot');
+  });
+
+  it('keeps periodic discovery when no tasks are schedulable', () => {
+    for (let i = 0; i < 10; i++) advanceTick();
+    const decision = schedulerPick(tmpDir, []);
+
+    expect(decision.action).toBe('discovery');
+    expect(decision.reason).toContain('discovery slot');
+  });
+
+  it('keeps direct external signals on the full open-cycle path even with no tasks', () => {
+    advanceTick();
+    const decision = schedulerPick(tmpDir, [{ source: 'room', priority: 0, isAlexDirectMessage: true }]);
+
+    expect(decision.action).toBe('discovery');
+    expect(decision.reason).toContain('direct signal');
+  });
+
   it('does not pick a suppressed task', async () => {
     const task = await appendMemoryIndexEntry(tmpDir, {
       type: 'task',


### PR DESCRIPTION
## Summary
- gate empty-task cycles so routine no-task ticks use idle instead of full open-cycle discovery
- preserve full discovery for direct/P0 signals and every 10th discovery slot
- add scheduler regression coverage for idle, periodic discovery, and direct-signal behavior

## Verification
- pnpm exec vitest run tests/scheduler-dispatch-suppression.test.ts tests/dispatcher.test.ts
- pnpm typecheck

## Notes
- Full pnpm test in runtime checkout exposed an existing unrelated failure in tests/should-fast-fail-fast-band.test.ts (slow-band subtype expectation), not caused by this scheduler change.
