### PR TITLE
fix: route routine cycles through token governor

### DIFF
--- a/src/cloud-token-governor.ts
+++ b/src/cloud-token-governor.ts
@@ -1,0 +1,204 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type { SchedulingDecision, IncomingEvent } from './scheduler.js';
+import type { CycleMode } from './memory.js';
+
+export type CloudPromptBucket =
+  | 'heartbeat-cron'
+  | 'open-cycle/discovery'
+  | 'autonomy-closure/scheduler'
+  | 'continue-current'
+  | 'foreground/status-room'
+  | 'delegation-absorb'
+  | 'other';
+
+export interface CloudPromptUsageBucket {
+  calls: number;
+  promptChars: number;
+  estInputTokens: number;
+  durationMs: number;
+  lastSeenAt: string | null;
+}
+
+export type CloudPromptUsage = Record<CloudPromptBucket, CloudPromptUsageBucket>;
+
+export interface CloudTokenGovernorInput {
+  decision: SchedulingDecision;
+  events: IncomingEvent[];
+  cycleMode: CycleMode;
+  promptChars: number;
+  hasPendingTasks: boolean;
+  hasHighPriorityTasks: boolean;
+  trueNoopStreak: number;
+  date?: string;
+  now?: Date;
+  logsRoot?: string;
+  env?: NodeJS.ProcessEnv;
+}
+
+export interface CloudTokenGovernorDecision {
+  action: 'call-cloud' | 'deterministic-probe';
+  reason: string;
+  bucket?: CloudPromptBucket;
+  usage?: CloudPromptUsageBucket;
+  cooldownMs?: number;
+}
+
+const BUCKETS: CloudPromptBucket[] = [
+  'heartbeat-cron',
+  'open-cycle/discovery',
+  'autonomy-closure/scheduler',
+  'continue-current',
+  'foreground/status-room',
+  'delegation-absorb',
+  'other',
+];
+
+const DIRECT_TRIGGER_SOURCES = new Set(['telegram', 'room', 'chat', 'direct-message']);
+const ROUTINE_TRIGGER_SOURCES = new Set(['heartbeat', 'cron', 'startup', 'workspace', 'continuation']);
+
+export function classifyCloudPrompt(prompt: string): CloudPromptBucket {
+  const p = prompt.toLowerCase();
+  if (p.includes('check heartbeat.md for pending tasks')) return 'heartbeat-cron';
+  if (p.includes('binding="open-cycle"') || p.includes('open cycle')) return 'open-cycle/discovery';
+  if (p.includes('binding="scheduler"') || p.includes('scheduler task') || p.includes('autonomy closure')) return 'autonomy-closure/scheduler';
+  if (p.includes('continue-current') || p.includes('binding="continue"')) return 'continue-current';
+  if (p.includes('telegram-user') || p.includes('chat-room-inbox') || p.includes('room-priority')) return 'foreground/status-room';
+  if (p.includes('delegation') || p.includes('background-completed')) return 'delegation-absorb';
+  return 'other';
+}
+
+export function readCloudPromptUsage(
+  date: string,
+  logsRoot = path.join(os.homedir(), '.mini-agent', 'instances'),
+): CloudPromptUsage {
+  const usage = emptyUsage();
+  if (!fs.existsSync(logsRoot)) return usage;
+
+  for (const entry of fs.readdirSync(logsRoot, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const file = path.join(logsRoot, entry.name, 'logs', 'claude', `${date}.jsonl`);
+    if (!fs.existsSync(file)) continue;
+    for (const line of fs.readFileSync(file, 'utf-8').split('\n')) {
+      if (!line.trim()) continue;
+      try {
+        const row = JSON.parse(line) as {
+          timestamp?: string;
+          data?: { input?: { userMessage?: string }; duration?: number };
+          metadata?: { duration?: number };
+        };
+        const prompt = row.data?.input?.userMessage ?? '';
+        if (!prompt) continue;
+        const bucket = classifyCloudPrompt(prompt);
+        const current = usage[bucket];
+        current.calls += 1;
+        current.promptChars += prompt.length;
+        current.estInputTokens += Math.round(prompt.length / 4);
+        const duration = Number(row.data?.duration ?? row.metadata?.duration ?? 0);
+        if (Number.isFinite(duration)) current.durationMs += duration;
+        if (row.timestamp && (!current.lastSeenAt || row.timestamp > current.lastSeenAt)) {
+          current.lastSeenAt = row.timestamp;
+        }
+      } catch {
+        // Ignore malformed log rows; the governor must not break the loop.
+      }
+    }
+  }
+  return usage;
+}
+
+export function decideCloudTokenRoute(input: CloudTokenGovernorInput): CloudTokenGovernorDecision {
+  const env = input.env ?? process.env;
+  if (env.MINI_AGENT_CLOUD_TOKEN_GOVERNOR === '0') {
+    return { action: 'call-cloud', reason: 'governor disabled by MINI_AGENT_CLOUD_TOKEN_GOVERNOR=0' };
+  }
+
+  if (input.events.some(event => event.isAlexDirectMessage || DIRECT_TRIGGER_SOURCES.has(event.source))) {
+    return { action: 'call-cloud', reason: 'direct user-visible signal deserves cloud reasoning budget' };
+  }
+
+  if (input.decision.taskId || input.hasPendingTasks || input.hasHighPriorityTasks || input.cycleMode === 'task' || input.cycleMode === 'respond') {
+    return { action: 'call-cloud', reason: 'bound or pending work deserves cloud reasoning budget' };
+  }
+
+  const routine = input.events.length === 0 || input.events.some(event => ROUTINE_TRIGGER_SOURCES.has(event.source));
+  if (!routine) return { action: 'call-cloud', reason: 'non-routine trigger' };
+
+  const date = input.date ?? (input.now ?? new Date()).toISOString().slice(0, 10);
+  const usage = readCloudPromptUsage(date, input.logsRoot);
+  const openCycleUsage = usage['open-cycle/discovery'];
+  const totalTokens = BUCKETS.reduce((sum, bucket) => sum + usage[bucket].estInputTokens, 0);
+  const openCycleBudget = readIntEnv(env, 'MINI_AGENT_OPEN_CYCLE_CLOUD_TOKEN_BUDGET', 80_000);
+  const dailyBudget = readIntEnv(env, 'MINI_AGENT_DAILY_CLOUD_TOKEN_BUDGET', 350_000);
+  const cooldownMs = readIntEnv(env, 'MINI_AGENT_OPEN_CYCLE_CLOUD_COOLDOWN_MS', 6 * 60 * 60_000);
+  const nowMs = (input.now ?? new Date()).getTime();
+  const lastOpenCycleMs = openCycleUsage.lastSeenAt ? Date.parse(openCycleUsage.lastSeenAt) : 0;
+  const openCycleCoolingDown = lastOpenCycleMs > 0 && nowMs - lastOpenCycleMs < cooldownMs;
+
+  if (input.decision.action === 'idle') {
+    return {
+      action: 'deterministic-probe',
+      reason: 'routine idle cycle has no bound work; use code probes instead of cloud LLM',
+      bucket: 'open-cycle/discovery',
+      usage: openCycleUsage,
+      cooldownMs,
+    };
+  }
+
+  if (input.decision.action === 'discovery') {
+    if (totalTokens >= dailyBudget) {
+      return {
+        action: 'deterministic-probe',
+        reason: `daily cloud prompt budget reached (${totalTokens} >= ${dailyBudget}); reserve cloud for direct or bound work`,
+        bucket: 'open-cycle/discovery',
+        usage: openCycleUsage,
+        cooldownMs,
+      };
+    }
+    if (openCycleUsage.estInputTokens >= openCycleBudget) {
+      return {
+        action: 'deterministic-probe',
+        reason: `open-cycle cloud prompt budget reached (${openCycleUsage.estInputTokens} >= ${openCycleBudget}); use shell/local probes`,
+        bucket: 'open-cycle/discovery',
+        usage: openCycleUsage,
+        cooldownMs,
+      };
+    }
+    if (openCycleCoolingDown) {
+      return {
+        action: 'deterministic-probe',
+        reason: `routine open-cycle is cooling down; last cloud discovery ${Math.round((nowMs - lastOpenCycleMs) / 60_000)}m ago`,
+        bucket: 'open-cycle/discovery',
+        usage: openCycleUsage,
+        cooldownMs,
+      };
+    }
+    if (input.trueNoopStreak >= 3) {
+      return {
+        action: 'deterministic-probe',
+        reason: `trueNoopStreak=${input.trueNoopStreak}; run probes before spending another open-cycle cloud call`,
+        bucket: 'open-cycle/discovery',
+        usage: openCycleUsage,
+        cooldownMs,
+      };
+    }
+  }
+
+  return { action: 'call-cloud', reason: 'within cloud budget and cooldown' };
+}
+
+function emptyUsage(): CloudPromptUsage {
+  return Object.fromEntries(BUCKETS.map(bucket => [bucket, {
+    calls: 0,
+    promptChars: 0,
+    estInputTokens: 0,
+    durationMs: 0,
+    lastSeenAt: null,
+  }])) as CloudPromptUsage;
+}
+
+function readIntEnv(env: NodeJS.ProcessEnv, key: string, fallback: number): number {
+  const value = Number(env[key]);
+  return Number.isFinite(value) && value > 0 ? Math.floor(value) : fallback;
+}

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -149,6 +149,7 @@ import {
   buildImprovementTelemetry,
   recordImprovementTelemetry,
 } from './improvement-telemetry.js';
+import { decideCloudTokenRoute } from './cloud-token-governor.js';
 
 // =============================================================================
 // Types
@@ -2866,6 +2867,69 @@ export class AgentLoop {
           return null;
         }
       } catch { /* best-effort: if state unreadable, proceed with callClaude normally */ }
