### PR TITLE
fix: gate low-value heartbeat cron llm calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "setup": "pnpm install && pnpm build && npm link",
     "prepare": "git config core.hooksPath .githooks 2>/dev/null || true",
     "check:pr-lifecycle": "tsx scripts/check-pr-lifecycle.ts",
+    "llm:token-usage": "tsx scripts/llm-token-usage.ts",
     "rotate:logs": "node scripts/rotate-decision-logs.mjs",
     "rotate:logs:dry": "node scripts/rotate-decision-logs.mjs --dry-run"
   },

--- a/scripts/llm-token-usage.ts
+++ b/scripts/llm-token-usage.ts
@@ -1,0 +1,117 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+interface Bucket {
+  calls: number;
+  promptChars: number;
+  estInputTokens: number;
+  durationMs: number;
+}
+
+function add(bucket: Map<string, Bucket>, key: string, promptChars: number, durationMs = 0): void {
+  const current = bucket.get(key) ?? { calls: 0, promptChars: 0, estInputTokens: 0, durationMs: 0 };
+  current.calls += 1;
+  current.promptChars += promptChars;
+  current.estInputTokens += Math.round(promptChars / 4);
+  current.durationMs += durationMs;
+  bucket.set(key, current);
+}
+
+function classifyPrompt(prompt: string): string {
+  const p = prompt.toLowerCase();
+  if (p.includes('check heartbeat.md for pending tasks')) return 'heartbeat-cron';
+  if (p.includes('binding="open-cycle"') || p.includes('open cycle')) return 'open-cycle/discovery';
+  if (p.includes('binding="scheduler"') || p.includes('scheduler task') || p.includes('autonomy closure')) return 'autonomy-closure/scheduler';
+  if (p.includes('continue-current') || p.includes('binding="continue"')) return 'continue-current';
+  if (p.includes('telegram-user') || p.includes('chat-room-inbox') || p.includes('room-priority')) return 'foreground/status-room';
+  if (p.includes('delegation') || p.includes('background-completed')) return 'delegation-absorb';
+  return 'other';
+}
+
+function readJsonl(file: string): unknown[] {
+  if (!fs.existsSync(file)) return [];
+  return fs.readFileSync(file, 'utf-8')
+    .split('\n')
+    .filter(Boolean)
+    .flatMap(line => {
+      try {
+        return [JSON.parse(line) as unknown];
+      } catch {
+        return [];
+      }
+    });
+}
+
+function findClaudeLogs(date: string, root = path.join(os.homedir(), '.mini-agent', 'instances')): string[] {
+  if (!fs.existsSync(root)) return [];
+  return fs.readdirSync(root, { withFileTypes: true })
+    .filter(entry => entry.isDirectory())
+    .map(entry => path.join(root, entry.name, 'logs', 'claude', `${date}.jsonl`))
+    .filter(file => fs.existsSync(file));
+}
+
+function formatTable(title: string, buckets: Map<string, Bucket>): void {
+  const rows = [...buckets.entries()]
+    .sort((a, b) => b[1].estInputTokens - a[1].estInputTokens);
+  const totalTokens = rows.reduce((sum, [, b]) => sum + b.estInputTokens, 0);
+  const totalCalls = rows.reduce((sum, [, b]) => sum + b.calls, 0);
+
+  console.log(`\n${title}`);
+  console.log(`total_calls=${totalCalls} est_input_tokens=${totalTokens}${totalTokens === 0 ? ' token_telemetry=missing' : ''}`);
+  for (const [name, b] of rows) {
+    const pct = totalTokens === 0 ? 0 : Math.round((b.estInputTokens / totalTokens) * 100);
+    const sec = Math.round(b.durationMs / 1000);
+    const tokenCell = totalTokens === 0
+      ? 'tokens=unknown'
+      : `tokens=${String(b.estInputTokens).padStart(8)} pct=${String(pct).padStart(3)}%`;
+    console.log(`${name.padEnd(30)} calls=${String(b.calls).padStart(4)} ${tokenCell} duration_s=${sec}`);
+  }
+}
+
+function main(): void {
+  const date = process.argv.find(arg => /^\d{4}-\d{2}-\d{2}$/.test(arg)) ?? new Date().toISOString().slice(0, 10);
+  const memoryDir = process.env.MINI_AGENT_MEMORY_DIR ?? path.join(process.cwd(), 'memory');
+  const cloud = new Map<string, Bucket>();
+
+  for (const file of findClaudeLogs(date)) {
+    for (const row of readJsonl(file)) {
+      const obj = row as {
+        data?: { input?: { userMessage?: string }, duration?: number },
+        metadata?: { duration?: number },
+      };
+      const prompt = obj.data?.input?.userMessage ?? '';
+      if (!prompt) continue;
+      const durationMs = Number(obj.data?.duration ?? obj.metadata?.duration ?? 0);
+      add(cloud, classifyPrompt(prompt), prompt.length, Number.isFinite(durationMs) ? durationMs : 0);
+    }
+  }
+
+  const brain = new Map<string, Bucket>();
+  const brainRuns = path.join(memoryDir, 'index', 'brain-runs.jsonl');
+  for (const row of readJsonl(brainRuns)) {
+    const obj = row as {
+      createdAt?: string,
+      actor?: string,
+      status?: string,
+      taskType?: string,
+      estimatedTokens?: number,
+      durationMs?: number,
+    };
+    if (!obj.createdAt?.startsWith(date)) continue;
+    const key = `${obj.actor ?? 'unknown'}:${obj.status ?? 'unknown'}:${obj.taskType ?? 'unknown'}`;
+    add(brain, key, Math.max(0, Number(obj.estimatedTokens ?? 0) * 4), Number(obj.durationMs ?? 0));
+  }
+
+  formatTable(`Cloud Claude prompt usage ${date}`, cloud);
+  formatTable(`BrainRuntime usage ${date}`, brain);
+
+  const cloudTokens = [...cloud.values()].reduce((sum, b) => sum + b.estInputTokens, 0);
+  const shellCalls = [...brain.entries()]
+    .filter(([name]) => name.startsWith('shell:'))
+    .reduce((sum, [, b]) => sum + b.calls, 0);
+  const brainCalls = [...brain.values()].reduce((sum, b) => sum + b.calls, 0);
+  console.log(`\nroute_hint cloud_tokens=${cloudTokens} shell_calls=${shellCalls}/${brainCalls} shell_call_ratio=${brainCalls === 0 ? 0 : Math.round((shellCalls / brainCalls) * 100)}%`);
+}
+
+main();

