### PR TITLE
fix: bound middleware cycle timeout

### DIFF
--- a/src/middleware-cycle-client.ts
+++ b/src/middleware-cycle-client.ts
@@ -23,7 +23,7 @@ import { slog } from './utils.js';
 import { buildForensicEntryShell, writeForensicEntry } from './forensic-log.js';
 
 const DEFAULT_POLL_INTERVAL_MS = 2_000;
-const DEFAULT_TIMEOUT_MS = 1_500_000;
+const DEFAULT_TIMEOUT_MS = 90_000;
 
 interface DispatchResponse {
   taskId: string;
@@ -58,7 +58,7 @@ export async function execClaudeViaMiddleware(
   opts?: ExecOptions,
 ): Promise<string> {
   const baseUrl = getMiddlewareUrl();
-  const timeoutMs = opts?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const timeoutMs = resolveMiddlewareCycleTimeoutMs(opts);
   const source = opts?.source ?? 'loop';
   const startTs = Date.now();
   const pollIntervalMs = DEFAULT_POLL_INTERVAL_MS;
@@ -190,4 +190,8 @@ export async function execClaudeViaMiddleware(
       middlewareStatus: 'poll-timeout',
     },
   );
+}
+
+export function resolveMiddlewareCycleTimeoutMs(opts?: Pick<ExecOptions, 'timeoutMs'>): number {
+  return opts?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
 }

--- a/tests/middleware-cycle-client.test.ts
+++ b/tests/middleware-cycle-client.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { resolveMiddlewareCycleTimeoutMs } from '../src/middleware-cycle-client.js';
+
+describe('middleware cycle client', () => {
+  it('defaults Kuro cycle calls to the same bounded timeout as the local Claude path', () => {
+    expect(resolveMiddlewareCycleTimeoutMs()).toBe(90_000);
+  });
+
+  it('honors explicit per-call timeout overrides', () => {
+    expect(resolveMiddlewareCycleTimeoutMs({ timeoutMs: 12_345 })).toBe(12_345);
+  });
+});


### PR DESCRIPTION
## Summary
- reduce middleware cycle default timeout from 25 minutes to 90 seconds
- expose and test timeout resolution so Kuro's main loop remains bounded when USE_MIDDLEWARE_FOR_CYCLE=true
- keep explicit per-call timeout overrides intact for callers that need them

## Verification
- pnpm typecheck
- pnpm exec vitest run tests/middleware-cycle-client.test.ts tests/middleware-provider.test.ts
- pnpm test (before rebase; 129 files, 1077 passed, 2 skipped)