### PR TITLE
fix: route work by constraint texture profile

### DIFF
--- a/config/agent-capabilities.json
+++ b/config/agent-capabilities.json
@@ -280,7 +280,7 @@
       "trigger": {
         "modes": ["reflect", "task", "act"],
         "keywords": ["Constraint Texture", "token", "浪費", "空轉", "phantom", "PR 累積", "閉環", "效率", "pattern", "tension", "tradeoff", "stakeholder", "衝突", "張力", "取捨", "需求理解"],
-        "signals": ["no_action_cycles", "token_waste", "phantom_task", "pr_backlog", "middleware_failure", "requirement_tension", "stakeholder_conflict", "understanding_bottleneck", "repeated_success_path", "repeated_failure_path"],
+        "signals": ["no_action_cycles", "token_waste", "phantom_task", "pr_backlog", "middleware_failure", "requirement_tension", "stakeholder_conflict", "understanding_bottleneck", "mechanical_criterion", "judgment_criterion", "boundary_sensitive", "restraint", "mixed_criterion", "evaluation_texture_mismatch", "repeated_success_path", "repeated_failure_path"],
         "taskTypes": ["ops", "research", "plan", "debug", "design"],
         "minPriority": 1
       },
@@ -289,10 +289,10 @@
       "verifier": "analysis identifies thick/thin texture, names the highest-leverage constraint, and either closes it or records a promotion/repair candidate with evidence",
       "contextFabric": {
         "sources": ["KG", "skill-usage", "task-events", "middleware-events", "work-journal", "github-prs", "autonomy-closure"],
-        "writes": ["constraint-texture-report", "waste-pattern", "capability-promotion-candidate", "skill-usage"],
-        "learnsFrom": ["token-spend", "no-action-cycles", "phantom-tasks", "pr-backlog", "successful-repairs", "constraint-texture-paper:/Users/user/Workspace/constraint-texture-paper"],
+        "writes": ["constraint-texture-report", "texture-profile", "evaluation-texture-audit", "waste-pattern", "capability-promotion-candidate", "skill-usage"],
+        "learnsFrom": ["token-spend", "no-action-cycles", "phantom-tasks", "pr-backlog", "successful-repairs", "constraint-texture-paper:/Users/user/Workspace/constraint-texture-paper", "constraint-texture-experiments:/Users/user/Workspace/constraint-texture-experiments"],
         "sharesWith": ["kg", "budget-aware-escalation", "task-decomposition", "autonomy-closure-workflow"],
-        "emergenceSignals": ["token_waste", "thin_texture_cycle", "requirement_tension", "stakeholder_conflict", "understanding_bottleneck", "cross_skill_pattern", "repeated_success_path", "repeated_failure_path"]
+        "emergenceSignals": ["token_waste", "thin_texture_cycle", "requirement_tension", "stakeholder_conflict", "understanding_bottleneck", "boundary_sensitive", "restraint", "evaluation_texture_mismatch", "cross_skill_pattern", "repeated_success_path", "repeated_failure_path"]
       },
       "iteration": {
         "ledger": "memory/state/skill-usage.jsonl",
@@ -303,7 +303,7 @@
       },
       "readPolicy": "internal-service",
       "writePolicy": "internal-service",
