### PR TITLE
fix: clean merged worktrees without github history

### DIFF
--- a/scripts/workspace-janitor.ts
+++ b/scripts/workspace-janitor.ts
@@ -53,12 +53,15 @@ for (const wt of worktrees) {
     continue;
   }
   if (openPrBranches.has(wt.branch)) continue;
-  if (mergedPrBranches.has(wt.branch) && isWorktreeClean(wt.path)) {
+  if ((mergedPrBranches.has(wt.branch) || isMergedToBase(wt.branch, base)) && isWorktreeClean(wt.path)) {
     removableWorktreeBranches.add(wt.branch);
+    const githubMerged = mergedPrBranches.has(wt.branch);
     actions.push({
       type: 'remove-worktree',
       target: wt.path,
-      reason: `branch ${wt.branch} was merged and worktree is clean`,
+      reason: githubMerged
+        ? `branch ${wt.branch} was merged and worktree is clean`
+        : `branch ${wt.branch} is already merged into ${base} and worktree is clean`,
       command: ['git', 'worktree', 'remove', wt.path],
     });
   }
@@ -220,8 +223,26 @@ function isBranchCheckedOut(branch: string, records: WorktreeRecord[]): boolean 
 }
 
 function isMergedToBase(branch: string, baseBranch: string): boolean {
+  const candidates = [`origin/${baseBranch}`, baseBranch];
+  for (const candidate of candidates) {
+    if (!refExists(candidate)) continue;
+    try {
+      execFileSync('git', ['merge-base', '--is-ancestor', branch, candidate], {
+        cwd: root,
+        stdio: 'ignore',
+        timeout: 5000,
+      });
+      return true;
+    } catch {
+      // Try the next known base ref.
+    }
+  }
+  return false;
+}
+
+function refExists(ref: string): boolean {
   try {
-    execFileSync('git', ['merge-base', '--is-ancestor', branch, `origin/${baseBranch}`], {
+    execFileSync('git', ['rev-parse', '--verify', '--quiet', ref], {
       cwd: root,
       stdio: 'ignore',
       timeout: 5000,

--- a/tests/workspace-janitor.test.ts
+++ b/tests/workspace-janitor.test.ts
@@ -69,6 +69,64 @@ describe('workspace janitor', () => {
       parsed.actions.findIndex(action => action.type === 'delete-local-branch'),
     );
   });
+
+  it('removes a clean worktree whose branch is already merged into base even when GitHub history is missing it', () => {
+    const repoDir = path.join(tmpDir, 'repo');
+    const worktreeDir = path.join(tmpDir, 'repo-old-fix');
+    const binDir = path.join(tmpDir, 'bin');
+    mkdirSync(repoDir);
+    mkdirSync(binDir);
+
+    git(repoDir, ['init', '-b', 'main']);
+    git(repoDir, ['config', 'user.email', 'test@example.com']);
+    git(repoDir, ['config', 'user.name', 'Test']);
+    writeFileSync(path.join(repoDir, 'README.md'), 'base\n');
+    git(repoDir, ['add', 'README.md']);
+    git(repoDir, ['commit', '-m', 'init']);
+    git(repoDir, ['checkout', '-b', 'fix/old-merged']);
+    writeFileSync(path.join(repoDir, 'README.md'), 'base\nold fix\n');
+    git(repoDir, ['add', 'README.md']);
+    git(repoDir, ['commit', '-m', 'old fix']);
+    git(repoDir, ['checkout', 'main']);
+    git(repoDir, ['merge', '--no-ff', 'fix/old-merged', '-m', 'merge old fix']);
+    git(repoDir, ['worktree', 'add', worktreeDir, 'fix/old-merged']);
+
+    const ghPath = path.join(binDir, 'gh');
+    writeFileSync(ghPath, [
+      '#!/bin/sh',
+      'case "$*" in',
+      '  *"--state merged"*) printf \'[]\\n\' ;;',
+      '  *"--state open"*) printf \'[]\\n\' ;;',
+      '  *) exit 1 ;;',
+      'esac',
+      '',
+    ].join('\n'));
+    chmodSync(ghPath, 0o755);
+
+    const out = execFileSync(path.join(process.cwd(), 'node_modules/.bin/tsx'), [path.join(process.cwd(), 'scripts/workspace-janitor.ts'), '--json'], {
+      cwd: repoDir,
+      encoding: 'utf-8',
+      env: {
+        ...process.env,
+        PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ''}`,
+        MINI_AGENT_RUNTIME_WORKSPACE: path.join(tmpDir, 'runtime'),
+      },
+    });
+    const parsed = JSON.parse(out) as { actions: Array<{ type: string; target: string; reason: string; command?: string[] }> };
+
+    expect(parsed.actions).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        type: 'remove-worktree',
+        target: expect.stringContaining('repo-old-fix'),
+        reason: expect.stringContaining('already merged into main'),
+      }),
+      expect.objectContaining({
+        type: 'delete-local-branch',
+        target: 'fix/old-merged',
+        command: ['git', 'branch', '-d', 'fix/old-merged'],
+      }),
+    ]));
+  });
 });
 
 function git(cwd: string, args: string[]): void {


### PR DESCRIPTION
## Summary
- allow workspace janitor to remove clean worktrees whose branches are already merged into the base branch even when the branch is absent from the recent GitHub merged PR listing
- fall back from origin/main to local main for local-only/offline janitor runs
- add regression coverage for old merged branch cleanup without GitHub history

## Verification
- pnpm typecheck
- pnpm exec vitest run tests/workspace-janitor.test.ts tests/deploy-script.test.ts
- pnpm test