### PR TITLE
feat(autonomy-closure): self-heal unsnapshotted curated memory

### DIFF
--- a/src/autonomy-closure-diagnostics.ts
+++ b/src/autonomy-closure-diagnostics.ts
@@ -5,12 +5,14 @@ import {
   type AutonomyClosureStage,
   type AutonomyClosureStageResult,
 } from './autonomy-closure-health.js';
+import { snapshotCuratedMemoryChanges } from './external-memory-health.js';
 import { autoRepairPrVerificationEvidence, githubAutoActions } from './github.js';
 import { slog } from './utils.js';
 
 export type AutonomyClosureMechanicalAction =
   | 'github-autopilot'
   | 'repair-pr-verification-evidence'
+  | 'snapshot-curated-memory'
   | 'none';
 
 export interface AutonomyClosureDiagnosticCase {
@@ -57,6 +59,12 @@ export async function diagnoseAndRepairAutonomyClosure(
     if (diagnostic.mechanicalAction === 'github-autopilot') {
       await githubAutoActions();
       actionsRun.push(diagnostic.mechanicalAction);
+      continue;
+    }
+    if (diagnostic.mechanicalAction === 'snapshot-curated-memory') {
+      const result = snapshotCuratedMemoryChanges(memoryDir);
+      if (result.committed) actionsRun.push(diagnostic.mechanicalAction);
+      if (result.error) slog('AUTONOMY', `curated memory snapshot failed: ${result.error}`);
       continue;
     }
   }
@@ -161,9 +169,10 @@ function diagnoseStage(stage: AutonomyClosureStageResult, ts: string): AutonomyC
   }
 
   if (stage.stage === 'memory-state-truth') {
+    const canSnapshotCuratedMemory = /curated memory git change\(s\) not snapshotted/i.test(stage.summary);
     return {
       ...base,
-      status: 'fallback-task',
+      status: canSnapshotCuratedMemory ? 'mechanical-action' : 'fallback-task',
       rootCause: 'External file memory is not in a durable parseable state.',
       evidence: stage.evidence,
       probeCommands: [
@@ -171,12 +180,14 @@ function diagnoseStage(stage: AutonomyClosureStageResult, ts: string): AutonomyC
         'pnpm check:autonomy-closure -- --json',
       ],
       constraintTexture: constraintTextureFor(stage, 'memory may change often, but curated state must be parseable, snapshotted, and replayable'),
-      mechanicalAction: 'none',
-      fallbackTask: {
-        title: 'P0 diagnostic: restore external memory state truth',
-        verifyCommand: 'git -C "$MINI_AGENT_MEMORY_DIR" status --short && pnpm check:autonomy-closure -- --json',
-        acceptanceCriteria: 'Critical JSONL is parseable and curated memory changes are either snapshotted or explicitly ignored as high-frequency telemetry.',
-      },
+      mechanicalAction: canSnapshotCuratedMemory ? 'snapshot-curated-memory' : 'none',
+      fallbackTask: canSnapshotCuratedMemory
+        ? null
+        : {
+            title: 'P0 diagnostic: restore external memory state truth',
+            verifyCommand: 'git -C "$MINI_AGENT_MEMORY_DIR" status --short && pnpm check:autonomy-closure -- --json',
+            acceptanceCriteria: 'Critical JSONL is parseable and curated memory changes are either snapshotted or explicitly ignored as high-frequency telemetry.',
+          },
     };
   }
 

--- a/tests/autonomy-closure-diagnostics.test.ts
+++ b/tests/autonomy-closure-diagnostics.test.ts
@@ -1,6 +1,21 @@
-import { describe, expect, it } from 'vitest';
-import { diagnoseAutonomyClosure, diagnosticFingerprint } from '../src/autonomy-closure-diagnostics.js';
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  diagnoseAndRepairAutonomyClosure,
+  diagnoseAutonomyClosure,
+  diagnosticFingerprint,
+} from '../src/autonomy-closure-diagnostics.js';
 import type { AutonomyClosureSnapshot } from '../src/autonomy-closure-health.js';
+
+let tmpDir: string | null = null;
+
+afterEach(() => {
+  if (tmpDir) rmSync(tmpDir, { recursive: true, force: true });
+  tmpDir = null;
+});
 
 describe('autonomy closure diagnostics', () => {
   it('routes PR review consensus blockers through mechanical verification repair first', () => {
@@ -111,6 +126,50 @@ describe('autonomy closure diagnostics', () => {
       }),
     }));
   });