+
+      // Cloud token governor: routine idle/open-cycle work should first spend cheap,
+      // deterministic probes. Cloud reasoning stays reserved for direct user input,
+      // bound tasks, high-priority work, and budgeted exploration windows.
+      try {
+        const route = decideCloudTokenRoute({
+          decision: schedulerDecision,
+          events: schedulerEvents,
+          cycleMode,
+          promptChars: effectivePrompt.length,
+          hasPendingTasks,
+          hasHighPriorityTasks,
+          trueNoopStreak: this.trueNoopStreak,
+        });
+        if (route.action === 'deterministic-probe') {
+          slog('CLOUD-GOVERNOR', `deterministic-probe: ${route.reason}`);
+          eventBus.emit('action:loop', {
+            event: 'cloud-token-governor.deterministic-probe',
+            cycleCount: this.cycleCount,
+            reason: route.reason,
+            bucket: route.bucket ?? null,
+            bucketTokens: route.usage?.estInputTokens ?? null,
+            bucketCalls: route.usage?.calls ?? null,
+            promptChars: effectivePrompt.length,
+          });
+          writeActivity({
+            lane: 'ooda',
+            summary: 'Cloud token governor routed routine cycle to deterministic probes',
+            trigger: route.reason,
+            tags: ['CLOUD-GOVERNOR', 'SHELL-FIRST'],
+          });
+          recordImprovementTelemetry(buildImprovementTelemetry({
+            cycle: this.cycleCount,
+            trigger: currentTriggerReason,
+            action: 'cloud-token-governor deterministic probe',
+            tags: ['CLOUD-GOVERNOR', 'SHELL-FIRST'],
+            sideEffects: [],
+            noopStreak: this.noopStreak,
+            trueNoopStreak: this.trueNoopStreak,
+            autonomousTaskRatio: 'pending',
+            repeatRate: 'pending',
+            hasMainVisibleOutput: false,
+            hadForegroundAction: false,
+            outcomeOverride: 'reallocated-hold',
+            note: route.reason,
+          }));
+          const done = trackStart('cloud-governor-probe');
+          try {
+            await Promise.race([
+              this.runConcurrentTasks(),
+              new Promise<number>(resolve => setTimeout(() => resolve(0), 30_000)),
+            ]);
+            done();
+          } catch (err) {
+            done(String(err));
+          }
+          clearCycleCheckpoint();
+          this.adjustInterval(false);
+          return null;
+        }
+      } catch (err) {
+        slog('WARN', `cloud token governor failed: ${err}`);
+      }
 
       // Phase 2: Concurrent Action — run perception refresh + housekeeping during Claude await
       const concurrentPromise = isEnabled('concurrent-action')

