### PR TITLE
fix(stash-governance): drain deploy-backup snapshots instead of accumulating them

### DIFF
--- a/src/stash-governance.ts
+++ b/src/stash-governance.ts
@@ -17,6 +17,7 @@ export interface GitStashRecord {
 export type StashGovernanceDecision =
   | 'ignore'
   | 'drop-absorbed'
+  | 'drop-stale-deploy-backup'
   | 'regenerate-generated-artifacts'
   | 'merge-append-union'
   | 'manual-diagnostic';
@@ -53,6 +54,7 @@ export interface StashGovernanceResult {
   createdTasks: MemoryIndexEntry[];
   closedTasks: MemoryIndexEntry[];
   appendUnionMerges?: AppendUnionMergeOutcome[];
+  deployBackupDrops?: string[];
 }
 
 export async function governGitStashes(
@@ -108,6 +110,23 @@ export async function governGitStashes(
     }
   }
 
+  // Deploy-backup drop pass. Re-lists stashes fresh so it is immune to the
+  // index shifts the absorbed / append-union drop loops above may have caused
+  // (stash refs are positional — `stash@{N}`). Iterates descending index so
+  // each drop leaves every lower ref valid. Deliberately unbounded by maxCases:
+  // that cap throttles task-creating diagnoses, not a `git stash drop`, and a
+  // backlog of obsolete snapshots should drain in a single pass rather than
+  // ceil(N / maxCases) runs — the failure mode that let 33 accumulate.
+  const deployBackupDrops: string[] = [];
+  if (opts.dropAbsorbed) {
+    const live = opts.stashes ?? listGitStashes(repoRoot);
+    for (let i = live.length - 1; i >= 0; i--) {
+      const stash = live[i];
+      if (classifyStash(stash, opts.reason).decision !== 'drop-stale-deploy-backup') continue;
+      if (dropStash(repoRoot, stash.ref)) deployBackupDrops.push(stash.ref);
+    }
+  }
+
   if (opts.createTasks) {
     const { createTask } = await import('./memory-index.js');
     closedTasks.push(...await closeObsoleteStashTasks(memoryDir, allCases));
@@ -137,11 +156,12 @@ export async function governGitStashes(
     }
   }
 
-  if (cases.length > 0 && (opts.record || opts.createTasks)) {
-    slog('HOUSEKEEPING', `stash governance diagnosed ${cases.length} stash case(s); tasks=${createdTasks.length} closed=${closedTasks.length} absorbedDrops=${absorbedDrops.length} appendUnionDrops=${appendUnionMerges.filter(m => m.dropped).length}`);
+  if ((cases.length > 0 || deployBackupDrops.length > 0) && (opts.record || opts.createTasks)) {
+    const deferred = allCases.length - cases.length;
+    slog('HOUSEKEEPING', `stash governance diagnosed ${cases.length}/${allCases.length} stash case(s)${deferred > 0 ? ` (${deferred} deferred to next run)` : ''}; tasks=${createdTasks.length} closed=${closedTasks.length} absorbedDrops=${absorbedDrops.length} deployBackupDrops=${deployBackupDrops.length} appendUnionDrops=${appendUnionMerges.filter(m => m.dropped).length}`);
   }
 
-  return { cases, createdTasks, closedTasks, appendUnionMerges };
+  return { cases, createdTasks, closedTasks, appendUnionMerges, deployBackupDrops };
 }
 
 /**
@@ -290,6 +310,9 @@ export function classifyStash(stash: GitStashRecord, reason = 'periodic-scan'): 
   const allAiTrend = stash.files.length > 0
     && stash.files.every(file => file.startsWith('kuro-portfolio/ai-trend/'));
   const id = `stash-${hashCase(stash.message, stash.files)}`;
+  const onlyAppendUnion = assessment.manual.length === 0
+    && assessment.autoResolvable.length > 0
+    && assessment.autoResolvable.every(file => file.resolution === 'append-union');
 
   if (stash.absorbed) {
     return {
@@ -313,6 +336,37 @@ export function classifyStash(stash: GitStashRecord, reason = 'periodic-scan'): 
     };
   }
 
+  // Deploy-backup snapshots (`deploy-backup-<ISO8601>`) are safety stashes the
+  // deploy pipeline takes automatically before each deploy. Once the deploy has
+  // landed they are obsolete — the pre-deploy state stays reachable via the
+  // deploy reflog (~30d) and main branch history. They are not work-in-progress
+  // and must never become diagnose tasks. Left unclassified they silently
+  // accumulated (57 stashes / 33 deploy-backups, 2026-05-22): some failed
+  // isManagedStash and were ignored, the rest fell off the maxCases window.
+  // Exception: a snapshot carrying append-only memory conflicts falls through
+  // to merge-append-union below so that memory is union-merged before drop.
+  if (isDeployBackupStash(stash.message) && !onlyAppendUnion) {
+    return {
+      id,
+      ts: new Date().toISOString(),
+      stashRef: stash.ref,
+      message: stash.message,
+      files: stash.files,
+      assessment,
+      decision: 'drop-stale-deploy-backup',
+      rootCause: 'Pre-deploy safety snapshot superseded once the deploy landed; pre-deploy state remains reachable via the deploy reflog and main branch history.',
+      evidence: [
+        `trigger=${reason}`,
+        `stash=${stash.ref}`,
+        `message=${stash.message}`,
+        `files=${stash.files.length} file(s)`,
+        'policy=obsolete deploy-backup snapshots are dropped mechanically; recoverable from reflog ~30d',
+      ],
+      mechanicalAction: 'drop-deploy-backup-snapshot',
+      fallbackTask: null,
+    };
+  }
+
   if (!isManagedStash(stash) && !allGenerated) {
     return {
       id,
@@ -328,10 +382,6 @@ export function classifyStash(stash: GitStashRecord, reason = 'periodic-scan'): 
       fallbackTask: null,
     };
   }
-
-  const onlyAppendUnion = assessment.manual.length === 0
-    && assessment.autoResolvable.length > 0
-    && assessment.autoResolvable.every(file => file.resolution === 'append-union');
 
   if (isManagedStash(stash) && onlyAppendUnion) {
     return {
@@ -407,6 +457,16 @@ export function classifyStash(stash: GitStashRecord, reason = 'periodic-scan'): 
 
 function isManagedStash(stash: GitStashRecord): boolean {
   return /auto-push|keep-ai-trend-dirty|runtime|autocorrect|pre-rebase/i.test(stash.message);
+}
+
+/**
+ * A deploy-backup snapshot — `git stash` reflog subject ending in
+ * `deploy-backup-<YYYYMMDDThhmmssZ>`, e.g. `On runtime/main:
+ * deploy-backup-20260520T110613Z`. The timestamp is anchored to the end so the
+ * match never catches work-in-progress stashes that merely mention the words.
+ */
+function isDeployBackupStash(message: string): boolean {
+  return /(?:^|:\s)deploy-backup-\d{8}T\d{6}Z$/.test(message.trim());
 }
 
 async function hasActiveTaskForCase(memoryDir: string, caseId: string): Promise<boolean> {

--- a/tests/stash-governance.test.ts
+++ b/tests/stash-governance.test.ts
@@ -93,6 +93,23 @@ describe('stash governance', () => {
     expect(diagnostic.assessment.autoResolvable.every(f => f.resolution === 'append-union')).toBe(true);
   });
 
+  it('classifies a stale deploy-backup snapshot as a mechanical drop, not a diagnose task', () => {
+    const diagnostic = classifyStash(deployBackupCodeStash());
+
+    expect(diagnostic).toEqual(expect.objectContaining({
+      decision: 'drop-stale-deploy-backup',
+      mechanicalAction: 'drop-deploy-backup-snapshot',
+      fallbackTask: null,
+      rootCause: expect.stringContaining('Pre-deploy safety snapshot'),
+    }));
+  });
+
+  it('does not reclassify a deploy-backup carrying append-only memory — merge-append-union still wins', () => {
+    // Regression guard: the deploy-backup drop branch must not steal stashes
+    // that still have append-only memory to union-merge before being dropped.
+    expect(classifyStash(deployBackupAppendOnlyStash()).decision).toBe('merge-append-union');
+  });
+
   it('does not create scheduler tasks for managed deploy-backup append-only stashes (regression: phantom P1 loop)', async () => {
     const memoryDir = path.join(tmpDir, 'memory');
     mkdirSync(path.join(memoryDir, 'state'), { recursive: true });
@@ -167,6 +184,45 @@ describe('stash governance', () => {
 
     const stashList = execFileSync('git', ['stash', 'list'], { cwd: repo, encoding: 'utf-8' });
     expect(stashList.trim()).toBe('');
+  });
+
+  it('drops every stale deploy-backup snapshot in one pass, unbounded by maxCases', async () => {
+    const repo = path.join(tmpDir, 'repo');
+    mkdirSync(repo, { recursive: true });
+    const git = (...args: string[]) => execFileSync('git', args, { cwd: repo, encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] });
+    git('init', '-q', '-b', 'main');
+    git('config', 'user.email', 'test@test');
+    git('config', 'user.name', 'test');
+    git('config', 'commit.gpgsign', 'false');
+
+    const file = path.join(repo, 'src', 'thing.ts');
+    mkdirSync(path.dirname(file), { recursive: true });
+    writeFileSync(file, 'export const v = 1;\n', 'utf-8');
+    git('add', '.');
+    git('commit', '-q', '-m', 'init');
+
+    // Four deploy-backup snapshots — more than the default maxCases (3) — to
+    // prove the drop pass drains the whole backlog in a single run rather than
+    // ceil(N / maxCases) runs (the failure mode that let 33 accumulate).
+    for (let i = 0; i < 4; i++) {
+      writeFileSync(file, `export const v = ${i + 2};\n`, 'utf-8');
+      git('stash', 'push', '-q', '-m', `On main: deploy-backup-2026050${i + 1}T010101Z`, '--', 'src/thing.ts');
+    }
+
+    const memoryDir = path.join(tmpDir, 'memory');
+    mkdirSync(path.join(memoryDir, 'state', 'index'), { recursive: true });
+    writeFileSync(path.join(memoryDir, 'state', 'task-events.jsonl'), '', 'utf-8');
+    writeFileSync(path.join(memoryDir, 'state', 'index', 'relations.jsonl'), '', 'utf-8');
+
+    const result = await governGitStashes(memoryDir, repo, {
+      dropAbsorbed: true,
+      maxCases: 3,
+      reason: 'test',
+    });
+
+    expect(result.deployBackupDrops).toHaveLength(4);
+    expect(result.createdTasks).toHaveLength(0);
+    expect(execFileSync('git', ['stash', 'list'], { cwd: repo, encoding: 'utf-8' }).trim()).toBe('');
   });
 
   it('executor refuses to drop the stash if the merged output would shrink (append-only invariant)', async () => {
@@ -265,5 +321,13 @@ function deployBackupAppendOnlyStash(): GitStashRecord {
     ref: 'stash@{0}',
     message: 'On runtime/main: deploy-backup-20260508T165720Z',
     files: ['memory/handoffs/active.md'],
+  };
+}
+
+function deployBackupCodeStash(): GitStashRecord {
+  return {
+    ref: 'stash@{0}',
+    message: 'On main: deploy-backup-20260506T091949Z',
+    files: ['src/loop.ts'],
   };
 }


### PR DESCRIPTION
## Summary
- `classifyStash` now recognises `deploy-backup-<ISO8601>` snapshots and routes them to a new `drop-stale-deploy-backup` decision — previously they were classified `ignore` or fell off the `maxCases` window, so 33 accumulated (57 stashes total observed 2026-05-22).
- New drop pass in `governGitStashes` re-lists stashes fresh (immune to positional-ref shifts) and drains all deploy-backups in one pass, unbounded by `maxCases`.
- `slog` now reports `cases/allCases` + a deferred count so the truncation window is no longer silent.
- Append-only memory exception preserved: deploy-backups carrying memory conflicts still route to `merge-append-union` (regression-guarded).

## Why safe to drop
deploy-backup stashes are pre-deploy safety snapshots; the pre-deploy state stays reachable via deploy reflog (~30d) + main branch history. Ground truth: Kuro's `stash-cleanup-2026-05-22` receipt, which dropped all 33 with this exact assessment.

## Test plan
- [x] 3 new tests (classification, append-only regression guard, real-repo multi-stash drain)
- [x] 17/17 stash-governance + conflict-governance tests pass
- [x] typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)