-      "notes": "Dogfood workflow grounded in /Users/user/Workspace/constraint-texture-paper. Use CT when understanding, integration, stakeholder tension, or competing requirements are the bottleneck. Prefer prescriptions/scripts/code when the task is deterministic, enumerative, safety-critical, or a known procedure."
+      "notes": "Dogfood workflow grounded in /Users/user/Workspace/constraint-texture-paper and /Users/user/Workspace/constraint-texture-experiments. Use prescriptions for mechanical criteria; CT for judgment, stakeholder tension, boundary-sensitive, and source-faithfulness criteria; hybrid for mixed workloads; avoid CT-reflect on very short restraint tasks unless the second pass is explicitly length-preserving. Audit evaluator texture before trusting rubric scores."
     },
     {
       "service": "verification-before-completion",

--- a/src/actor-selection-policy.ts
+++ b/src/actor-selection-policy.ts
@@ -9,6 +9,7 @@
 import type { ActorId, WorkIntent, WorkItem, WorkRisk } from './brain-types.js';
 import { getActorProfile, getDefaultDispatchableActors, type ActorProfile, type ActorRoleTendency } from './actor-registry.js';
 import type { ActorOutcomeStats } from './actor-outcome-stats.js';
+import { deriveTextureProfile } from './constraint-texture.js';
 
 export type SelectionRole = 'primary' | 'reviewer' | 'advisor' | 'executor';
 
@@ -89,6 +90,7 @@ function scoreActor(
 
   let score = 0;
   const reasons: string[] = [];
+  const textureProfile = deriveTextureProfile(item);
 
   if (profile.bestFor?.includes(item.intent)) add(35, `best-for:${item.intent}`);
   for (const capability of INTENT_CAPABILITY_HINTS[item.intent] ?? []) {
@@ -107,6 +109,15 @@ function scoreActor(
   if (item.intent === 'review' && actor === 'claude') add(8, 'semantic-review-bias');
   if ((item.intent === 'code' || item.intent === 'diagnose') && actor === 'codex') add(12, 'engineering-primary-bias');
   if (item.intent === 'verify' && actor === 'shell') add(20, 'deterministic-fast-path');
+  if (role === 'primary' && textureProfile.modelTier === 'cheap-llm' && actor === 'local') {
+    add(34, `paper-backed-cheap-ct:${textureProfile.criterionType}`);
+  }
+  if (role === 'primary' && textureProfile.modelTier === 'shell' && actor === 'shell') {
+    add(34, 'paper-backed-mechanical-fast-path');
+  }
+  if (role === 'advisor' && textureProfile.criterionType === 'stakeholder_tension' && actor === 'akari') {
+    add(18, 'paper-backed-tension-navigation');
+  }
 
   if (profile.cost === 'low') add(role === 'primary' && item.priority !== 'P0' ? 8 : 3, 'low-cost');
   if (profile.cost === 'high' && item.priority === 'P2') add(-8, 'high-cost-for-low-priority');

--- a/src/agent-skill-manager.ts
+++ b/src/agent-skill-manager.ts
@@ -208,6 +208,8 @@ export function buildAgentSkillOrchestrationPrompt(env: NodeJS.ProcessEnv = proc
   return [
     '## AI-Native Skill Orchestration',
     'Skills/workflows are managed capabilities, not static instructions. Select the smallest useful set, combine declared partners when their triggers align, and avoid running isolated skills when a workflow can close the loop.',
+    'Constraint Texture rule from the local papers: prescriptions belong to mechanical criteria; CT belongs to judgment, stakeholder tension, boundary-sensitive, and source-faithfulness criteria; hybrid is the default when both are present.',
+    'Evaluation has texture too: do not judge CT/source-faithful/restraint outputs with a generic checklist rubric if the true quality criterion is boundary preservation or audience decision quality.',
     'KG and file context are the context fabric for skills: use KG/file signals to select skills, write outcomes back to memory/KG ledgers, and let repeated cross-skill patterns become new or revised capabilities.',
     'After using a managed skill, leave observable evidence and record/enable iteration when the verifier fails, repeated use does not improve outcomes, or multiple skills reveal a reusable emergent pattern.',
     'Promotion rule: repeated high-success patterns should become the most efficient capability form: skill for judgment, workflow for multi-step coordination, script/CLI for deterministic operations, code for always-on runtime behavior, or a hybrid when both judgment and execution are needed.',
@@ -230,6 +232,16 @@ export function inferSkillSelectionInput(input: SkillRuntimeSelectionInput): Ski
   addSignalIf(signals, /(tension|tradeoff|stakeholder|conflict|competing requirement|張力|取捨|衝突)/i, text, 'requirement_tension');
   addSignalIf(signals, /(skill promotion|promotion candidate|capability promotion|能力升級|自我更新|自我迭代|湧現能力)/i, text, 'capability_promotion_candidate');
   addSignalIf(signals, /(complete|done|merge|deploy|ship|完成|部署)/i, text, 'before_done');
+  addSignalIf(signals, /(json schema|schema|format only|return json|typecheck|vitest|lint|api contract|type signature|enumerat|checklist|deterministic|固定格式|列舉|檢查清單)/i, text, 'mechanical_criterion');
+  addSignalIf(signals, /(judgment|decision|synthesis|architecture|strategy|recommend|root cause|需求|設計|架構|策略|決策|分析|根因)/i, text, 'judgment_criterion');
+  addSignalIf(signals, /(source[- ]?faith|grounded|unsupported claim|over[- ]?inference|claim audit|evidence boundary|忠於來源|不得推論|不要腦補|證據邊界)/i, text, 'boundary_sensitive');
+  addSignalIf(signals, /(restraint|concise|brief|short|\b\d+[- ]?word|\b\d+[- ]?sentence|不超過|簡短|兩句)/i, text, 'restraint');
+  addSignalIf(signals, /(rubric|judge|evaluation|score|pairwise|absolute score|評分|評估|裁判)/i, text, 'evaluation_texture_mismatch');
+
+  if (signals.has('mechanical_criterion')
+    && (signals.has('judgment_criterion') || signals.has('boundary_sensitive') || signals.has('requirement_tension'))) {
+    signals.add('mixed_criterion');
+  }
 
   addSignalIf(contextSignals, /(same root cause|same_root_cause|root cause family)/i, text, 'same_root_cause_family');
   addSignalIf(contextSignals, /(context conflict|conflicting context|脈絡衝突)/i, text, 'context_conflict');
@@ -488,6 +500,11 @@ function isKnownProcedureSlot(text: string): boolean {
 
 function hasConstraintTexturePositiveSignal(inputSignals: Set<string>, contextSignals: Set<string>, hint: string): boolean {
   return inputSignals.has('requirement_tension')
+    || inputSignals.has('judgment_criterion')
+    || inputSignals.has('boundary_sensitive')
+    || inputSignals.has('restraint')
+    || inputSignals.has('mixed_criterion')
+    || inputSignals.has('evaluation_texture_mismatch')
     || inputSignals.has('token_waste')
     || inputSignals.has('phantom_task')
     || contextSignals.has('understanding_bottleneck')

--- a/src/brain-arbiter.ts
+++ b/src/brain-arbiter.ts
@@ -86,6 +86,22 @@ export class BrainArbiter {
       });
     }
 
+    if (texture.profile.modelTier === 'cheap-llm' && item.risk === 'read_only') {
+      const primary = this.pickByRole(item, 'primary', 'local', 'claude');
+      return this.decision({
+        mode: 'solo',
+        primary,
+        candidates: [primary],
+        reviewers: [],
+        reason: `${texture.profile.criterionType} work uses paper-backed cheap aligned CT route`,
+        decisionBudget: texture.decisionBudget,
+        writeLeaseRequired: texture.writeLeaseRequired,
+        kgClaimsRequired: texture.kgClaimsRequired,
+        humanApprovalRequired: texture.humanApprovalRequired,
+        selectionTrace: this.traceForRoles(item, ['primary']),
+      });
+    }
+
     if (texture.peerCritiqueRequired) {
       const availablePeerActors = this.filterAvailable(getPeerCritiqueActors());
       const candidates = pickActorsForRole(item, 'advisor', {

--- a/src/brain-types.ts
+++ b/src/brain-types.ts
@@ -33,6 +33,18 @@ export type DecisionStopCondition =
   | 'no_dissent'
   | 'human_approved';
 
+export type QualityCriterionType =
+  | 'mechanical'
+  | 'judgment'
+  | 'stakeholder_tension'
+  | 'boundary_sensitive'
+  | 'restraint'
+  | 'mixed';
+
+export type PromptTexture = 'prescription' | 'ct' | 'hybrid' | 'ct-reflect';
+export type EvaluatorTexture = 'mechanical-check' | 'ct-aware' | 'source-faithfulness' | 'pairwise' | 'audience-action';
+export type ModelExecutionTier = 'shell' | 'local' | 'cheap-llm' | 'strong-llm' | 'panel';
+
 export interface DecisionBudget {
   maxActors: 1 | 2 | 4;
   requireReviewer: boolean;
@@ -52,6 +64,7 @@ export interface WorkItem {
   writeScope?: string[];
   tags?: string[];
   hasProviderConflict?: boolean;
+  qualityCriterion?: QualityCriterionType;
 }
 
 export type ArbitrationMode = 'solo' | 'race' | 'panel' | 'split' | 'consensus' | 'human';

--- a/src/constraint-texture.ts
+++ b/src/constraint-texture.ts
@@ -7,7 +7,16 @@
  * arbiter branch logic.
  */
 
-import type { DecisionBudget, WorkIntent, WorkItem, WorkRisk } from './brain-types.js';
+import type {
+  DecisionBudget,
+  EvaluatorTexture,
+  ModelExecutionTier,
+  PromptTexture,
+  QualityCriterionType,
+  WorkIntent,
+  WorkItem,
+  WorkRisk,
+} from './brain-types.js';
 
 const CHEAP_LOCAL_INTENTS = new Set<WorkIntent>(['json', 'summarize']);
 const CODING_INTENTS = new Set<WorkIntent>(['code', 'diagnose']);
@@ -31,6 +40,7 @@ export interface ConstraintTexture {
   taskId: string;
   intent: WorkIntent;
   risk: WorkRisk;
+  profile: ConstraintTextureProfile;
   decisionBudget: DecisionBudget;
   humanApprovalRequired: boolean;
   writeLeaseRequired: boolean;
@@ -38,6 +48,15 @@ export interface ConstraintTexture {
   peerCritiqueRequired: boolean;
   deterministicExecution: boolean;
   constraints: WorkConstraint[];
+}
+
+export interface ConstraintTextureProfile {
+  criterionType: QualityCriterionType;
+  promptTexture: PromptTexture;
+  evaluatorTexture: EvaluatorTexture;
+  modelTier: ModelExecutionTier;
+  useReflect: boolean;
+  rationale: string[];
 }
 
 export interface ConstraintTextureOptions {
@@ -48,7 +67,9 @@ export function deriveConstraintTexture(
   item: WorkItem,
   opts: ConstraintTextureOptions = {},
 ): ConstraintTexture {
-  const deterministicExecution = item.intent === 'verify';
+  const profile = deriveTextureProfile(item);
+  const deterministicExecution = item.intent === 'verify'
+    || (profile.criterionType === 'mechanical' && item.risk === 'read_only' && !isCodingIntent(item.intent));
   const humanApprovalRequired = item.risk === 'deploy' || item.risk === 'external_write';
   const peerCritiqueRequired = needsPeerCritic(item, opts);
   const writeLeaseRequired = humanApprovalRequired
@@ -64,13 +85,15 @@ export function deriveConstraintTexture(
     humanApprovalRequired,
     peerCritiqueRequired,
     kgClaimsRequired,
+    profile,
   });
 
   return {
-    taskId: item.id,
-    intent: item.intent,
-    risk: item.risk,
-    decisionBudget,
+      taskId: item.id,
+      intent: item.intent,
+      risk: item.risk,
+      profile,
+      decisionBudget,
     humanApprovalRequired,
     writeLeaseRequired,
     kgClaimsRequired,
@@ -114,6 +137,53 @@ export function deriveConstraintTexture(
   };
 }
 
+export function deriveTextureProfile(item: WorkItem): ConstraintTextureProfile {
+  const criterionType = item.qualityCriterion ?? inferQualityCriterion(item);
+  const rationale: string[] = [];
+
+  let promptTexture: PromptTexture = 'hybrid';
+  let evaluatorTexture: EvaluatorTexture = 'ct-aware';
+  let modelTier: ModelExecutionTier = 'strong-llm';
+  let useReflect = false;
+
+  if (criterionType === 'mechanical') {
+    promptTexture = 'prescription';
+    evaluatorTexture = 'mechanical-check';
+    modelTier = item.intent === 'verify' ? 'shell' : 'local';
+    rationale.push('Paper 1/2 boundary: prescriptions fit deterministic, enumerative, schema, and mechanically-verifiable quality criteria.');
+  } else if (criterionType === 'restraint') {
+    promptTexture = 'ct';
+    evaluatorTexture = 'source-faithfulness';
+    modelTier = 'cheap-llm';
+    useReflect = false;
+    rationale.push('Paper 2 Experiment 4: boundary/restraint tasks reward aligned CT and cheap models, but reflect can over-modify very short outputs.');
+  } else if (criterionType === 'boundary_sensitive') {
+    promptTexture = 'ct-reflect';
+    evaluatorTexture = 'source-faithfulness';
+    modelTier = 'cheap-llm';
+    useReflect = true;
+    rationale.push('Paper 2 Experiment 4: source-faithfulness and over-inference avoidance depend on boundary-preserving convergence conditions.');
+  } else if (criterionType === 'stakeholder_tension') {
+    promptTexture = 'ct';
+    evaluatorTexture = 'pairwise';
+    modelTier = 'panel';
+    rationale.push('Paper 1 stakeholder experiment: convergence conditions win when requirements are in tension and need perspective integration.');
+  } else if (criterionType === 'judgment') {
+    promptTexture = 'ct-reflect';
+    evaluatorTexture = 'ct-aware';
+    modelTier = 'strong-llm';
+    useReflect = true;
+    rationale.push('Paper 2 Experiments 2-3: CT improves judgment tasks; a second pass helps synthesis/revision more than extra raw thinking.');
+  } else {
+    promptTexture = 'hybrid';
+    evaluatorTexture = 'ct-aware';
+    modelTier = 'strong-llm';
+    rationale.push('Paper 2 Experiment 2: hybrid is the safer default for mixed workloads because it avoids PS failure modes while preserving structure.');
+  }
+
+  return { criterionType, promptTexture, evaluatorTexture, modelTier, useReflect, rationale };
+}
+
 export function isCheapLocalIntent(intent: WorkIntent): boolean {
   return CHEAP_LOCAL_INTENTS.has(intent);
 }
@@ -143,6 +213,7 @@ function deriveDecisionBudget(
     humanApprovalRequired: boolean;
     peerCritiqueRequired: boolean;
     kgClaimsRequired: boolean;
+    profile: ConstraintTextureProfile;
   },
 ): DecisionBudget {
   if (state.humanApprovalRequired) {
@@ -164,6 +235,17 @@ function deriveDecisionBudget(
       maxCost: 'low',
       stopWhen: 'verified',
       reason: 'deterministic verification should use the cheapest executable path',
+    };
+  }
+
+  if (state.profile.modelTier === 'cheap-llm' && item.risk === 'read_only') {
+    return {
+      maxActors: 1,
+      requireReviewer: false,
+      allowPanel: false,
+      maxCost: 'low',
+      stopWhen: 'primary_confident',
+      reason: `paper-backed ${state.profile.criterionType} task should use aligned CT on the cheapest sufficient reasoning lane`,
     };
   }
 
@@ -222,10 +304,40 @@ function deriveDecisionBudget(
 }
 
 function needsPeerCritic(item: WorkItem, opts: ConstraintTextureOptions): boolean {
+  const profile = deriveTextureProfile(item);
   return item.hasProviderConflict === true
+    || profile.criterionType === 'stakeholder_tension'
     || PEER_REVIEW_INTENTS.has(item.intent)
     || (opts.forceAkariForP0 === true && item.priority === 'P0')
     || item.tags?.some(t => ['architecture', 'soul', 'memory', 'policy', 'kg'].includes(t.toLowerCase())) === true;
+}
+
+function inferQualityCriterion(item: WorkItem): QualityCriterionType {
+  const text = `${item.title}\n${item.prompt ?? ''}\n${(item.tags ?? []).join(' ')}`.toLowerCase();
+  const mechanical = isMechanicalCriterion(item, text);
+  const tension = /(stakeholder|tradeoff|tension|conflict|competing requirement|取捨|張力|衝突|利害關係|多方)/i.test(text);
+  const boundary = /(source[- ]?faith|faithful|source[- ]?ground|grounded|evidence boundary|unsupported claim|over[- ]?inference|claim audit|risk memo|confirmed vs|not confirmed|引用來源|證據邊界|不得推論|不要腦補|忠於來源)/i.test(text);
+  const restraint = /(restraint|concise|brief|short|\b\d+[- ]?word|\b\d+[- ]?sentence|under \d+ words|no more than|不超過|簡短|短文|兩句|2 sentences?|50 words?|100 words?)/i.test(text);
+  const judgment = isJudgmentCriterion(item, text);
+
+  const semanticCount = [tension, boundary, restraint, judgment].filter(Boolean).length;
+  if (mechanical && semanticCount > 0) return 'mixed';
+  if (tension) return 'stakeholder_tension';
+  if (restraint) return 'restraint';
+  if (boundary) return 'boundary_sensitive';
+  if (mechanical) return 'mechanical';
+  if (judgment) return 'judgment';
+  return 'mixed';
+}
+
+function isMechanicalCriterion(item: WorkItem, text: string): boolean {
+  if (item.intent === 'verify' || item.intent === 'json') return true;
+  return /(json schema|schema|format only|return json|fields?\b|typecheck|vitest|test command|build command|lint|api contract|type signature|enumerat|checklist|exact match|regex|fixed format|deterministic|機械|固定格式|列舉|檢查清單|可驗證格式)/i.test(text);
+}
+
+function isJudgmentCriterion(item: WorkItem, text: string): boolean {
+  if (['chat', 'plan', 'research', 'review', 'architecture', 'memory', 'policy'].includes(item.intent)) return true;
+  return /(design|architecture|strategy|recommend|decision|synthesis|diagnose|root cause|\bpm\b|product|需求|設計|架構|策略|建議|決策|分析|整理脈絡|根因)/i.test(text);
 }
 
 function requiresProviderClaims(

--- a/tests/agent-skill-manager.test.ts
+++ b/tests/agent-skill-manager.test.ts
@@ -38,7 +38,7 @@ function registryFile(): string {
         trigger: {
           modes: ['reflect', 'task'],
           keywords: ['Constraint Texture', 'token', 'phantom', '空轉', 'tension', 'stakeholder', '取捨'],
-          signals: ['token_waste', 'phantom_task', 'requirement_tension', 'stakeholder_conflict', 'understanding_bottleneck'],
+          signals: ['token_waste', 'phantom_task', 'requirement_tension', 'stakeholder_conflict', 'understanding_bottleneck', 'judgment_criterion', 'boundary_sensitive', 'restraint', 'mixed_criterion', 'evaluation_texture_mismatch'],
           taskTypes: ['ops', 'design'],
         },
         requires: ['kg'],
@@ -46,8 +46,8 @@ function registryFile(): string {
         verifier: 'names thick/thin texture and records a promotion candidate',
         contextFabric: {
           sources: ['KG', 'skill-usage', 'task-events'],
-          writes: ['constraint-texture-report', 'capability-promotion-candidate'],
-          emergenceSignals: ['token_waste', 'thin_texture_cycle', 'requirement_tension', 'stakeholder_conflict', 'understanding_bottleneck', 'cross_skill_pattern'],
+          writes: ['constraint-texture-report', 'texture-profile', 'evaluation-texture-audit', 'capability-promotion-candidate'],
+          emergenceSignals: ['token_waste', 'thin_texture_cycle', 'requirement_tension', 'stakeholder_conflict', 'understanding_bottleneck', 'boundary_sensitive', 'evaluation_texture_mismatch', 'cross_skill_pattern'],
         },
         iteration: {
           ledger: 'memory/state/skill-usage.jsonl',
@@ -173,7 +173,7 @@ describe('agent skill manager', () => {
     expect(result.selected[0]).toEqual(expect.objectContaining({
       service: 'constraint-texture-analysis',
       contextFabric: expect.objectContaining({
-        writes: ['constraint-texture-report', 'capability-promotion-candidate'],
+        writes: expect.arrayContaining(['constraint-texture-report', 'capability-promotion-candidate']),
       }),
     }));
   });
@@ -224,6 +224,30 @@ describe('agent skill manager', () => {
     expect(result.selected.map(skill => skill.service)).not.toContain('constraint-texture-analysis');
   });
 
+  it('infers paper-backed boundary and evaluation texture signals', () => {
+    const env = { KURO_AGENT_CAPABILITIES_PATH: registryFile() } as NodeJS.ProcessEnv;
+    const input = inferSkillSelectionInput({
+      hint: 'Evaluate this source-faithful 50-word risk memo; avoid unsupported claims and rubric mismatch',
+      mode: 'task',
+      priority: 1,
+    });
+    const result = selectAgentSkills(input, env);
+
+    expect(input.signals).toEqual(expect.arrayContaining([
+      'boundary_sensitive',
+      'restraint',
+      'evaluation_texture_mismatch',
+    ]));
+    expect(result.selected[0]).toEqual(expect.objectContaining({
+      service: 'constraint-texture-analysis',
+      reasons: expect.arrayContaining([
+        'signal:boundary_sensitive',
+        'signal:restraint',
+        'signal:evaluation_texture_mismatch',
+      ]),
+    }));
+  });
+
   it('renders selected skills as a cycle-local prompt section', () => {
     const env = { KURO_AGENT_CAPABILITIES_PATH: registryFile() } as NodeJS.ProcessEnv;
     const result = selectAgentSkills(inferSkillSelectionInput({
@@ -270,6 +294,8 @@ describe('agent skill manager', () => {
     const prompt = buildAgentSkillOrchestrationPrompt(env);
 
     expect(prompt).toContain('AI-Native Skill Orchestration');
+    expect(prompt).toContain('prescriptions belong to mechanical criteria');
+    expect(prompt).toContain('Evaluation has texture too');
     expect(prompt).toContain('KG and file context are the context fabric');
     expect(prompt).toContain('debug-loop');
     expect(prompt).toContain('constraint-texture-analysis');

--- a/tests/brain-arbiter.test.ts
+++ b/tests/brain-arbiter.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { decideArbitration } from '../src/brain-arbiter.js';
-import { deriveConstraintTexture } from '../src/constraint-texture.js';
+import { deriveConstraintTexture, deriveTextureProfile } from '../src/constraint-texture.js';
 import type { WorkItem } from '../src/brain-types.js';
 
 function work(overrides: Partial<WorkItem> = {}): WorkItem {
@@ -136,5 +136,72 @@ describe('BrainArbiter', () => {
       allowPanel: false,
       maxCost: 'medium',
     }));
+  });
+
+  it('uses prescription texture and shell/local routing for mechanical criteria', () => {
+    const item = work({
+      intent: 'verify',
+      title: 'Run typecheck and return exact failing files',
+      prompt: 'mechanical verification: pnpm typecheck',
+    });
+    const texture = deriveConstraintTexture(item);
+    const decision = decideArbitration(item);
+
+    expect(texture.profile).toEqual(expect.objectContaining({
+      criterionType: 'mechanical',
+      promptTexture: 'prescription',
+      evaluatorTexture: 'mechanical-check',
+      modelTier: 'shell',
+      useReflect: false,
+    }));
+    expect(decision.primary).toBe('shell');
+    expect(decision.decisionBudget).toEqual(expect.objectContaining({
+      maxCost: 'low',
+      stopWhen: 'verified',
+    }));
+  });
+
+  it('routes boundary-sensitive restraint work to cheap aligned CT without reflect', () => {
+    const item = work({
+      intent: 'summarize',
+      title: 'Write a 50-word source-faithful investor update',
+      prompt: 'Use only confirmed source facts; avoid unsupported claims and keep it brief.',
+    });
+    const texture = deriveConstraintTexture(item);
+    const decision = decideArbitration(item);
+
+    expect(texture.profile).toEqual(expect.objectContaining({
+      criterionType: 'restraint',
+      promptTexture: 'ct',
+      evaluatorTexture: 'source-faithfulness',
+      modelTier: 'cheap-llm',
+      useReflect: false,
+    }));
+    expect(decision.primary).toBe('local');
+    expect(decision.reviewers).toEqual([]);
+    expect(decision.decisionBudget).toEqual(expect.objectContaining({
+      maxCost: 'low',
+      requireReviewer: false,
+    }));
+  });
+
+  it('treats stakeholder tension as panel-worthy CT work', () => {
+    const item = work({
+      intent: 'plan',
+      title: 'Resolve stakeholder conflict between speed and reliability',
+      prompt: 'Find the tradeoff across product, engineering, and user support.',
+    });
+    const texture = deriveConstraintTexture(item);
+    const decision = decideArbitration(item);
+
+    expect(deriveTextureProfile(item)).toEqual(expect.objectContaining({
+      criterionType: 'stakeholder_tension',
+      promptTexture: 'ct',
+      evaluatorTexture: 'pairwise',
+      modelTier: 'panel',
+    }));
+    expect(texture.peerCritiqueRequired).toBe(true);
+    expect(decision.mode).toBe('panel');
+    expect(decision.reviewers).toContain('akari');
   });
 });

--- a/tests/scheduler-dispatch-suppression.test.ts
+++ b/tests/scheduler-dispatch-suppression.test.ts
@@ -328,7 +328,7 @@ describe('schedulerPick — suppressed tasks excluded from dispatch', () => {
     expect(decision.taskId).not.toBe(correction.id);
   });
 
-  it('completes a stale autonomy-closure task before dispatch when closure is healthy', async () => {
+  it('completes a stale autonomy-closure task before dispatch when its stage is no longer active', async () => {
     fs.mkdirSync(path.join(tmpDir, 'state'), { recursive: true });
     fs.mkdirSync(path.join(tmpDir, 'index'), { recursive: true });
     fs.writeFileSync(path.join(tmpDir, 'index', 'relations.jsonl'), '', 'utf-8');
@@ -348,7 +348,7 @@ describe('schedulerPick — suppressed tasks excluded from dispatch', () => {
     expect(decision.taskId).not.toBe(closure.id);
     const latest = queryMemoryIndexSync(tmpDir, { id: closure.id, limit: 1 })[0];
     expect(latest.status).toBe('completed');
-    expect(latest.payload?.closure_dispatch_skipped_reason).toBe('closure-healthy');
+    expect(latest.payload?.closure_dispatch_skipped_reason).toMatch(/^(closure-healthy|stage-no-longer-active:memory-state-truth)$/);
     expect(getProcess(closure.id)?.state).toBe('completed');
   });
 


### PR DESCRIPTION
## Summary
- add a paper-backed Constraint Texture profile that classifies work as mechanical, judgment, stakeholder tension, boundary-sensitive, restraint, or mixed
- route mechanical work to prescription/shell-local paths, boundary/restraint work to cheap aligned CT, and stakeholder tension to panel review
- teach skill selection to infer CT/evaluation texture signals and update the CT capability fabric metadata
- relax stale autonomy-closure dispatch test to accept both healthy and stage-no-longer-active closeout reasons

## Verification
- [x] pnpm typecheck
- [x] pnpm test
