### PR TITLE
fix: clean merged worktrees with disposable artifacts

### DIFF
--- a/scripts/workspace-janitor.ts
+++ b/scripts/workspace-janitor.ts
@@ -30,6 +30,10 @@ const protectedRoot = path.resolve(process.env.MINI_AGENT_RUNTIME_WORKSPACE ?? i
 
 const actions: JanitorAction[] = [];
 const removableWorktreeBranches = new Set<string>();
+const disposableDirtyArtifacts = new Set([
+  '.runtime-autocorrect.patch',
+  'package-lock.json',
+]);
 
 if (path.resolve(root) === protectedRoot && !isSafeRuntimeBranch(currentBranch)) {
   actions.push({
@@ -42,7 +46,7 @@ if (path.resolve(root) === protectedRoot && !isSafeRuntimeBranch(currentBranch))
 for (const wt of worktrees) {
   if (!wt.branch) continue;
   if (path.resolve(wt.path) === protectedRoot) continue;
-  if (wt.branch === base && isDisposableBaseWorktree(wt.path) && isWorktreeClean(wt.path)) {
+  if (wt.branch === base && isDisposableBaseWorktree(wt.path) && isWorktreeClean(wt.path).clean) {
     removableWorktreeBranches.add(wt.branch);
     actions.push({
       type: 'remove-worktree',
@@ -53,15 +57,14 @@ for (const wt of worktrees) {
     continue;
   }
   if (openPrBranches.has(wt.branch)) continue;
-  if ((mergedPrBranches.has(wt.branch) || isMergedToBase(wt.branch, base)) && isWorktreeClean(wt.path)) {
+  const cleanliness = isWorktreeClean(wt.path);
+  if ((mergedPrBranches.has(wt.branch) || isMergedToBase(wt.branch, base)) && cleanliness.clean) {
     removableWorktreeBranches.add(wt.branch);
     const githubMerged = mergedPrBranches.has(wt.branch);
     actions.push({
       type: 'remove-worktree',
       target: wt.path,
-      reason: githubMerged
-        ? `branch ${wt.branch} was merged and worktree is clean`
-        : `branch ${wt.branch} is already merged into ${base} and worktree is clean`,
+      reason: worktreeRemovalReason(wt.branch, base, githubMerged, cleanliness.disposableArtifacts),
       command: ['git', 'worktree', 'remove', wt.path],
     });
   }
@@ -208,8 +211,31 @@ function readRemoteBranches(): string[] {
     .map(s => s.replace(/^origin\//, ''));
 }
 
-function isWorktreeClean(worktreePath: string): boolean {
-  return (git(['-C', worktreePath, 'status', '--porcelain']) ?? '').trim().length === 0;
+function isWorktreeClean(worktreePath: string): { clean: boolean; disposableArtifacts: string[] } {
+  const status = (git(['-C', worktreePath, 'status', '--porcelain']) ?? '').trim();
+  if (!status) return { clean: true, disposableArtifacts: [] };
+
+  const dirtyPaths = status
+    .split('\n')
+    .map(line => ({ code: line.slice(0, 2), file: line.slice(3).trim() }))
+    .filter(entry => entry.file);
+  const disposableArtifacts = dirtyPaths
+    .filter(entry => entry.code === '??' && disposableDirtyArtifacts.has(entry.file))
+    .map(entry => entry.file);
+  return {
+    clean: dirtyPaths.length > 0 && dirtyPaths.length === disposableArtifacts.length,
+    disposableArtifacts,
+  };
+}
+
+function worktreeRemovalReason(branch: string, baseBranch: string, githubMerged: boolean, disposableArtifacts: string[]): string {
+  const prefix = githubMerged
+    ? `branch ${branch} was merged`
+    : `branch ${branch} is already merged into ${baseBranch}`;
+  if (disposableArtifacts.length > 0) {
+    return `${prefix} and only disposable artifact(s) remain: ${disposableArtifacts.join(', ')}`;
+  }
+  return `${prefix} and worktree is clean`;
 }
 
 function isDisposableBaseWorktree(worktreePath: string): boolean {

--- a/tests/workspace-janitor.test.ts
+++ b/tests/workspace-janitor.test.ts
@@ -127,6 +127,65 @@ describe('workspace janitor', () => {
       }),
     ]));
   });
+
+  it('removes an already-merged worktree when only disposable untracked artifacts remain', () => {
+    const repoDir = path.join(tmpDir, 'repo');
+    const worktreeDir = path.join(tmpDir, 'repo-artifact-only');
+    const binDir = path.join(tmpDir, 'bin');
+    mkdirSync(repoDir);
+    mkdirSync(binDir);
+
+    git(repoDir, ['init', '-b', 'main']);
+    git(repoDir, ['config', 'user.email', 'test@example.com']);
+    git(repoDir, ['config', 'user.name', 'Test']);
+    writeFileSync(path.join(repoDir, 'README.md'), 'base\n');
+    git(repoDir, ['add', 'README.md']);
+    git(repoDir, ['commit', '-m', 'init']);
+    git(repoDir, ['checkout', '-b', 'fix/artifact-only']);
+    writeFileSync(path.join(repoDir, 'README.md'), 'base\nartifact fix\n');
+    git(repoDir, ['add', 'README.md']);
+    git(repoDir, ['commit', '-m', 'artifact fix']);
+    git(repoDir, ['checkout', 'main']);
+    git(repoDir, ['merge', '--no-ff', 'fix/artifact-only', '-m', 'merge artifact fix']);
+    git(repoDir, ['worktree', 'add', worktreeDir, 'fix/artifact-only']);
+    writeFileSync(path.join(worktreeDir, '.runtime-autocorrect.patch'), 'temporary patch payload\n');
+
+    const ghPath = path.join(binDir, 'gh');
+    writeFileSync(ghPath, [
+      '#!/bin/sh',
+      'case "$*" in',
+      '  *"--state merged"*) printf \'[]\\n\' ;;',
+      '  *"--state open"*) printf \'[]\\n\' ;;',
+      '  *) exit 1 ;;',
+      'esac',
+      '',
+    ].join('\n'));
+    chmodSync(ghPath, 0o755);
+
+    const out = execFileSync(path.join(process.cwd(), 'node_modules/.bin/tsx'), [path.join(process.cwd(), 'scripts/workspace-janitor.ts'), '--json'], {
+      cwd: repoDir,
+      encoding: 'utf-8',
+      env: {
+        ...process.env,
+        PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ''}`,
+        MINI_AGENT_RUNTIME_WORKSPACE: path.join(tmpDir, 'runtime'),
+      },
+    });
+    const parsed = JSON.parse(out) as { actions: Array<{ type: string; target: string; reason: string; command?: string[] }> };
+
+    expect(parsed.actions).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        type: 'remove-worktree',
+        target: expect.stringContaining('repo-artifact-only'),
+        reason: expect.stringContaining('only disposable artifact(s) remain: .runtime-autocorrect.patch'),
+      }),
+      expect.objectContaining({
+        type: 'delete-local-branch',
+        target: 'fix/artifact-only',
+        command: ['git', 'branch', '-d', 'fix/artifact-only'],
+      }),
+    ]));
+  });
 });
 
 function git(cwd: string, args: string[]): void {


### PR DESCRIPTION
## Summary
- treat merged worktrees with only untracked disposable artifacts as removable
- currently scoped to runtime-autocorrect patch files and accidental npm package-lock files
- keep real dirty source/test/html changes protected for lifecycle triage

## Verification
- pnpm typecheck
- pnpm exec vitest run tests/workspace-janitor.test.ts tests/deploy-script.test.ts
- pnpm test