--- a/src/omlx-gate.ts
+++ b/src/omlx-gate.ts
@@ -46,6 +46,13 @@ export interface GateStats {
   totalSaved: number; // estimated chars saved
 }
 
+export interface HeartbeatCronActionability {
+  uncheckedLines: string[];
+  actionableLines: string[];
+  blockedLines: string[];
+  lowPriorityLines: string[];
+}
+
 // =============================================================================
 // State
 // =============================================================================
@@ -156,22 +163,52 @@ export function cronGate(taskDescription: string): CronGateResult {
     return 'skip';
   }
 
-  // Has unchecked tasks — check if any have actionable verbs
-  const lines = content.split('\n').filter(l => /^- \[ ?\]/.test(l.trim()));
-  const ACTION_VERBS = /\b(fix|implement|add|create|build|deploy|write|send|check|review|update|research|investigate|refactor|merge|push|test|publish|run)\b|測試|發佈|部署|修復|建立|檢查|研究|撰寫|送出|執行|更新/i;
-  const hasActionable = lines.some(l => ACTION_VERBS.test(l));
+  const actionability = classifyHeartbeatCronActionability(content);
+  const hasActionable = actionability.actionableLines.length > 0;
 
   if (!hasActionable) {
     stats.cronSkipped++;
     stats.totalSaved += 13000;
     eventBus.emit('log:info', {
-      tag: 'omlx-gate', msg: `R3: HEARTBEAT has ${lines.length} unchecked tasks but none actionable (no action verbs), skipping`,
+      tag: 'omlx-gate',
+      msg: `R3: HEARTBEAT has ${actionability.uncheckedLines.length} unchecked tasks but none cron-actionable (blocked=${actionability.blockedLines.length}, low=${actionability.lowPriorityLines.length}), skipping`,
     });
     return 'skip';
   }
 
   stats.cronPassed++;
   return 'claude';
+}
+
+export function classifyHeartbeatCronActionability(content: string): HeartbeatCronActionability {
+  const uncheckedLines = content
+    .split('\n')
+    .filter(l => /^- \[ ?\]/.test(l.trim()));
+
+  const ACTION_VERBS = /\b(fix|implement|add|create|build|deploy|write|send|check|review|update|research|investigate|refactor|merge|push|test|publish|run)\b|測試|發佈|部署|修復|建立|檢查|研究|撰寫|送出|執行|更新/i;
+  const BLOCKED_OR_WAITING = /\b(HOLD|blocked|waiting|refuted|depends on|needs human|human required)\b|等\s*(Alex|B\d|B1|B2|B3|B4|confirm)|需\s*Alex|Alex\s+confirm|待解封|不存在於 codebase|平台 live 投票|人工|登入|login|npm login|Gmail session|Mastodon/i;
+  const HIGH_PRIORITY = /\bP[01]\b|🔴|CRITICAL/i;
+  const LOW_PRIORITY = /\bP[2-9]\b/i;
+
+  const blockedLines: string[] = [];
+  const lowPriorityLines: string[] = [];
+  const actionableLines: string[] = [];
+
+  for (const line of uncheckedLines) {
+    if (BLOCKED_OR_WAITING.test(line)) {
+      blockedLines.push(line);
+      continue;
+    }
+    if (!HIGH_PRIORITY.test(line) || LOW_PRIORITY.test(line)) {
+      lowPriorityLines.push(line);
+      continue;
+    }
+    if (ACTION_VERBS.test(line)) {
+      actionableLines.push(line);
+    }
+  }
+
+  return { uncheckedLines, actionableLines, blockedLines, lowPriorityLines };
 }
 
 // =============================================================================
