### PR TITLE
refactor(autonomy-closure): widen curated-memory snapshot detection to evidence lines

### DIFF
--- a/src/autonomy-closure-diagnostics.ts
+++ b/src/autonomy-closure-diagnostics.ts
@@ -169,7 +169,7 @@ function diagnoseStage(stage: AutonomyClosureStageResult, ts: string): AutonomyC
   }
 
   if (stage.stage === 'memory-state-truth') {
-    const canSnapshotCuratedMemory = /curated memory git change\(s\) not snapshotted/i.test(stage.summary);
+    const canSnapshotCuratedMemory = isUnsnapshottedCuratedMemoryStage(stage);
     return {
       ...base,
       status: canSnapshotCuratedMemory ? 'mechanical-action' : 'fallback-task',
@@ -229,6 +229,11 @@ function diagnoseStage(stage: AutonomyClosureStageResult, ts: string): AutonomyC
       acceptanceCriteria: `${stage.summary} ${stage.repair ?? ''}`.trim(),
     },
   };
+}
+
+function isUnsnapshottedCuratedMemoryStage(stage: AutonomyClosureStageResult): boolean {
+  if (/curated memory git change\(s\) not snapshotted/i.test(stage.summary)) return true;
+  return stage.evidence.some(line => /\b[AMDRCU? ]{1,2}\s+\S+ \((?:curated-knowledge)\)/i.test(line));
 }
 
 function diagnosticBase(stage: AutonomyClosureStageResult, ts: string): Pick<AutonomyClosureDiagnosticCase, 'id' | 'ts' | 'stage' | 'fingerprint'> {

--- a/tests/autonomy-closure-diagnostics.test.ts
+++ b/tests/autonomy-closure-diagnostics.test.ts
@@ -147,6 +147,23 @@ describe('autonomy closure diagnostics', () => {
     }));
   });
 
+  it('recognizes unsnapshotted curated memory from evidence even when summary wording changes', () => {
+    const cases = diagnoseAutonomyClosure(warningSnapshotWithStage({
+      stage: 'memory-state-truth',
+      status: 'warn',
+      summary: 'external memory has durable edits waiting for local snapshot',
+      evidence: [' M handoffs/active.md (curated-knowledge)'],
+      repair: 'Commit curated memory changes locally; keep high-frequency telemetry ignored.',
+    }));
+
+    expect(cases[0]).toEqual(expect.objectContaining({
+      stage: 'memory-state-truth',
+      status: 'mechanical-action',
+      mechanicalAction: 'snapshot-curated-memory',
+      fallbackTask: null,
+    }));
+  });
+
   it('self-heals curated memory dirt while leaving high-frequency telemetry local', async () => {
     tmpDir = mkdtempSync(path.join(os.tmpdir(), 'mini-agent-autonomy-diagnostics-'));
     initGitMemory(tmpDir);


### PR DESCRIPTION
## Summary
- Extract `isUnsnapshottedCuratedMemoryStage` helper from the inline regex used in `diagnoseStage` for the `memory-state-truth` stage.
- Widen detection so the mechanical-action gate also fires when evidence lines tag files as `(curated-knowledge)`, not only when the summary uses the exact "curated memory git change(s) not snapshotted" phrasing.

## Why
PR #546 (`589f970c`) introduced the self-heal path so the diagnostics layer can call `snapshot-curated-memory` instead of routing through a fallback repair task. But that path is gated by a regex on `stage.summary`. The same diagnostic can emit a different summary wording while still listing the curated-knowledge files in `evidence` — in that case the gate silently misses and we drop back to fallback-task. This widens the gate to also read the evidence shape, which is the more stable signal.

## Test plan
- [x] `npx vitest run tests/autonomy-closure-diagnostics.test.ts` → 8/8 pass
- [x] New test `recognizes unsnapshotted curated memory from evidence even when summary wording changes` exercises a drifted summary + curated-knowledge evidence line and asserts the diagnostic still resolves to `mechanical-action` / `snapshot-curated-memory`
- [x] Existing self-heal integration test (`self-heals curated memory dirt while leaving high-frequency telemetry local`) still passes — no regression on the original path

## Verification
- [x] All 8 tests in `tests/autonomy-closure-diagnostics.test.ts` pass locally
- [x] No changes outside diagnostics module
- [x] Helper kept private (no API surface change)