### PR TITLE
fix: avoid duplicate guard for lifecycle worktrees

### DIFF
--- a/src/worktree-lifecycle-janitor.ts
+++ b/src/worktree-lifecycle-janitor.ts
@@ -1,5 +1,6 @@
 import { appendFileSync, existsSync, mkdirSync, readFileSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import path from 'node:path';
 import { appendMemoryIndexEntry, queryMemoryIndexSync, updateMemoryIndexEntry, type MemoryIndexEntry } from './memory-index.js';
 import { slog } from './utils.js';
@@ -200,7 +201,7 @@ async function ensureWorktreeFollowUpTask(memoryDir: string, item: WorktreeLifec
   const entry = await appendMemoryIndexEntry(memoryDir, {
     type: 'task',
     status: 'pending',
-    summary: `Worktree lifecycle: ${item.bucket} ${item.branch}`,
+    summary: `WT ${shortCaseHash(item.id)} ${item.bucket}: ${item.branch}`,
     refs: [item.path],
     tags: ['workspace', 'worktree-lifecycle', item.bucket],
     payload: {
@@ -357,6 +358,10 @@ function ensureLedger(memoryDir: string): string {
 
 function stableCaseId(worktreePath: string, branch: string, bucket: string): string {
   return `worktree:${bucket}:${branch}:${worktreePath}`;
+}
+
+function shortCaseHash(input: string): string {
+  return createHash('sha256').update(input).digest('hex').slice(0, 8);
 }
 
 function git(args: string[], cwd: string): string | null {

--- a/tests/worktree-lifecycle-janitor.test.ts
+++ b/tests/worktree-lifecycle-janitor.test.ts
@@ -87,7 +87,7 @@ describe('worktree lifecycle janitor', () => {
     const tasks = queryMemoryIndexSync(tmpDir, { type: ['task'], status: ['pending'] });
     expect(tasks).toHaveLength(2);
     expect(tasks[0]).toEqual(expect.objectContaining({
-      summary: expect.stringContaining('Worktree lifecycle:'),
+      summary: expect.stringContaining('WT '),
       tags: expect.arrayContaining(['workspace', 'worktree-lifecycle']),
       payload: expect.objectContaining({
         origin: 'worktree-lifecycle-janitor',
@@ -96,6 +96,24 @@ describe('worktree lifecycle janitor', () => {
       }),
     }));
     expect(readWorktreeLifecycleRecords(tmpDir)).toHaveLength(2);
+  });
+
+  it('does not let similar lifecycle task summaries trip the global duplicate guard', async () => {
+    const cases: WorktreeLifecycleCase[] = [
+      lifecycleCase('same-prefix-a', 'clean-unmerged'),
+      lifecycleCase('same-prefix-b', 'clean-unmerged'),
+      lifecycleCase('same-prefix-c', 'clean-unmerged'),
+    ];
+
+    const result = await queueWorktreeLifecycleTasks(tmpDir, cases, new Date('2026-05-10T00:00:00.000Z'), {
+      maxActiveTasks: 3,
+      maxQueuedPerSweep: 3,
+    });
+
+    expect(result.queued).toBe(3);
+    const tasks = queryMemoryIndexSync(tmpDir, { type: ['task'], status: ['pending'] });
+    expect(tasks).toHaveLength(3);
+    expect(new Set(tasks.map(task => task.summary?.slice(0, 11))).size).toBe(3);
   });
 
   it('is idempotent for known worktree cases and caps active lifecycle tasks', async () => {


### PR DESCRIPTION
## Summary
- give worktree lifecycle tasks a stable short id prefix so unrelated worktrees do not collide in the global similar-summary duplicate guard
- add a regression test with several same-bucket lifecycle tasks sharing similar summaries

## Verification
- pnpm typecheck
- pnpm exec vitest run tests/worktree-lifecycle-janitor.test.ts tests/memory-index-buckets.test.ts