### PR TITLE
fix: skip stale autonomy closure dispatch

### DIFF
--- a/src/memory-index.ts
+++ b/src/memory-index.ts
@@ -9,7 +9,7 @@
  * Design: #207/#208 conversation consensus.
  */
 
-import { readFileSync, existsSync, mkdirSync, writeFileSync, statSync } from 'node:fs';
+import { appendFileSync, readFileSync, existsSync, mkdirSync, writeFileSync, statSync } from 'node:fs';
 import { exec, execSync } from 'node:child_process';
 import { promisify } from 'node:util';
 
@@ -452,6 +452,37 @@ export async function updateMemoryIndexEntry(
 
   writeThroughEntry(memoryDir, updated);
   await recordWorkflowTransition(memoryDir, current, updated);
+  return updated;
+}
+
+export function updateMemoryIndexEntrySync(
+  memoryDir: string,
+  id: string,
+  patch: Partial<Omit<MemoryIndexEntry, 'id'>>,
+): MemoryIndexEntry | null {
+  const normalId = normalizeId(id);
+  const current = queryMemoryIndexSync(memoryDir, { id: normalId, limit: 1 })[0];
+  if (!current) {
+    slog('WARN', `updateMemoryIndexEntrySync: lookup miss for id=${normalId} — no-op`);
+    return null;
+  }
+
+  const updated: MemoryIndexEntry = {
+    ...current,
+    ...patch,
+    id: normalId,
+    ts: new Date().toISOString(),
+    refs: patch.refs ?? current.refs,
+  };
+
+  const bucket = getBucketForType(updated.type);
+  const filePath = ensureBucketFileSync(memoryDir, bucket);
+  appendFileSync(filePath, JSON.stringify(updated) + '\n', 'utf-8');
+
+  writeThroughEntry(memoryDir, updated);
+  void recordWorkflowTransition(memoryDir, current, updated).catch(error => {
+    slog('WARN', `workflow transition record failed after sync update: ${error instanceof Error ? error.message : String(error)}`);
+  });
   return updated;
 }
 

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -8,11 +8,12 @@
 import { existsSync, readFileSync, statSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { execSync } from 'node:child_process';
-import { queryMemoryIndexSync, updateMemoryIndexEntry, loadResolvedTaskKeysFromEvents, type MemoryIndexEntry } from './memory-index.js';
+import { queryMemoryIndexSync, updateMemoryIndexEntry, updateMemoryIndexEntrySync, loadResolvedTaskKeysFromEvents, type MemoryIndexEntry } from './memory-index.js';
 import { slog } from './utils.js';
 import { eventBus } from './event-bus.js';
-import { getProcess } from './process-table.js';
+import { completeProcess, getProcess } from './process-table.js';
 import { evaluateCorrectionGate, isCorrectionTask, type CorrectionGateSnapshot } from './correction-gate.js';
+import { evaluateAutonomyClosure, isAutonomyClosureTask, type AutonomyClosureSnapshot } from './autonomy-closure-health.js';
 import { reverifyPredicate } from './predicate-freshness.js';
 import { filterHeldCorrectionTasks } from './correction-holds.js';
 
@@ -471,6 +472,11 @@ export function schedulerPick(
 
   const correctionSnapshot = evaluateCorrectionGate(memoryDir);
   const activeCorrectionReasons = new Set(correctionSnapshot.reasons.map(reason => reason.type));
+  const autonomySnapshot = evaluateAutonomyClosure(memoryDir);
+  const activeAutonomyStages = new Set([
+    ...autonomySnapshot.blockingStages,
+    ...autonomySnapshot.warningStages,
+  ]);
   const entries = queryMemoryIndexSync(memoryDir, {
     type: ['task'],
     status: ['pending', 'in_progress'],
@@ -488,6 +494,13 @@ export function schedulerPick(
       if (!entry || !isCorrectionTask(entry)) return true;
       if (correctionTaskMatchesSnapshot(entry, correctionSnapshot, activeCorrectionReasons)) return true;
       slog('SCHED', `dispatch-correction-stale: skipping task=${t.id.slice(0, 12)} ${t.summary.slice(0, 50)}`);
+      return false;
+    })
+    .filter(t => {
+      const entry = entries.find(item => item.id === t.id);
+      if (!entry || !isAutonomyClosureTask(entry)) return true;
+      if (autonomyClosureTaskMatchesSnapshot(entry, autonomySnapshot, activeAutonomyStages)) return true;
+      completeStaleAutonomyClosureTask(memoryDir, entry, autonomySnapshot);
       return false;
     })
     .filter(t => {
@@ -681,6 +694,54 @@ function correctionTaskMatchesSnapshot(
   const summaryReason = parseCorrectionReasonFromSummary(entry.summary ?? '');
   const reason = payloadReason ?? summaryReason;
   return reason ? activeReasonTypes.has(reason) : true;
+}
+
+function autonomyClosureTaskMatchesSnapshot(
+  entry: MemoryIndexEntry,
+  snapshot: AutonomyClosureSnapshot,
+  activeStages: Set<string>,
+): boolean {
+  if (snapshot.status === 'healthy') return false;
+  const stage = parseAutonomyClosureStage(entry.summary ?? '');
+  if (!stage) return true;
+  return activeStages.has(stage);
+}
+
+function parseAutonomyClosureStage(summary: string): string | null {
+  const match = summary.match(/autonomy closure:\s*repair\s+([a-z0-9-]+)/i);
+  return match?.[1] ?? null;
+}
+
+function completeStaleAutonomyClosureTask(
+  memoryDir: string,
+  entry: MemoryIndexEntry,
+  snapshot: AutonomyClosureSnapshot,
+): void {
+  const stage = parseAutonomyClosureStage(entry.summary ?? '');
+  const reason = snapshot.status === 'healthy'
+    ? 'closure-healthy'
+    : `stage-no-longer-active:${stage ?? 'unknown'}`;
+  const payload = (entry.payload ?? {}) as Record<string, unknown>;
+  updateMemoryIndexEntrySync(memoryDir, entry.id, {
+    status: 'completed',
+    payload: {
+      ...payload,
+      closure_resolved_at: new Date().toISOString(),
+      closure_final_score: snapshot.score,
+      closure_dispatch_skipped_reason: reason,
+    },
+  });
+  completeProcess(entry.id);
+  slog('SCHED', `dispatch-autonomy-closure-stale: completed task=${entry.id.slice(0, 12)} reason=${reason}`);
+  eventBus.emit('action:scheduler', {
+    event: 'autonomy-closure-stale-skip',
+    taskId: entry.id,
+    stage,
+    reason,
+    closureStatus: snapshot.status,
+    closureScore: snapshot.score,
+    ts: new Date().toISOString(),
+  });
 }
 
 function parseCorrectionReasonFromSummary(summary: string): string | null {

--- a/tests/scheduler-dispatch-suppression.test.ts
+++ b/tests/scheduler-dispatch-suppression.test.ts
@@ -6,16 +6,23 @@
  * a task is excluded from the dispatch queue until an external trigger resets it.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import {
   appendMemoryIndexEntry,
   invalidateIndexCache,
+  queryMemoryIndexSync,
 } from '../src/memory-index.js';
 import {
+  clearProcessTable,
+  getProcess,
+  registerProcess,
+} from '../src/process-table.js';
+import {
   schedulerPick,
+  entryToSnapshot,
   recordTaskTerminalSignal,
   resetTaskSuppression,
   resetAllSuppressions,
@@ -36,6 +43,8 @@ beforeEach(() => {
   resetAllSuppressions();
   resetCurrentTask();
   resetSchedulerStateForTest();
+  clearProcessTable();
+  vi.stubEnv('MINI_AGENT_DISABLE_MIDDLEWARE_QUALITY_CLOSURE', '1');
 });
 
 afterEach(() => {
@@ -44,6 +53,8 @@ afterEach(() => {
   resetAllSuppressions();
   resetCurrentTask();
   resetSchedulerStateForTest();
+  clearProcessTable();
+  vi.unstubAllEnvs();
 });
 
 // ─── Constants ────────────────────────────────────────────────────────────────
@@ -315,6 +326,30 @@ describe('schedulerPick — suppressed tasks excluded from dispatch', () => {
 
     expect(decision.taskId).toBe(normal.id);
     expect(decision.taskId).not.toBe(correction.id);
+  });
+
+  it('completes a stale autonomy-closure task before dispatch when closure is healthy', async () => {
+    fs.mkdirSync(path.join(tmpDir, 'state'), { recursive: true });
+    fs.mkdirSync(path.join(tmpDir, 'index'), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, 'index', 'relations.jsonl'), '', 'utf-8');
+
+    const closure = await appendMemoryIndexEntry(tmpDir, {
+      type: 'task',
+      status: 'pending',
+      summary: 'P1 autonomy closure: repair memory-state-truth',
+      tags: ['autonomy-closure'],
+      payload: { origin: 'autonomy-closure', priority: 1 },
+    });
+    registerProcess(entryToSnapshot(closure));
+    invalidateIndexCache();
+
+    const decision = schedulerPick(tmpDir, []);
+
+    expect(decision.taskId).not.toBe(closure.id);
+    const latest = queryMemoryIndexSync(tmpDir, { id: closure.id, limit: 1 })[0];
+    expect(latest.status).toBe('completed');
+    expect(latest.payload?.closure_dispatch_skipped_reason).toBe('closure-healthy');
+    expect(getProcess(closure.id)?.state).toBe('completed');
   });
 
   it('does not pick a task whose stack-rank resolved summary is a title variant', async () => {


### PR DESCRIPTION
## Summary
- reverify autonomy-closure tasks against the live closure snapshot before scheduler dispatch
- synchronously complete stale closure tasks and mark their process-table entry completed
- add regression coverage for healthy closure no longer being sent to the LLM

## Verification
- pnpm typecheck
- pnpm exec vitest run tests/scheduler-dispatch-suppression.test.ts
- pnpm test