@@ -602,6 +639,8 @@ export function resetGateStats(): void {
     perceptionSectionsPruned: 0, skillsReduced: 0,
     totalSaved: 0,
   });
+  lastHeartbeatContentHash = '';
+  lastContextHash = '';
 }
 
 /**

--- a/tests/omlx-gate.test.ts
+++ b/tests/omlx-gate.test.ts
@@ -1,0 +1,78 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  classifyHeartbeatCronActionability,
+  cronGate,
+  getGateStats,
+  resetGateStats,
+} from '../src/omlx-gate.js';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(path.join(os.tmpdir(), 'mini-agent-omlx-gate-'));
+  mkdirSync(path.join(tmpDir, 'state'), { recursive: true });
+  vi.stubEnv('MINI_AGENT_MEMORY_DIR', tmpDir);
+  resetGateStats();
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+  vi.unstubAllEnvs();
+  resetGateStats();
+});
+
+describe('classifyHeartbeatCronActionability', () => {
+  it('ignores blocked, waiting, and low-priority HEARTBEAT items for cron wakeups', () => {
+    const result = classifyHeartbeatCronActionability([
+      '# HEARTBEAT',
+      '## Active Tasks',
+      '- [ ] **B3 Arena**: 需 Alex 觸發 c3 generation 拉 n。',
+      '- [ ] P2: ai-trend Path 2 — add TrendRadar lane。等 Alex confirm scope 再動。',
+      '- [ ] 深讀 ArXiv 1 篇 → research and form opinion。',
+    ].join('\n'));
+
+    expect(result.uncheckedLines).toHaveLength(3);
+    expect(result.actionableLines).toEqual([]);
+    expect(result.blockedLines).toHaveLength(2);
+    expect(result.lowPriorityLines).toHaveLength(1);
+  });
+
+  it('allows only high-priority non-blocked executable items through to Claude', () => {
+    const result = classifyHeartbeatCronActionability([
+      '# HEARTBEAT',
+      '## Active Tasks',
+      '- [ ] P1: fix duplicate scheduler dispatch and run tests.',
+      '- [ ] P0 Repair autonomy closure: implement runtime-workspace guard.',
+    ].join('\n'));
+
+    expect(result.actionableLines).toHaveLength(2);
+  });
+});
+
+describe('cronGate', () => {
+  it('skips HEARTBEAT cron when unchecked items are not cron-actionable', () => {
+    writeFileSync(path.join(tmpDir, 'HEARTBEAT.md'), [
+      '# HEARTBEAT',
+      '## Active Tasks',
+      '- [ ] **B3 Arena**: 需 Alex 觸發 c3 generation 拉 n。',
+      '- [ ] P2: ai-trend Path 2 — update preview。等 Alex confirm scope 再動。',
+    ].join('\n'), 'utf-8');
+
+    expect(cronGate('Check HEARTBEAT.md for pending tasks and execute them if any')).toBe('skip');
+    expect(getGateStats().cronSkipped).toBe(1);
+  });
+
+  it('passes high-priority executable HEARTBEAT tasks to Claude', () => {
+    writeFileSync(path.join(tmpDir, 'HEARTBEAT.md'), [
+      '# HEARTBEAT',
+      '## Active Tasks',
+      '- [ ] P1: fix token routing gate and run pnpm test.',
+    ].join('\n'), 'utf-8');
+
+    expect(cronGate('Check HEARTBEAT.md for pending tasks and execute them if any')).toBe('claude');
+    expect(getGateStats().cronPassed).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add HEARTBEAT cron actionability classification so blocked/waiting/P2 items do not wake Claude
- add llm:token-usage report for daily cloud prompt buckets and BrainRuntime call mix
- cover cron gate behavior with regression tests

## Verification
- pnpm typecheck
- pnpm exec vitest run tests/omlx-gate.test.ts
- pnpm test
- MINI_AGENT_MEMORY_DIR=/Users/user/Workspace/mini-agent-memory/memory pnpm llm:token-usage 2026-05-10