### PR TITLE
fix(runtime): preserve local runtime commit 337cbb4a

### DIFF
--- a/src/loop.ts
+++ b/src/loop.ts
@@ -3001,6 +3001,12 @@ export class AgentLoop {
             priorityPrefix,
             rebuildPriorityPrefix: rebuildPriorityPrefixFn,
             source: 'loop',
+            // OODA cycles need budget to converge (diagnose+clear a stash,
+            // drain an overdue P1). The middleware exec path silently caps at
+            // 90s — too short for convergence work, so cycles get killed
+            // mid-task and degrade to "拆小". callClaude's documented default
+            // is 15min; 240s restores real budget while staying bounded.
+            timeoutMs: 240_000,
             onPartialOutput,
             cycleMode,
             model: modelCliName,


### PR DESCRIPTION
## Summary
- autocorrected 1 commit(s) that were made on protected runtime/main
- moved the change into an isolated worktree branch so review/merge/deploy can proceed normally
- reset the runtime checkout back to origin/main after preserving the change

## Verification
- [x] `git push -u origin fix/runtime-autocorrect-337cbb4a` passed; the runtime-local commit is preserved on an isolated review branch
- [x] `git reset --hard origin/main` passed; the protected runtime checkout was restored to origin/main