### PR TITLE
fix(prompt-builder): filter PROTECTIVE_SUBTYPES from Recurring Errors hint

### DIFF
--- a/src/prompt-builder.ts
+++ b/src/prompt-builder.ts
@@ -19,7 +19,7 @@ import { buildLedgerSection } from './commitment-ledger.js';
 import { detectResearchLoop } from './cycle-state.js';
 import { isEnabled } from './features.js';
 import { getCurrentInstanceId, getInstanceDir } from './instance.js';
-import { readState } from './feedback-loops.js';
+import { readState, PROTECTIVE_SUBTYPES } from './feedback-loops.js';
 import { slog } from './utils.js';
 import { getActiveDelegationSummaries } from './delegation.js';
 import { buildAgentOwnedIdentityPrompt, buildAgentRelationshipPrompt } from './agent-owned-identity.js';
@@ -444,6 +444,11 @@ export function buildErrorPatternsHint(): string {
     const actionable = Object.entries(patterns)
       .map(([key, v]) => {
         if (v.count < 3 || v.resolved) return false;
+        // Issue #512: protective subtypes (sigterm_*, budget_exceeded, etc.) are guard
+        // mechanisms working as intended. They live in error-patterns.json for telemetry
+        // (see pulse.ts:732) but must not surface as actionable recurring bugs.
+        const subtype = key.split(":")[1] ?? "";
+        if (PROTECTIVE_SUBTYPES.has(subtype)) return false;
         const ts = Date.parse(v.lastSeen);
         if (!Number.isFinite(ts) || ts < cutoff) return false;
         if (!v.resolvedAt) return [key, v, false] as const;

--- a/tests/prompt-builder-error-patterns-hint.test.ts
+++ b/tests/prompt-builder-error-patterns-hint.test.ts
@@ -16,15 +16,19 @@ type Pattern = {
 
 const state: { patterns: Record<string, Pattern> } = { patterns: {} };
 
-vi.mock('../src/feedback-loops.js', () => ({
-  readState: <T>(filename: string, fallback: T): T => {
-    if (filename === 'error-patterns.json') {
-      return state.patterns as unknown as T;
-    }
-    return fallback;
-  },
-  writeState: () => {},
-}));
+vi.mock('../src/feedback-loops.js', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    readState: <T>(filename: string, fallback: T): T => {
+      if (filename === 'error-patterns.json') {
+        return state.patterns as unknown as T;
+      }
+      return fallback;
+    },
+    writeState: () => {},
+  };
+});
 
 vi.mock('../src/utils.js', async (importOriginal) => {
   const actual = (await importOriginal()) as Record<string, unknown>;
@@ -161,5 +165,44 @@ describe('buildErrorPatternsHint — issue #315 staleness filter', () => {
     expect(out).not.toContain('[REGRESSION]');
     // The pattern itself should not surface (mitigated recurrence after grace returns false)
     expect(out).toBe('');
+  });
+
+  it('omits PROTECTIVE_SUBTYPES even when fresh and high-count — issue #512', () => {
+    state.patterns = {
+      'TIMEOUT:sigterm_shutdown::callClaude': {
+        count: 9,
+        taskCreated: true,
+        lastSeen: isoDaysAgo(0),
+      },
+      'TIMEOUT:sigterm_hard::callClaude': {
+        count: 5,
+        taskCreated: true,
+        lastSeen: isoDaysAgo(1),
+      },
+      'TIMEOUT:budget_exceeded::callClaude': {
+        count: 4,
+        taskCreated: true,
+        lastSeen: isoDaysAgo(0),
+      },
+    };
+    expect(buildErrorPatternsHint()).toBe('');
+  });
+
+  it('keeps actionable bug subtypes alongside protective ones — issue #512', () => {
+    state.patterns = {
+      'TIMEOUT:sigterm_shutdown::callClaude': {
+        count: 9,
+        taskCreated: true,
+        lastSeen: isoDaysAgo(0),
+      },
+      'TIMEOUT:dns_lookup_failed::callClaude': {
+        count: 4,
+        taskCreated: true,
+        lastSeen: isoDaysAgo(1),
+      },
+    };
+    const out = buildErrorPatternsHint();
+    expect(out).toContain('dns_lookup_failed');
+    expect(out).not.toContain('sigterm_shutdown');
   });
 });


### PR DESCRIPTION
## Summary
Closes #512.

`buildErrorPatternsHint()` (prompt-builder.ts:430) was rendering protective subtypes (`sigterm_shutdown`, `sigterm_hard`, `budget_exceeded`, …) as actionable recurring bugs in the cycle prompt's `## Recurring Errors` section, contradicting `feedback-loops.ts:178-188`:

> Subtypes 代表「保護機制正常工作」而非 bug — 不該進入 recurring-error task 通道

Today's prompt rendered three protective subtypes which nudged Kuro to investigate non-bugs every cycle.

This patch mirrors the existing filter in `pulse.ts:732`: extract `key.split(':')[1]` and skip if `PROTECTIVE_SUBTYPES.has(subtype)`. Source of truth remains in `feedback-loops.ts`.

## Changes
- `src/prompt-builder.ts`: import `PROTECTIVE_SUBTYPES`, add filter in the `actionable` chain
- `tests/prompt-builder-error-patterns-hint.test.ts`: mock now uses `importOriginal` so the real Set drives the test; +2 cases (protective-only → empty; mixed → actionable kept, protective dropped)

## Test plan
- [x] `vitest run tests/prompt-builder-error-patterns-hint.test.ts` — 11/11 pass
- [ ] Next cycle's prompt no longer lists `sigterm_shutdown` / `sigterm_hard` / `budget_exceeded`

🤖 Filed by Kuro