### PR TITLE
fix(scheduler): durable suppression + phantom-P0 fix + token ledger

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -1090,6 +1090,7 @@ export function createApi(port = 3001): express.Express {
       },
       loop: loopRef ? { enabled: true, ...loopRef.getStatus() } : { enabled: false },
       cron: { active: getRecurringTaskCount(getMemoryRootDir()), queued: 0 },
+      tokens: getLogger().getTokenUsageSummary(),
       telegram: {
         connected: !!getTelegramPoller(),
         notifications: getNotificationStats(),

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -24,7 +24,7 @@ import { getInstanceDir, getCurrentInstanceId } from './instance.js';
 /**
  * 日誌類型
  */
-export type LogType = 'claude-call' | 'api-request' | 'cron' | 'error' | 'diag' | 'behavior';
+export type LogType = 'claude-call' | 'api-request' | 'cron' | 'error' | 'diag' | 'behavior' | 'tokens';
 
 /**
  * Claude 輸入
@@ -71,6 +71,32 @@ export interface LogMetadata {
   success: boolean;
   error?: string;
   mode?: string;  // 'task' | 'autonomous' | 'heartbeat'
+}
+
+/**
+ * Per-call token usage — one Claude call's actual token spend.
+ */
+export interface TokenUsage {
+  source: string;       // loop / cron / foreground / delegate ...
+  model?: string;
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheCreation: number;
+  durationMs?: number;
+}
+
+/**
+ * Aggregated daily token ledger.
+ */
+export interface TokenUsageSummary {
+  date: string;
+  calls: number;
+  totalInput: number;
+  totalOutput: number;
+  totalCacheRead: number;
+  totalCacheCreation: number;
+  bySource: Record<string, { calls: number; input: number; output: number }>;
 }
 
 /**
@@ -187,7 +213,7 @@ export class Logger {
    * 確保日誌目錄存在
    */
   private ensureLogDirs(): void {
-    const dirs = ['claude', 'api', 'cron', 'error', 'diag', 'behavior'];
+    const dirs = ['claude', 'api', 'cron', 'error', 'diag', 'behavior', 'tokens'];
     for (const dir of dirs) {
       const dirPath = path.join(this.logsDir, dir);
       if (!existsSync(dirPath)) {
@@ -207,6 +233,7 @@ export class Logger {
       'error': 'error',
       'diag': 'diag',
       'behavior': 'behavior',
+      'tokens': 'tokens',
     };
     return mapping[type];
   }
@@ -283,6 +310,66 @@ export class Logger {
     };
     this.writeLog(entry);
     return id;
+  }
+
+  /**
+   * 記錄一次 Claude call 的實際 token 用量 — 寫入每日 token 帳本。
+   */
+  logTokenUsage(usage: TokenUsage): string {
+    const id = this.generateRequestId();
+    const entry: LogEntry = {
+      timestamp: new Date().toISOString(),
+      type: 'tokens',
+      instanceId: this.instanceId,
+      requestId: id,
+      data: {
+        source: usage.source,
+        model: usage.model ?? null,
+        input: usage.input,
+        output: usage.output,
+        cacheRead: usage.cacheRead,
+        cacheCreation: usage.cacheCreation,
+      },
+      metadata: { success: true, duration: usage.durationMs },
+    };
+    this.writeLog(entry);
+    return id;
+  }
+
+  /**
+   * 聚合當日 token 帳本 — 總花費 + 依 source 分組。
+   */
+  getTokenUsageSummary(date?: string): TokenUsageSummary {
+    const dateStr = date ?? this.getToday();
+    const summary: TokenUsageSummary = {
+      date: dateStr,
+      calls: 0,
+      totalInput: 0,
+      totalOutput: 0,
+      totalCacheRead: 0,
+      totalCacheCreation: 0,
+      bySource: {},
+    };
+    for (const e of this.readLogFile('tokens', dateStr)) {
+      const d = e.data as {
+        source?: string; input?: number; output?: number;
+        cacheRead?: number; cacheCreation?: number;
+      };
+      const input = d.input ?? 0;
+      const output = d.output ?? 0;
+      summary.calls++;
+      summary.totalInput += input;
+      summary.totalOutput += output;
+      summary.totalCacheRead += d.cacheRead ?? 0;
+      summary.totalCacheCreation += d.cacheCreation ?? 0;
+      const src = d.source ?? 'unknown';
+      const bucket = summary.bySource[src] ?? { calls: 0, input: 0, output: 0 };
+      bucket.calls++;
+      bucket.input += input;
+      bucket.output += output;
+      summary.bySource[src] = bucket;
+    }
+    return summary;
   }
 
   /**

--- a/src/memory-index.ts
+++ b/src/memory-index.ts
@@ -1063,6 +1063,27 @@ export async function dequeueNextGoal(memoryDir: string): Promise<string | null>
 const STALENESS_THRESHOLD = 3;
 
 /**
+ * True when a task is marked resolved in task-events.jsonl (by id, exact
+ * summary, or a length>=24 substring variant). Mirrors the resolved cross-check
+ * in getP0TaskPreviews so staleness and P0-preview agree on what is resolved.
+ */
+function taskMatchesResolvedKeys(
+  task: { id: string; summary?: string },
+  resolved: { ids: Set<string>; summaries: Set<string> },
+): boolean {
+  if (resolved.ids.has(task.id)) return true;
+  const summary = (task.summary ?? '').trim();
+  if (summary && resolved.summaries.has(summary)) return true;
+  if (summary.length >= 24) {
+    for (const resolvedSummary of resolved.summaries) {
+      if (resolvedSummary.length < 24) continue;
+      if (summary.includes(resolvedSummary) || resolvedSummary.includes(summary)) return true;
+    }
+  }
+  return false;
+}
+
+/**
  * Increment ticksSinceLastProgress for all pending/in_progress tasks.
  * Called at the end of each OODA cycle (fire-and-forget).
  * Returns tasks that exceed the staleness threshold for surfacing.
@@ -1086,6 +1107,12 @@ export async function incrementTaskStaleness(
   const taskEventsBucket = getCachedBucket(memoryDir, 'task-events');
   const taskEventIds = new Set(taskEventsBucket.keys());
 
+  // Issue #525: a task already marked resolved in task-events.jsonl can linger
+  // as `pending` in the index snapshot (event/index desync). Without this guard
+  // it would be ticked and re-escalated to P0 every cycle — the phantom-P0
+  // recurrence loop. Complete such tasks instead of escalating them.
+  const resolvedKeys = loadResolvedTaskKeysFromEvents(memoryDir);
+
   const stale: Array<{ id: string; summary: string; ticks: number; firstEscalation: boolean }> = [];
 
   for (const task of tasks) {
@@ -1093,6 +1120,19 @@ export async function incrementTaskStaleness(
     // Goals live in relations.jsonl and are exempt from this check.
     if (task.type === 'task' && !taskEventIds.has(task.id)) {
       slog('SCHED', `[scheduler] phantom-id-skipped ${task.id} summary="${(task.summary ?? '').slice(0, 60)}" — absent from task-events.jsonl`);
+      continue;
+    }
+
+    // Issue #525: resolved-but-still-pending → complete, never re-escalate.
+    if (taskMatchesResolvedKeys(task, resolvedKeys)) {
+      slog('SCHED', `[scheduler] staleness-resolved-skip ${task.id} — resolved per task-events; completing instead of escalating`);
+      await updateMemoryIndexEntry(memoryDir, task.id, {
+        status: 'completed',
+        payload: {
+          ...((task.payload as Record<string, unknown> | undefined) ?? {}),
+          terminal_resolution: 'resolved per task-events; completed by staleness sweep',
+        },
+      });
       continue;
     }
 

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -489,7 +489,7 @@ export function schedulerPick(
   });
   const entriesById = new Map(entries.map(entry => [entry.id, entry]));
 
-  resetSuppressionsForExternalEvents(events);
+  persistSuppressedTasksToHold(memoryDir, entriesById);
 
   const phantomTitles = loadPhantomTaskTitles(memoryDir);
   const phantomClosureKeys = loadPhantomClosureKeys(memoryDir);
@@ -862,15 +862,47 @@ export function resetAllSuppressions(): void {
   }
 }
 
-function resetSuppressionsForExternalEvents(events: IncomingEvent[]): void {
-  if (suppressedTaskIds.size === 0 && terminalSignalCount.size === 0) return;
-  const hasHumanDirectedEvent = events.some(event =>
-    event.isAlexDirectMessage
-    || event.priority === 0
-    || ['telegram', 'telegram-user', 'room', 'chat'].includes(event.source),
-  );
-  if (!hasHumanDirectedEvent) return;
-  resetAllSuppressions();
+/**
+ * Cooldown a suppressed task is held for before it is re-evaluated.
+ * After this window checkHoldTasks unblocks it; if it is still non-converging
+ * it gets re-suppressed and re-held, capping wasted cycles to the threshold
+ * (3) per cooldown window instead of an unbounded re-spin loop.
+ */
+const SUPPRESSION_HOLD_COOLDOWN_MS = 6 * 60 * 60 * 1000;
+
+/**
+ * Persist dispatch suppression durably. A task suppressed in-memory (3+ terminal
+ * signals) is downgraded to a held memory-index task with a date-after cooldown,
+ * so it leaves the pending/in_progress dispatch pool, survives process restart,
+ * and is no longer re-picked every cycle. This is the CT downgrade: non-converging
+ * work loses its "active judgment" texture instead of being re-spun at full cost.
+ *
+ * Replaces the former resetSuppressionsForExternalEvents, which globally cleared
+ * all suppression on any room/telegram message — defeating suppression entirely.
+ */
+function persistSuppressedTasksToHold(
+  memoryDir: string,
+  entriesById: Map<string, MemoryIndexEntry>,
+): void {
+  if (suppressedTaskIds.size === 0) return;
+  const until = new Date(Date.now() + SUPPRESSION_HOLD_COOLDOWN_MS).toISOString();
+  for (const taskId of [...suppressedTaskIds]) {
+    const entry = entriesById.get(taskId);
+    if (!entry) continue; // not in the dispatch pool — already held or resolved
+    const payload = { ...((entry.payload as Record<string, unknown> | undefined) ?? {}) };
+    payload.holdCondition = { type: 'date-after', value: until };
+    payload.suppressionHold = true;
+    void updateMemoryIndexEntry(memoryDir, taskId, { status: 'hold', payload })
+      .then(() => {
+        // The durable hold now owns the suppression; clear the in-memory bridge
+        // so the task gets one fair re-evaluation when the cooldown expires.
+        suppressedTaskIds.delete(taskId);
+        terminalSignalCount.delete(taskId);
+      })
+      .catch(err =>
+        slog('SCHED', `suppression-hold failed task=${taskId.slice(0, 12)}: ${err instanceof Error ? err.message : String(err)}`),
+      );
+  }
 }
 
 export function isTaskSuppressed(taskId: string): boolean {

--- a/src/sdk-client.ts
+++ b/src/sdk-client.ts
@@ -24,6 +24,7 @@ import { performance } from 'node:perf_hooks';
 import path from 'node:path';
 import type { ExecOptions } from './agent.js';
 import { slog } from './utils.js';
+import { getLogger } from './logging.js';
 import { buildForensicEntryShell, writeForensicEntry, type ToolCallRecord } from './forensic-log.js';
 
 /** Tools the subprocess MUST be able to call in order for edits to land. */
@@ -279,6 +280,19 @@ export async function execClaudeViaSdk(
               `tok={in:${inputTok},out:${outputTok},cacheR:${cacheRead},cacheW:${cacheCreate}} ` +
               `duration=${durationMs}ms`,
           );
+          // Persist actual token usage to the daily ledger — previously this
+          // usage was only slog'd and discarded (no token accounting existed).
+          try {
+            getLogger().logTokenUsage({
+              source,
+              model: model ?? undefined,
+              input: inputTok,
+              output: outputTok,
+              cacheRead,
+              cacheCreation: cacheCreate,
+              durationMs,
+            });
+          } catch { /* never break the SDK path on a logging failure */ }
           slog(
             'PROFILE',
             `sdk-child handler: count=${msgHandlerCount + 1} totalMs=${Math.round(msgHandlerTotalMs)} onPartialOutput maxMs=${Math.round(partialOutputMaxMs)}`,

--- a/tests/scheduler-dispatch-suppression.test.ts
+++ b/tests/scheduler-dispatch-suppression.test.ts
@@ -438,11 +438,14 @@ describe('schedulerPick — suppressed tasks excluded from dispatch', () => {
     expect(completed.payload?.terminal_resolution).toBe('middleware triage follow-up exceeded 100 stale ticks without progress');
   });
 
-  it('resets suppression on a human-directed scheduler event', async () => {
+  it('keeps suppression even after a human-directed scheduler event', async () => {
+    // A room/Alex message about anything must NOT un-suppress an unrelated
+    // non-converging task. Reviving a specific task is an explicit action
+    // (resetTaskSuppression), not an implicit side effect of any message.
     const task = await appendMemoryIndexEntry(tmpDir, {
       type: 'task',
       status: 'pending',
-      summary: 'P0 task revived by Alex message',
+      summary: 'P0 task that keeps signalling terminal',
       payload: { priority: 0 },
     });
     invalidateIndexCache();
@@ -454,8 +457,36 @@ describe('schedulerPick — suppressed tasks excluded from dispatch', () => {
 
     const decision = schedulerPick(tmpDir, [{ source: 'room', priority: 0, isAlexDirectMessage: true }]);
 
-    expect(isTaskSuppressed(task.id)).toBe(false);
-    expect(getTerminalSignalCount(task.id)).toBe(0);
-    expect(decision.taskId).toBe(task.id);
+    expect(isTaskSuppressed(task.id)).toBe(true);
+    expect(decision.taskId).not.toBe(task.id);
+  });
+
+  it('downgrades a suppressed task to a held task with a future cooldown', async () => {
+    // CT: a task terminal-signalled past the threshold has its texture
+    // downgraded — persisted as a held task so it leaves the dispatch pool
+    // and survives restart, instead of being re-spun every cycle.
+    const task = await appendMemoryIndexEntry(tmpDir, {
+      type: 'task',
+      status: 'pending',
+      summary: 'P0 phantom task that never converges',
+      payload: { priority: 0 },
+    });
+    invalidateIndexCache();
+
+    for (let i = 0; i < DISPATCH_SUPPRESSION_THRESHOLD; i++) {
+      recordTaskTerminalSignal(task.id);
+    }
+
+    schedulerPick(tmpDir, []);
+    await new Promise(r => setTimeout(r, 80));
+    invalidateIndexCache();
+
+    const held = queryMemoryIndexSync(tmpDir, { id: task.id, limit: 1 })[0];
+    expect(held.status).toBe('hold');
+    const payload = held.payload as Record<string, unknown>;
+    const hold = payload.holdCondition as { type: string; value: string };
+    expect(hold.type).toBe('date-after');
+    expect(new Date(hold.value).getTime()).toBeGreaterThan(Date.now());
+    expect(payload.suppressionHold).toBe(true);
   });
 });

--- a/tests/staleness-resolved-skip.test.ts
+++ b/tests/staleness-resolved-skip.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Staleness sweep — resolved-but-pending tasks (GitHub issue #525)
+ *
+ * A task already marked resolved in task-events.jsonl can linger as `pending`
+ * in the index snapshot. incrementTaskStaleness must complete such tasks, not
+ * tick + re-escalate them to P0 — that was the phantom-P0 recurrence loop.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  appendMemoryIndexEntry,
+  incrementTaskStaleness,
+  queryMemoryIndexSync,
+  invalidateIndexCache,
+} from '../src/memory-index.js';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'staleness-resolved-'));
+  invalidateIndexCache();
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  invalidateIndexCache();
+});
+
+// Append a stack_rank resolution event for a task id (not an index entry, so
+// the index keeps showing the task as `pending` — the #525 desync scenario).
+function appendResolvedEvent(taskId: string): void {
+  const file = path.join(tmpDir, 'state', 'task-events.jsonl');
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.appendFileSync(file, JSON.stringify({
+    kind: 'stack_rank',
+    task_id: taskId,
+    to: 'resolved-phantom',
+  }) + '\n');
+}
+
+describe('incrementTaskStaleness — resolved-but-pending tasks', () => {
+  it('completes a resolved-but-pending task instead of escalating it', async () => {
+    const task = await appendMemoryIndexEntry(tmpDir, {
+      type: 'task',
+      status: 'pending',
+      summary: 'P0 phantom task already resolved in task-events',
+      payload: { priority: 1 },
+    });
+    appendResolvedEvent(task.id);
+    invalidateIndexCache();
+
+    await incrementTaskStaleness(tmpDir);
+    invalidateIndexCache();
+
+    const after = queryMemoryIndexSync(tmpDir, { id: task.id, limit: 1 })[0];
+    expect(after.status).toBe('completed');
+    // not escalated to P0
+    expect((after.payload as Record<string, unknown>).priority).not.toBe(0);
+    expect((after.payload as Record<string, unknown>).escalated_at).toBeUndefined();
+    expect((after.payload as Record<string, unknown>).terminal_resolution).toMatch(/resolved per task-events/);
+  });
+
+  it('leaves an unresolved pending task pending after one tick', async () => {
+    const task = await appendMemoryIndexEntry(tmpDir, {
+      type: 'task',
+      status: 'pending',
+      summary: 'P1 genuinely active task with no resolution event',
+      payload: { priority: 1 },
+    });
+    invalidateIndexCache();
+
+    await incrementTaskStaleness(tmpDir);
+    invalidateIndexCache();
+
+    const after = queryMemoryIndexSync(tmpDir, { id: task.id, limit: 1 })[0];
+    expect(after.status).toBe('pending');
+  });
+
+  it('still escalates a genuinely stale unresolved task to P0', async () => {
+    const task = await appendMemoryIndexEntry(tmpDir, {
+      type: 'task',
+      status: 'pending',
+      summary: 'P2 unresolved task that goes stale without progress',
+      payload: { priority: 2 },
+    });
+    invalidateIndexCache();
+
+    // >5 ticks crosses the staleness escalation boundary
+    for (let i = 0; i < 6; i++) {
+      await incrementTaskStaleness(tmpDir);
+      invalidateIndexCache();
+    }
+
+    const after = queryMemoryIndexSync(tmpDir, { id: task.id, limit: 1 })[0];
+    expect(after.status).toBe('pending');
+    expect((after.payload as Record<string, unknown>).priority).toBe(0);
+    expect((after.payload as Record<string, unknown>).escalated_at).toBeDefined();
+  });
+});

--- a/tests/token-ledger.test.ts
+++ b/tests/token-ledger.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Token ledger — per-call token accounting.
+ *
+ * Before this, the SDK response's `usage` was slog'd and discarded; there was
+ * no way to measure where tokens went. logTokenUsage persists each call to a
+ * daily ledger; getTokenUsageSummary aggregates total spend + per-source.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import { Logger } from '../src/logging.js';
+import { getInstanceDir } from '../src/instance.js';
+
+let instanceId: string;
+let logger: Logger;
+
+beforeEach(() => {
+  instanceId = 'token-ledger-test-' + Math.random().toString(36).slice(2, 10);
+  logger = new Logger(instanceId);
+});
+
+afterEach(() => {
+  fs.rmSync(getInstanceDir(instanceId), { recursive: true, force: true });
+});
+
+const flush = () => new Promise(r => setTimeout(r, 100));
+
+describe('Logger token ledger', () => {
+  it('returns an empty summary when nothing is recorded', () => {
+    const s = logger.getTokenUsageSummary();
+    expect(s.calls).toBe(0);
+    expect(s.totalInput).toBe(0);
+    expect(s.bySource).toEqual({});
+  });
+
+  it('records token usage and aggregates totals + per-source', async () => {
+    logger.logTokenUsage({ source: 'loop', model: 'claude-opus', input: 1000, output: 200, cacheRead: 500, cacheCreation: 100, durationMs: 2000 });
+    logger.logTokenUsage({ source: 'loop', input: 800, output: 150, cacheRead: 400, cacheCreation: 0 });
+    logger.logTokenUsage({ source: 'cron', input: 300, output: 50, cacheRead: 0, cacheCreation: 0 });
+    await flush();
+
+    const s = logger.getTokenUsageSummary();
+    expect(s.calls).toBe(3);
+    expect(s.totalInput).toBe(2100);
+    expect(s.totalOutput).toBe(400);
+    expect(s.totalCacheRead).toBe(900);
+    expect(s.totalCacheCreation).toBe(100);
+
+    expect(s.bySource.loop.calls).toBe(2);
+    expect(s.bySource.loop.input).toBe(1800);
+    expect(s.bySource.loop.output).toBe(350);
+    expect(s.bySource.cron.calls).toBe(1);
+    expect(s.bySource.cron.input).toBe(300);
+  });
+
+  it('isolates ledgers by date', async () => {
+    logger.logTokenUsage({ source: 'loop', input: 500, output: 100, cacheRead: 0, cacheCreation: 0 });
+    await flush();
+
+    const today = new Date().toISOString().split('T')[0];
+    expect(logger.getTokenUsageSummary(today).calls).toBe(1);
+    expect(logger.getTokenUsageSummary('2020-01-01').calls).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

A Constraint Texture analysis of Kuro's token spend found that on a peak day (2026-05-10) 751 Claude calls / ~9h Claude time were dominated by re-processing stuck P0 items — a single P0 was re-cycled **322 times**, ~84% of cycles produced no visible output. Three fixes:

**A — durable dispatch suppression** (`scheduler.ts`)
`resetSuppressionsForExternalEvents` globally cleared all suppression on any room/telegram message, so a non-converging task was un-suppressed almost immediately and re-picked. Suppression was also in-memory only (wiped on ~12 restarts/day). Now a task suppressed past the threshold is downgraded to a held memory-index task with a 6h date-after cooldown — leaves the dispatch pool, survives restart, capped re-spin.

**B — phantom-P0 recurrence (#525)** (`memory-index.ts`)
`incrementTaskStaleness` re-escalated resolved-but-still-`pending` tasks (event/index desync) to P0 every cycle. It now cross-checks `loadResolvedTaskKeysFromEvents` and completes such tasks instead.

**C — token ledger** (`sdk-client.ts`, `logging.ts`, `api.ts`)
SDK token usage was extracted then discarded. Now persisted per-call to `logs/tokens/<date>.jsonl`; `getTokenUsageSummary` aggregates total + per-source; `/status` exposes today's spend.

3 separate commits — each Part can be reverted independently.

## Test plan

- [x] `pnpm typecheck` clean (incl. post-rebase)
- [x] `pnpm test` — 1123 pass, 0 fail
- [x] new `tests/staleness-resolved-skip.test.ts`, `tests/token-ledger.test.ts`; updated `scheduler-dispatch-suppression.test.ts` (durable-hold + suppression-holds-through-external-events)
- [ ] post-merge: watch deploy; confirm phantom P0s no longer 322-spin (suppressed → hold); `/status.tokens` accumulates

🤖 Generated with [Claude Code](https://claude.com/claude-code)