### PR TITLE
fix(runtime): preserve local runtime commit dirty-moz8oufb

### DIFF
--- a/src/feedback-loops.ts
+++ b/src/feedback-loops.ts
@@ -282,7 +282,11 @@ export function extractErrorSubtype(errorMsg: string): string {
       // spawns false [REGRESSION] tasks for upstream events the breaker can't
       // influence. Attempt 2-3/N retry-storm fires stay as transient_fast_band
       // (genuine fast-band the damper applies to).
-      if (dur < 20 && /attempt 1\//.test(lower)) return 'upstream_quickreject_cn';
+      const hasQuickRejectShape =
+        lower.includes('exit n/a')
+        && lower.includes('ms this attempt')
+        && lower.includes('請稍後再試');
+      if (dur < 20 && /attempt 1\//.test(lower) && hasQuickRejectShape) return 'upstream_quickreject_cn';
       if (dur < 10) return 'transient_fast_band';
       if (dur < 60) return 'transient_slow_band';
     }


### PR DESCRIPTION
## Summary
- autocorrected 0 commit(s) that were made on protected runtime/main
- moved the change into an isolated worktree branch so review/merge/deploy can proceed normally
- reset the runtime checkout back to origin/main after preserving the change

## Verification
- [x] `git push -u origin fix/runtime-autocorrect-dirty-moz8oufb` passed; the runtime-local commit is preserved on an isolated review branch
- [x] `git reset --hard origin/main` passed; the protected runtime checkout was restored to origin/main