### PR TITLE
fix(runtime): preserve local runtime commit dirty-moz9qnxd

### DIFF
--- a/src/commitment-ledger.ts
+++ b/src/commitment-ledger.ts
@@ -343,6 +343,16 @@ export function parseFalsifierToQuery(falsifier: string): FalsifierQuery | undef
       threshold: Number.parseInt(grep[5], 10),
     };
   }
+
+  // abs_path /path >=N — legacy format, treat as file_exists check
+  const absPath = falsifier.match(/\babs_path\s+(\/\S+?)\s+(>=|<=|==)\s*(\d+)/);
+  if (absPath) {
+    const threshold = Number.parseInt(absPath[3], 10);
+    const op = absPath[2];
+    const must = op === '>=' ? threshold >= 1 : op === '==' ? threshold >= 1 : false;
+    return { kind: 'file_exists', path: absPath[1], must };
+  }
+
   return undefined;
 }
 


### PR DESCRIPTION
## Summary
- autocorrected 0 commit(s) that were made on protected runtime/main
- moved the change into an isolated worktree branch so review/merge/deploy can proceed normally
- reset the runtime checkout back to origin/main after preserving the change

## Verification
- [x] `git push -u origin fix/runtime-autocorrect-dirty-moz9qnxd` passed; the runtime-local commit is preserved on an isolated review branch
- [x] `git reset --hard origin/main` passed; the protected runtime checkout was restored to origin/main