### PR TITLE
fix(correction): auto-fast-forward runtime/main when clean+behind

### DIFF
--- a/src/loop.ts
+++ b/src/loop.ts
@@ -2428,7 +2428,7 @@ export class AgentLoop {
         const shouldAutocorrectRuntime = correction.reasons.some(reason =>
           reason.type === 'local-commit-not-pushed'
           || reason.type === 'dirty-runtime-workspace',
-        );
+        ) || correction.shipTruth.state === 'behind';
         if (shouldAutocorrectRuntime && process.env.MINI_AGENT_AUTOCORRECT_RUNTIME_WORKSPACE !== '0') {
           try {
             const { autocorrectRuntimeWorkspace } = await import('./runtime-workspace-autocorrect.js');


### PR DESCRIPTION
## Why

Autonomy closure cycles oscillate between healthy (score 92) and blocked (score 78, ship-and-deploy) every few cycles. Recent log: cycles 053 and 055 both report:

\`\`\`
ship-and-deploy: runtime checkout ship truth is behind — ahead=0
\`\`\`

Root cause: \`shouldAutocorrectRuntime\` in \`src/loop.ts:2428\` only triggers on \`local-commit-not-pushed\` or \`dirty-runtime-workspace\`. When \`runtime/main\` is purely behind \`origin/main\` (clean tree, no local commits, just outpaced by recent merges), no trigger fires — but the closure-check still flags it blocked, gating P0 work.

## Fix

Extend the trigger to also include \`correction.shipTruth.state === 'behind'\`. The downstream \`autocorrectRuntimeWorkspace()\` already handles this case at \`src/runtime-workspace-autocorrect.ts:80-87\` via \`git reset --hard origin/<base>\`; the gate just wasn't unlocking it.

## Verification

- [x] \`pnpm exec tsc --noEmit\` clean
- [x] Existing test \`syncs a clean runtime checkout that is behind origin/main\` (tests/runtime-workspace-autocorrect.test.ts:85) covers the unlocked path
- [ ] Post-merge: watch closure-check logs — ship-and-deploy oscillation should disappear; cycles after a PR merge should auto-resolve to healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)