### PR TITLE
fix: force cleanup disposable merged worktrees

### DIFF
--- a/scripts/workspace-janitor.ts
+++ b/scripts/workspace-janitor.ts
@@ -65,7 +65,9 @@ for (const wt of worktrees) {
       type: 'remove-worktree',
       target: wt.path,
       reason: worktreeRemovalReason(wt.branch, base, githubMerged, cleanliness.disposableArtifacts),
-      command: ['git', 'worktree', 'remove', wt.path],
+      command: cleanliness.disposableArtifacts.length > 0
+        ? ['git', 'worktree', 'remove', '--force', wt.path]
+        : ['git', 'worktree', 'remove', wt.path],
     });
   }
 }

--- a/tests/workspace-janitor.test.ts
+++ b/tests/workspace-janitor.test.ts
@@ -178,6 +178,7 @@ describe('workspace janitor', () => {
         type: 'remove-worktree',
         target: expect.stringContaining('repo-artifact-only'),
         reason: expect.stringContaining('only disposable artifact(s) remain: .runtime-autocorrect.patch'),
+        command: expect.arrayContaining(['git', 'worktree', 'remove', '--force']),
       }),
       expect.objectContaining({
         type: 'delete-local-branch',


### PR DESCRIPTION
## Summary
- use git worktree remove --force only when an already-merged worktree has no real dirty work and only disposable untracked artifacts remain
- keeps normal clean worktree removal unforced
- adds regression assertion for forced artifact cleanup command

## Verification
- pnpm typecheck
- pnpm exec vitest run tests/workspace-janitor.test.ts tests/deploy-script.test.ts