--- a/tests/cloud-token-governor.test.ts
+++ b/tests/cloud-token-governor.test.ts
@@ -1,0 +1,136 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  classifyCloudPrompt,
+  decideCloudTokenRoute,
+  readCloudPromptUsage,
+} from '../src/cloud-token-governor.js';
+import type { SchedulingDecision } from '../src/scheduler.js';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mini-agent-cloud-token-governor-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function decision(overrides: Partial<SchedulingDecision> = {}): SchedulingDecision {
+  return {
+    taskId: null,
+    reason: 'discovery slot: no tasks, free exploration',
+    action: 'discovery',
+    suspended: null,
+    ...overrides,
+  };
+}
+
+function writeClaudeLog(date: string, prompt: string, timestamp = `${date}T01:00:00.000Z`): void {
+  const dir = path.join(tmpDir, '03bbc29a', 'logs', 'claude');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.appendFileSync(path.join(dir, `${date}.jsonl`), `${JSON.stringify({
+    timestamp,
+    data: { input: { userMessage: prompt }, duration: 1000 },
+  })}\n`);
+}
+
+describe('cloud token governor', () => {
+  it('classifies cloud prompt buckets used by routing reports', () => {
+    expect(classifyCloudPrompt('<current-task binding="open-cycle">OPEN CYCLE</current-task>')).toBe('open-cycle/discovery');
+    expect(classifyCloudPrompt('<current-task binding="scheduler">autonomy closure</current-task>')).toBe('autonomy-closure/scheduler');
+    expect(classifyCloudPrompt('telegram-user says hello')).toBe('foreground/status-room');
+  });
+
+  it('reads daily cloud prompt usage from instance logs', () => {
+    writeClaudeLog('2026-05-10', '<current-task binding="open-cycle">OPEN CYCLE</current-task>', '2026-05-10T02:00:00.000Z');
+    const usage = readCloudPromptUsage('2026-05-10', tmpDir);
+
+    expect(usage['open-cycle/discovery'].calls).toBe(1);
+    expect(usage['open-cycle/discovery'].estInputTokens).toBeGreaterThan(0);
+    expect(usage['open-cycle/discovery'].lastSeenAt).toBe('2026-05-10T02:00:00.000Z');
+  });
+
+  it('preserves cloud budget for direct user-visible triggers', () => {
+    const route = decideCloudTokenRoute({
+      decision: decision(),
+      events: [{ source: 'room', priority: 0, isAlexDirectMessage: true }],
+      cycleMode: 'act',
+      promptChars: 10_000,
+      hasPendingTasks: false,
+      hasHighPriorityTasks: false,
+      trueNoopStreak: 0,
+      date: '2026-05-10',
+      logsRoot: tmpDir,
+      now: new Date('2026-05-10T03:00:00.000Z'),
+      env: {},
+    });
+
+    expect(route.action).toBe('call-cloud');
+    expect(route.reason).toContain('direct');
+  });
+
+  it('routes routine idle cycles to deterministic probes', () => {
+    const route = decideCloudTokenRoute({
+      decision: decision({ action: 'idle', reason: 'idle: no schedulable tasks until next discovery slot' }),
+      events: [{ source: 'heartbeat', priority: 3, isAlexDirectMessage: false }],
+      cycleMode: 'idle',
+      promptChars: 1000,
+      hasPendingTasks: false,
+      hasHighPriorityTasks: false,
+      trueNoopStreak: 0,
+      date: '2026-05-10',
+      logsRoot: tmpDir,
+      env: {},
+    });
+
+    expect(route.action).toBe('deterministic-probe');
+    expect(route.reason).toContain('routine idle');
+  });
+
+  it('cooldowns routine open-cycle discovery after a recent cloud discovery', () => {
+    writeClaudeLog(
+      '2026-05-10',
+      '<current-task binding="open-cycle">OPEN CYCLE: free exploration</current-task>',
+      '2026-05-10T02:30:00.000Z',
+    );
+
+    const route = decideCloudTokenRoute({
+      decision: decision(),
+      events: [{ source: 'heartbeat', priority: 3, isAlexDirectMessage: false }],
+      cycleMode: 'act',
+      promptChars: 20_000,
+      hasPendingTasks: false,
+      hasHighPriorityTasks: false,
+      trueNoopStreak: 0,
+      date: '2026-05-10',
+      logsRoot: tmpDir,
+      now: new Date('2026-05-10T03:00:00.000Z'),
+      env: {},
+    });
+
+    expect(route.action).toBe('deterministic-probe');
+    expect(route.reason).toContain('cooling down');
+  });
+
+  it('allows budgeted cloud discovery when no recent open-cycle exists', () => {
+    const route = decideCloudTokenRoute({
+      decision: decision(),
+      events: [{ source: 'heartbeat', priority: 3, isAlexDirectMessage: false }],
+      cycleMode: 'act',
+      promptChars: 20_000,
+      hasPendingTasks: false,
+      hasHighPriorityTasks: false,
+      trueNoopStreak: 0,
+      date: '2026-05-10',
+      logsRoot: tmpDir,
+      now: new Date('2026-05-10T03:00:00.000Z'),
+      env: {},
+    });
+
+    expect(route.action).toBe('call-cloud');
+  });
+});


### PR DESCRIPTION
## Summary
- add a cloud-token governor that reads daily Claude prompt logs by bucket
- route routine idle/open-cycle cycles to deterministic local probes when discovery is cooling down or over budget
- preserve cloud LLM budget for direct user signals, bound tasks, and high-priority work

## Verification
- pnpm typecheck
- pnpm exec vitest run tests/cloud-token-governor.test.ts tests/observation-efficiency.test.ts tests/scheduler-dispatch-suppression.test.ts
- pnpm test
