### PR TITLE
refactor(memory-repo-policy): extract classifyMemoryRepoGitStatus helper

### DIFF
--- a/src/external-memory-health.ts
+++ b/src/external-memory-health.ts
@@ -2,6 +2,7 @@ import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { isKgDiscussionLifecycleKnown, readKgDiscussionLifecycleRecords } from './kg-discussion-janitor.js';
+import { classifyMemoryRepoGitStatus } from './memory-repo-policy.js';
 
 export interface ExternalMemoryHealthResult {
   status: 'ok' | 'warn' | 'blocked';
@@ -66,12 +67,15 @@ export function evaluateMemoryStateTruth(memoryDir: string, repoRoot: string): E
     };
   }
 
-  const dirtyLines = status.split('\n').filter(Boolean);
-  if (dirtyLines.length > 0) {
+  const dirty = classifyMemoryRepoGitStatus(status);
+  if (dirty.trackable.length > 0) {
     return {
       status: 'warn',
-      summary: `${dirtyLines.length} curated memory git change(s) not snapshotted`,
-      evidence: [...evidence, ...dirtyLines.slice(0, 8)],
+      summary: `${dirty.trackable.length} curated memory git change(s) not snapshotted`,
+      evidence: [
+        ...evidence,
+        ...dirty.trackable.slice(0, 8).map(item => `${item.status} ${item.relPath} (${item.klass})`),
+      ],
       repair: 'Commit curated memory changes locally; keep high-frequency telemetry ignored.',
     };
   }

--- a/src/housekeeping.ts
+++ b/src/housekeeping.ts
@@ -30,7 +30,7 @@ import type { TaskResult } from './delegation.js';
 import { reconcileMiddlewareCommitmentsSafe } from './middleware-truth-reconciler.js';
 import { rotateDecisionLogs } from './decision-log-rotation.js';
 import { sweepMiddlewareFailures } from './middleware-failure-self-healing.js';
-import { classifyMemoryRepoPath } from './memory-repo-policy.js';
+import { classifyMemoryRepoGitStatus } from './memory-repo-policy.js';
 import { getFeature, setEnabled } from './features.js';
 import { pruneReviewBacklog } from './review-backlog-janitor.js';
 import { sweepKgDiscussionLifecycle } from './kg-discussion-janitor.js';
@@ -860,16 +860,7 @@ function ensureCriticalContextFeatures(): void {
 }
 
 function parseTrackableMemoryStatus(status: string): string[] {
-  const files = new Set<string>();
-  for (const line of status.split('\n')) {
-    if (!line.trim()) continue;
-    const rawPath = line.slice(3).trim();
-    const relPath = rawPath.includes(' -> ') ? rawPath.split(' -> ').pop()?.trim() ?? rawPath : rawPath;
-    if (!relPath || relPath.startsWith('"')) continue;
-    const classification = classifyMemoryRepoPath(relPath);
-    if (classification.track) files.add(relPath);
-  }
-  return [...files].sort();
+  return classifyMemoryRepoGitStatus(status).trackable.map(file => file.relPath).sort();
 }
 
 async function execGit(cwd: string, args: string[]): Promise<{ stdout: string; stderr: string }> {

--- a/src/memory-repo-policy.ts
+++ b/src/memory-repo-policy.ts
@@ -19,6 +19,10 @@ export interface MemoryRepoFileStat extends MemoryRepoPathClassification {
   bytes: number;
 }
 
+export interface MemoryRepoGitStatusClassification extends MemoryRepoPathClassification {
+  status: string;
+}
+
 export interface MemoryRepoHealthReport {
   generatedAt: string;
   memoryDir: string;
@@ -226,6 +230,39 @@ export function classifyMemoryRepoPath(relPath: string): MemoryRepoPathClassific
   }
 
   return { relPath: normalized, klass: 'curated-knowledge', track: true, reason: 'curated memory artifact' };
+}
+
+export function classifyMemoryRepoGitStatus(status: string): {
+  trackable: MemoryRepoGitStatusClassification[];
+  ignored: MemoryRepoGitStatusClassification[];
+} {
+  const trackable: MemoryRepoGitStatusClassification[] = [];
+  const ignored: MemoryRepoGitStatusClassification[] = [];
+
+  for (const line of status.split('\n')) {
+    if (!line.trim()) continue;
+    const parsed = parseGitPorcelainLine(line);
+    if (!parsed) continue;
+    const classification = {
+      ...classifyMemoryRepoPath(parsed.relPath),
+      status: parsed.status,
+    };
+    if (classification.track) {
+      trackable.push(classification);
+    } else {
+      ignored.push(classification);
+    }
+  }
+
+  return { trackable, ignored };
+}
+
+function parseGitPorcelainLine(line: string): { status: string; relPath: string } | null {
+  const status = line.slice(0, 2);
+  const rawPath = line.slice(3).trim();
+  const relPath = rawPath.includes(' -> ') ? rawPath.split(' -> ').pop()?.trim() ?? rawPath : rawPath;
+  if (!relPath || relPath.startsWith('"')) return null;
+  return { status, relPath };
 }
 
 export function buildMemoryRepoHealthReport(

--- a/tests/external-memory-health.test.ts
+++ b/tests/external-memory-health.test.ts
@@ -1,4 +1,5 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
 import os from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -33,13 +34,25 @@ describe('external memory health', () => {
   });
 
   it('warns when a git-backed external memory repo has unsnapshotted curated files', () => {
-    mkdirSync(path.join(tmpDir, '.git'));
+    initGitMemory(tmpDir);
     writeFileSync(path.join(tmpDir, 'state', 'task-events.jsonl'), '', 'utf-8');
-    writeFileSync(path.join(tmpDir, 'MEMORY.md'), '# Memory\n', 'utf-8');
+    writeFileSync(path.join(tmpDir, 'inner-notes.md'), '# Notes\n', 'utf-8');
 
     const result = evaluateMemoryStateTruth(tmpDir, tmpDir);
 
-    expect(['warn', 'ok']).toContain(result.status);
+    expect(result.status).toBe('warn');
+    expect(result.summary).toContain('1 curated memory git change');
+    expect(result.evidence.join('\n')).toContain('inner-notes.md (curated-knowledge)');
+  });
+
+  it('does not warn for ignored high-frequency telemetry changes', () => {
+    initGitMemory(tmpDir);
+    writeFileSync(path.join(tmpDir, 'state', 'task-events.jsonl'), '', 'utf-8');
+    writeFileSync(path.join(tmpDir, 'state', 'transient.json'), '{}', 'utf-8');
+
+    const result = evaluateMemoryStateTruth(tmpDir, tmpDir);
+
+    expect(result.status).toBe('ok');
   });
 
   it('blocks unchecked P0 recurring-error HEARTBEAT tasks with no live error-pattern support', () => {
@@ -121,3 +134,8 @@ describe('external memory health', () => {
     expect(result.repair).toContain('context exchange');
   });
 });
+
+function initGitMemory(dir: string): void {
+  execFileSync('git', ['init'], { cwd: dir, stdio: 'ignore' });
+  writeFileSync(path.join(dir, '.git', 'info', 'exclude'), 'state/\n*.jsonl\n', 'utf-8');
+}

--- a/tests/memory-repo-policy.test.ts
+++ b/tests/memory-repo-policy.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   buildMemoryRepoHealthReport,
+  classifyMemoryRepoGitStatus,
   classifyMemoryRepoPath,
   CONTEXT_FABRIC_DESIGN,
   formatMemoryRepoHealthMarkdown,
@@ -25,6 +26,22 @@ describe('memory repo policy', () => {
       klass: 'curated-knowledge',
       track: true,
     });
+  });
+
+  it('classifies git dirt into curated work and ignored telemetry', () => {
+    const status = [
+      ' M inner-notes.md',
+      '?? state/autonomy-closure-diagnostics.jsonl',
+      '?? logs/runtime.jsonl',
+    ].join('\n');
+
+    const result = classifyMemoryRepoGitStatus(status);
+
+    expect(result.trackable.map(file => file.relPath)).toEqual(['inner-notes.md']);
+    expect(result.ignored.map(file => file.relPath)).toEqual([
+      'state/autonomy-closure-diagnostics.jsonl',
+      'logs/runtime.jsonl',
+    ]);
   });
 
   it('surfaces curated Markdown as KG candidates for shared semantic memory', () => {


### PR DESCRIPTION
## Summary
Hoists git-status parsing out of `housekeeping.ts` and `external-memory-health.ts` into a single classifier `classifyMemoryRepoGitStatus(status)` that returns `{ trackable, ignored }` with per-file `klass`. `external-memory-health` evidence now shows `status path (klass)`.

- DRY: removes duplicated porcelain-parsing logic in two consumers.
- Better diagnostics: `evaluateMemoryStateTruth` evidence is now classified rather than raw porcelain.
- New unit test for the classifier; existing tests updated for the richer evidence shape.

## Provenance
Recovers uncommitted work that had been sitting dirty in forge worktree `mini-agent-forge-1` (branch synced to main, no PR). Diagnosed in `agent-middleware/memory/state/wt-a0f09b59-state.md`.

## Test plan
- [x] `npx vitest run tests/memory-repo-policy.test.ts tests/external-memory-health.test.ts` — 12/12 pass
- [ ] CI: full suite green

Co-Authored-By: Kuro <kuro.ai.agent@gmail.com>