+
+  it('routes unsnapshotted curated memory through a mechanical snapshot action', () => {
+    const cases = diagnoseAutonomyClosure(warningSnapshotWithStage({
+      stage: 'memory-state-truth',
+      status: 'warn',
+      summary: '1 curated memory git change(s) not snapshotted',
+      evidence: [' M handoffs/active.md (curated-knowledge)'],
+      repair: 'Commit curated memory changes locally; keep high-frequency telemetry ignored.',
+    }));
+
+    expect(cases[0]).toEqual(expect.objectContaining({
+      stage: 'memory-state-truth',
+      status: 'mechanical-action',
+      mechanicalAction: 'snapshot-curated-memory',
+      fallbackTask: null,
+      probeCommands: expect.arrayContaining([
+        'git -C "$MINI_AGENT_MEMORY_DIR" status --short',
+      ]),
+    }));
+  });
+
+  it('self-heals curated memory dirt while leaving high-frequency telemetry local', async () => {
+    tmpDir = mkdtempSync(path.join(os.tmpdir(), 'mini-agent-autonomy-diagnostics-'));
+    initGitMemory(tmpDir);
+    mkdirSync(path.join(tmpDir, 'state'), { recursive: true });
+    writeFileSync(path.join(tmpDir, 'inner-notes.md'), '# Notes\n', 'utf-8');
+    writeFileSync(path.join(tmpDir, 'state', 'autonomy-closure-diagnostics.jsonl'), '{"telemetry":true}\n', 'utf-8');
+
+    const result = await diagnoseAndRepairAutonomyClosure(tmpDir, warningSnapshotWithStage({
+      stage: 'memory-state-truth',
+      status: 'warn',
+      summary: '1 curated memory git change(s) not snapshotted',
+      evidence: [' M inner-notes.md (curated-knowledge)'],
+      repair: 'Commit curated memory changes locally; keep high-frequency telemetry ignored.',
+    }));
+    const status = execFileSync('git', ['status', '--porcelain', '--untracked-files=all'], {
+      cwd: tmpDir,
+      encoding: 'utf-8',
+    });
+
+    expect(result.actionsRun).toEqual(['snapshot-curated-memory']);
+    expect(status).not.toContain('inner-notes.md');
+    expect(status).toContain('state/autonomy-closure-diagnostics.jsonl');
+  });
 });
 
 function snapshotWithStage(stage: AutonomyClosureSnapshot['stages'][number]): AutonomyClosureSnapshot {
@@ -137,4 +196,19 @@ function snapshotWithStage(stage: AutonomyClosureSnapshot['stages'][number]): Au
       acknowledgedHolds: [],
     },
   };
+}
+
+function warningSnapshotWithStage(stage: AutonomyClosureSnapshot['stages'][number]): AutonomyClosureSnapshot {
+  return {
+    ...snapshotWithStage(stage),
+    status: 'degraded',
+    blockingStages: [],
+    warningStages: [stage.stage],
+  };
+}
+
+function initGitMemory(dir: string): void {
+  execFileSync('git', ['init'], { cwd: dir, stdio: 'ignore' });
+  execFileSync('git', ['config', 'user.name', 'test'], { cwd: dir, stdio: 'ignore' });
+  execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: dir, stdio: 'ignore' });
 }


### PR DESCRIPTION
## Summary
- Adds `snapshot-curated-memory` mechanical action to `AutonomyClosureMechanicalAction`.
- `diagnoseStage` for `memory-state-truth` routes the "N curated memory git change(s) not snapshotted" condition through the mechanical action instead of emitting a manual P0 fallback task.
- `diagnoseAndRepairAutonomyClosure` dispatches the new action by calling `snapshotCuratedMemoryChanges()` (already exported from `external-memory-health`).

## Why
Curated memory dirt is auto-recoverable — a snapshot commit is all that's needed. Emitting a P0 fallback task creates queue pressure that scheduler has to chew through, then resolves trivially. Mechanical-action path closes it in-loop.

High-frequency telemetry (`state/*.jsonl`) remains excluded by `snapshotCuratedMemoryChanges` — only curated knowledge gets committed.

## Verification
- [x] `pnpm vitest run tests/autonomy-closure-diagnostics.test.ts` → 7 passed
- New tests:
  - Routing test: `mechanicalAction='snapshot-curated-memory'`, `fallbackTask=null` when summary matches.
  - End-to-end self-heal: against temp git memory dir, confirms `inner-notes.md` is committed and `state/autonomy-closure-diagnostics.jsonl` stays as local telemetry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)