### PR TITLE
fix(build): keep dist/cli.js executable after tsc

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "mini-agent": "dist/cli.js"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && chmod +x dist/cli.js",
     "start": "node dist/cli.js",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",


### PR DESCRIPTION
## Summary

`mini-agent` is a global npm-link whose bin symlink points straight at the workspace `dist/cli.js`. `tsc` regenerates that file as `0644` whenever `cli.ts` changes, stripping the execute bit — the next deploy then breaks the `mini-agent` CLI with `zsh: permission denied`.

This surfaced right after the cron→recurrence refactor (#528), which modified `cli.ts`.

## Fix

Append `chmod +x dist/cli.js` to the `build` script so every build path (deploy, post-commit rebuild) keeps the entry point executable.

## Test plan

- [x] `rm dist/cli.js && pnpm build` → `dist/cli.js` is `-rwxr-xr-x`

🤖 Generated with [Claude Code](https://claude.com/claude-code)