### PR TITLE
fix(scheduler): preserve task-id tokens in delegate summary render

### DIFF
--- a/src/loop.ts
+++ b/src/loop.ts
@@ -207,6 +207,25 @@ interface ForegroundDelegationRecord {
   delegatedAt: string;
 }
 
+/**
+ * Truncate `text` to at most `max` chars without splitting an embedded
+ * task-id-like token (`task-`, `idx-`, `del-`, `cmt-`, etc).
+ * If the cut would land inside a word/identifier, back up to the last
+ * whitespace boundary that kept > max/2 of the prefix. See
+ * memory/notes/2026-05-15-scheduler-id-clobber.md for the rendering bug
+ * this protects against.
+ */
+export function truncatePreservingTaskId(text: string, max: number): string {
+  if (typeof text !== 'string' || text.length <= max) return text;
+  const nextChar = text[max];
+  if (nextChar && /[\w-]/.test(nextChar)) {
+    const cut = text.slice(0, max);
+    const lastSpace = cut.lastIndexOf(' ');
+    if (lastSpace > Math.floor(max / 2)) return cut.slice(0, lastSpace);
+  }
+  return text.slice(0, max);
+}
+
 function getForegroundDelegationsPath(): string {
   return path.join(getInstanceDir(getCurrentInstanceId()), 'foreground-delegations.json');
 }
@@ -3406,9 +3425,9 @@ export class AgentLoop {
             type: 'task',
             status: 'in_progress',
             source: 'ooda-delegate',
-            summary: `[delegate:${taskType}] ${del.prompt.slice(0, 80)}`,
+            summary: `[delegate:${taskType}] ${truncatePreservingTaskId(del.prompt, 80)}`,
           });
-          registerProcess({ id: taskId, summary: `[delegate:${taskType}] ${del.prompt.slice(0, 60)}`, priority: 2, source: 'kuro' as const, status: 'in_progress', createdAt: new Date().toISOString(), ticksSpent: 0, deadline: null, dependsOn: [] });
+          registerProcess({ id: taskId, summary: `[delegate:${taskType}] ${truncatePreservingTaskId(del.prompt, 60)}`, priority: 2, source: 'kuro' as const, status: 'in_progress', createdAt: new Date().toISOString(), ticksSpent: 0, deadline: null, dependsOn: [] });
         } catch { /* fire-and-forget */ }
       }
 

--- a/tests/truncate-preserving-task-id.test.ts
+++ b/tests/truncate-preserving-task-id.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { truncatePreservingTaskId } from '../src/loop.js';
+
+describe('truncatePreservingTaskId', () => {
+  it('returns input unchanged when shorter than max', () => {
+    expect(truncatePreservingTaskId('short', 80)).toBe('short');
+  });
+
+  it('hard-slices at word boundary when next char is whitespace', () => {
+    const text = 'a'.repeat(80) + ' suffix';
+    expect(truncatePreservingTaskId(text, 80)).toBe('a'.repeat(80));
+  });
+
+  it('backs up to last space when cut would split a task id token', () => {
+    // Reproduces the scheduler ID-clobber: a description that pushes
+    // the task id across the 80-char boundary used to drop the `-l` suffix.
+    const prompt = 'context up to here padded ' + 'x'.repeat(40) + ' task-1778459005838-l next';
+    const out = truncatePreservingTaskId(prompt, 80);
+    // Either we keep the full token or we stop before it — never split it
+    expect(out.includes('task-1778459005838-l') || !out.includes('task-1778459005838')).toBe(true);
+    expect(out.length).toBeLessThanOrEqual(80);
+  });
+
+  it('hard-slices when no whitespace is recoverable', () => {
+    const text = 'task-1778459005838-suffix-that-is-very-very-long-and-cannot-be-recovered-easily';
+    const out = truncatePreservingTaskId(text, 40);
+    expect(out.length).toBeLessThanOrEqual(40);
+  });
+
+  it('handles non-string input gracefully', () => {
+    expect(truncatePreservingTaskId(null as unknown as string, 80)).toBe(null);
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes Bug 1 from `memory/state/scheduler-id-clobber-repair.md` — `loop.ts` `slice(0, 80)` / `slice(0, 60)` was cutting mid-token on task-id-like patterns (`task-XXX-l`, `idx-XXX`, `del-XXX`), dropping trailing suffixes (e.g. `-l`) and breaking grep-based falsifier resolution.
- Result: phantom P0 tasks that never resolve (observed: `task-1778459005838-l` stuck 6+ cycles).
- Adds `truncatePreservingTaskId(text, max)` helper used by both delegate-summary write sites; backs up to last whitespace boundary when cut would split a hyphenated token.

## Scope
- `src/loop.ts`: +23/-2 lines (helper + 2 call sites)
- `tests/truncate-preserving-task-id.test.ts`: +33 lines (5 regression tests)
- Does NOT include Bug 2 (rate-limit auto-retry) — separate PR.

## Test plan
- [x] `npx vitest run tests/truncate-preserving-task-id.test.ts` → 5/5 pass
- [ ] Post-merge: confirm next phantom P0 task carries full `-X` suffix in stack-rank renderer output
- [ ] Post-merge: ledger resolution grep matches event row for next delegated task-id

🤖 Generated with [Claude Code](https://claude.com/claude-code)