### PR TITLE
fix(loop): align progressTimeoutMs with timeoutMs to stop silent_exit_void_midprompt at 30s

### DIFF
--- a/src/loop.ts
+++ b/src/loop.ts
@@ -3007,6 +3007,14 @@ export class AgentLoop {
             // mid-task and degrade to "拆小". callClaude's documented default
             // is 15min; 240s restores real budget while staying bounded.
             timeoutMs: 240_000,
+            // Silence-watchdog must match hard timeout — without this, PROGRESS_TIMEOUT_MS
+            // (agent.ts:697) defaults to 30_000ms, so claude streaming thinking-text for
+            // >30s with zero tool calls gets killed (toolCallCount===0 branch in agent.ts:907-909).
+            // This is the actual mechanism behind silent_exit_void_midprompt recurrence on
+            // 2026-05-22 (8 hits ~223s each, exit N/A, prompt 20-30K chars). PR #535 raised
+            // wall-clock to 240s but the silence-watchdog at 30s still fires first when claude
+            // reasons silently mid-prompt. Align both timeouts.
+            progressTimeoutMs: 240_000,
             onPartialOutput,
             cycleMode,
             model: modelCliName,


### PR DESCRIPTION
## Root cause

`silent_exit_void_midprompt::callClaude` regression on 2026-05-22 (9 hits, 8 clustered 00:51–05:03Z, all `exit N/A` at ~223s, prompt 20–30K chars). PR #535 raised the hard wall-clock to 240s but the **silence-watchdog still fires at 30s**, so the bucket keeps refilling.

Mechanism (all paths in `src/agent.ts` and `src/loop.ts`):

| Location | Behavior |
|---|---|
| `agent.ts:697` | `PROGRESS_TIMEOUT_MS = opts?.progressTimeoutMs ?? 30_000` |
| `agent.ts:907-909` | `toolCallCount === 0` → `effectiveTimeout = PROGRESS_TIMEOUT_MS` |
| `agent.ts:923-925` | silence-watchdog kills process group when `silentMs >= effectiveTimeout` |
| `loop.ts:2998-3013` | passes `timeoutMs: 240_000` only — **does not pass `progressTimeoutMs`** |
| `agent.ts:85`  | jsdoc claims default `300_000` — code default is `30_000` (separate 10× doc bug) |

Result: claude streams thinking-text mid-prompt with zero tool calls, goes silent for 30s while reasoning, gets killed. `feedback-loops.ts:349` classifies the kill as `silent_exit_void_midprompt` when `totalMs >= 200_000 && promptChars >= 20_000`.

## Fix

Pass `progressTimeoutMs: 240_000` next to the existing `timeoutMs: 240_000` so both watchdogs share the same budget.

```ts
timeoutMs: 240_000,
progressTimeoutMs: 240_000,  // <-- new
```

The `toolCallCount > 0` branch is unaffected — `Math.max(240_000, 480_000) = 480_000` already exceeds 240s.

## Evidence

`memory/state/error-patterns.json` (mini-agent-memory repo) bucket `TIMEOUT:silent_exit_void_midprompt::callClaude`:

- `count: 9`
- `firstSeenAt: 2026-05-09T01:05:19.371Z` (latent), 8 fresh occurrences on 2026-05-22 within 4h
- `lastMessage: "claude CLI TIMEOUT (exit N/A, 223335ms this attempt, 476756ms total, attempt 2/3, prompt 25918 chars, loop lane)"`

The recurrence was flagged this cycle by reopening `staleResolvedAt: 2026-05-08T08:48:06.000Z` after detecting `lastSeenAt > prior resolvedAt`.

## Verification plan

- [ ] Post-deploy: `TIMEOUT:silent_exit_void_midprompt::callClaude` count stops incrementing
- [ ] No new `exit N/A` kills with `silentMs < 240_000` in loop lane
- [ ] `TIMEOUT:silent_exit_void::callClaude` and `TIMEOUT:real_timeout::callClaude` (same cluster) also stop accruing

## Out of scope (follow-ups)

- `agent.ts:85` jsdoc says `default: 300_000` but code uses `30_000` — fix doc or default in a separate PR
- Foreground path at `agent.ts:908` uses literal `120_000`/`300_000` — leave for now

🤖 Generated with [Claude Code](https://claude.com/claude-code)