### PR TITLE
fix(worktree-lifecycle): auto-resolve tasks when case no longer present

### DIFF
--- a/src/worktree-lifecycle-janitor.ts
+++ b/src/worktree-lifecycle-janitor.ts
@@ -142,6 +142,29 @@ export async function queueWorktreeLifecycleTasks(
     held: 0,
   };
 
+  // Phantom-prune (issue: P0 banner restalance): when a previously-queued lifecycle task no
+  // longer matches an actionable case (worktree pruned, branch deleted, PR opened), auto-
+  // resolve it so the P0 banner stops re-surfacing the ghost. Without this, deleted worktrees
+  // leak phantoms — see memory/topics/p0-circuit-breaker-phantom-2026-05-10.md.
+  {
+    const caseIds = new Set(cases.map(c => c.id));
+    let autoResolved = 0;
+    for (const entry of getLifecycleTasks(memoryDir, ["pending", "in_progress", "hold"])) {
+      const caseId = (entry.payload ?? {}).worktree_case_id as string | undefined;
+      if (!caseId || caseIds.has(caseId)) continue;
+      await updateMemoryIndexEntry(memoryDir, entry.id, {
+        status: "resolved",
+        payload: {
+          ...(entry.payload ?? {}),
+          resolved_at: now.toISOString(),
+          resolved_reason: "worktree case no longer present (worktree pruned, branch deleted, or PR opened)",
+        },
+      });
+      autoResolved++;
+    }
+    if (autoResolved > 0) slog("WORKTREE-LIFECYCLE", `auto-resolved ${autoResolved} stale lifecycle task(s) — case no longer present`);
+  }
+
   const maxActive = options.maxActiveTasks ?? DEFAULT_MAX_ACTIVE_TASKS;
   result.held += await rebalanceActiveTasks(memoryDir, maxActive);
   const activeBudget = Math.max(0, maxActive - countActiveTasks(memoryDir));


### PR DESCRIPTION
## Why
Today's heartbeat re-fired a P0 banner item:

> P0: Worktree lifecycle: clean-unmerged feat/middleware-circuit-breaker

The branch does not exist anywhere — local, remote, or in mini-agent — and never had a worktree. This is the **3rd phantom of this exact shape today** (after `pr-review-consensus` and `memory-state-truth`).

Root cause: `queueWorktreeLifecycleTasks` only **adds** tasks. When a worktree is later pruned, branch deleted, or a PR opens for the tracked branch, the lifecycle task created from that case stays `pending` forever. The P0 banner picks it up every cycle.

The existing P0-banner reverify gate (`loop.ts` Layer 1.7) only handles `correction gate: resolve <predicate>` strings — `Worktree lifecycle:` items have no live re-check.

## What
At the start of `queueWorktreeLifecycleTasks`, compare the active `caseIds` against pending/in-progress/hold lifecycle tasks. Tasks whose `worktree_case_id` no longer appears in current cases are auto-resolved with reason `worktree case no longer present`.

Cost is one extra `getLifecycleTasks` query per sweep (housekeeping already runs the sweep, so no new schedule).

## Evidence trail
- `memory/topics/p0-circuit-breaker-phantom-2026-05-10.md`
- `memory/topics/phantom-task-feat-middleware-circuit-b-2026-05-10.md`
- `memory/state/scheduler-phantom-pattern.jsonl` (4th-phantom note for `fix/issue-306-predicate-freshnes`)

## Verification
- [x] `tsc --noEmit` clean
- [ ] Unit test for the new auto-resolve branch (TODO — happy to add a follow-up; current PR is the structural fix)
- [ ] Watch P0 banner: `feat/middleware-circuit-breaker` line should disappear after first post-merge sweep cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)