### PR TITLE
fix(runtime): preserve local runtime commit dirty-moz9ac5u

### DIFF
--- a/src/commitment-ledger.ts
+++ b/src/commitment-ledger.ts
@@ -98,11 +98,28 @@ function deduplicateLines(lines: string[]): Map<string, CommitmentEntry> {
   for (const line of lines) {
     try {
       const entry = JSON.parse(line) as CommitmentEntry;
-      if (entry.id) map.set(entry.id, entry);
+      if (!entry.id) continue;
+      // #78: skip entries missing required fields — prevents corrupt drain
+      // records from overwriting valid prior state for the same id.
+      if (!entry.cycle_id || !entry.status) {
+        if (!map.has(entry.id)) map.set(entry.id, entry);
+        continue;
+      }
+      map.set(entry.id, entry);
     } catch { /* skip malformed lines */ }
   }
   return map;
 }
+
+
+
+
+
+
+
+
+
+
 
 function appendLine(entry: CommitmentEntry): void {
   const p = getLedgerPath();


### PR DESCRIPTION
## Summary
- autocorrected 0 commit(s) that were made on protected runtime/main
- moved the change into an isolated worktree branch so review/merge/deploy can proceed normally
- reset the runtime checkout back to origin/main after preserving the change

## Verification
- [x] `git push -u origin fix/runtime-autocorrect-dirty-moz9ac5u` passed; the runtime-local commit is preserved on an isolated review branch
- [x] `git reset --hard origin/main` passed; the protected runtime checkout was restored to origin/main