### PR TITLE
fix(commitment-ledger): accept single-quoted grep falsifier DSL (#78)

### DIFF
--- a/src/commitment-ledger.ts
+++ b/src/commitment-ledger.ts
@@ -330,17 +330,21 @@ export function parseFalsifierToQuery(falsifier: string): FalsifierQuery | undef
   const pos = falsifier.match(new RegExp(String.raw`\bfile_exists:(\/\S+?)` + stop));
   if (pos) return { kind: 'file_exists', path: pos[1], must: true };
 
+  // Accept either double- or single-quoted pattern. Issue #78: agents commonly
+  // emit single-quoted variants (`grep:/path 'regex' >=N`) which the original
+  // double-quote-only regex silently no-op'd, causing the falsifier to age out
+  // unverified. Capture group [2] = double-quoted body, [3] = single-quoted body.
   const grep = falsifier.match(
-    /\bgrep:(\/\S+?)\s+"((?:[^"\\]|\\.)*)"(?:\s+since:(\S+?))?\s+(>=|<=|==)\s*(\d+)/,
+    /\bgrep:(\/\S+?)\s+(?:"((?:[^"\\]|\\.)*)"|'((?:[^'\\]|\\.)*)')(?:\s+since:(\S+?))?\s+(>=|<=|==)\s*(\d+)/,
   );
   if (grep) {
     return {
       kind: 'log_grep',
       path: grep[1],
-      pattern: unescapeQuotedPattern(grep[2]),
-      since_iso: grep[3] ?? new Date().toISOString(),
-      op: grep[4] as '<=' | '>=' | '==',
-      threshold: Number.parseInt(grep[5], 10),
+      pattern: unescapeQuotedPattern(grep[2] ?? grep[3] ?? ''),
+      since_iso: grep[4] ?? new Date().toISOString(),
+      op: grep[5] as '<=' | '>=' | '==',
+      threshold: Number.parseInt(grep[6], 10),
     };
   }
 

--- a/tests/commitment-ledger.test.ts
+++ b/tests/commitment-ledger.test.ts
@@ -231,6 +231,18 @@ describe('commitment-ledger trust-layer branching', () => {
     expect(parsed && parsed.kind === 'log_grep' ? parsed.since_iso : '').toMatch(/^\d{4}-\d{2}-\d{2}T/);
   });
 
+  it('parses single-quoted grep falsifier DSL (issue #78 single-quote tolerance)', () => {
+    const parsed = parseFalsifierToQuery("grep:/tmp/x.log 'foo.*bar' >=2");
+
+    expect(parsed).toEqual(expect.objectContaining({
+      kind: 'log_grep',
+      path: '/tmp/x.log',
+      pattern: 'foo.*bar',
+      op: '>=',
+      threshold: 2,
+    }));
+  });
+
   it('parses grep falsifier DSL with explicit since timestamp', () => {
     const parsed = parseFalsifierToQuery('grep:/tmp/x.log "bar" since:2026-05-01T00:00:00Z ==0');
 


### PR DESCRIPTION
## Summary

- `parseFalsifierToQuery` only matched **double-quoted** patterns (`grep:/path "regex" >=N`). Agents commonly emit **single-quoted** variants (`grep:/path 'regex' >=N`) which silently no-op'd → falsifier aged out unverified, feeding the 99.97% prose-falsifier expiry rate flagged in #78.
- Extends the grep regex with a non-capturing alternation `("..."|'...')`; capture groups shift by one, with `pattern: grep[2] ?? grep[3] ?? ''` picking whichever quote style filled.
- Adds a test (`parses single-quoted grep falsifier DSL`) covering the single-quote path. All 17 `commitment-ledger.test.ts` tests pass.

## Why

Memory state shows multiple cycles where I emitted `grep:/path '...' >=N` and the parser silently dropped the entry. Tightening accepted DSL surface area without changing semantics turns those into resolvable commitments.

## Test plan

- [x] `pnpm vitest run tests/commitment-ledger.test.ts` — 17/17 pass
- [ ] After merge: monitor commitments.jsonl for single-quote falsifiers transitioning to `kept`/`refuted` instead of `expired`

🤖 Generated with [Claude Code](https://claude.com/claude-code)