### PR TITLE
fix(agent): correct progressTimeoutMs jsdoc to match 30_000 default (#545)

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -82,7 +82,7 @@ export interface ExecOptions {
   fgSlotId?: string;
   /** Hard timeout in ms (default: 900_000 = 15min). FG lane should use shorter value. */
   timeoutMs?: number;
-  /** No-progress timeout in ms (default: 300_000 = 5min). Kill if no stdout for this long. */
+  /** No-progress timeout in ms (default: 30_000 = 30s). Kill if no stdout for this long. Callers needing longer tolerance (long Claude turns, KG steps) should pass an explicit value — see loop.ts:3060 (240_000) and housekeeping.ts:964. */
   progressTimeoutMs?: number;
   /** Thinking budget in tokens (Phase B — rubric-driven dynamic budget). 0 = disabled. */
   maxThinkingTokens?: number;


### PR DESCRIPTION
## Summary
- Closes #545. Changes `src/agent.ts:85` jsdoc from `default: 300_000 = 5min` to `default: 30_000 = 30s` to match actual code at `src/agent.ts:697`.
- Adds pointer to explicit-value examples (`loop.ts:3060`, `housekeeping.ts:964`) so future callers don't re-discover the 10× trap.

## Why Option A (doc-only)
Audited all in-tree callers — none pass `300_000`. Explicit callers use 30s / 60s / 240s / KG_STEP. The 30s default is what every undefined-passing caller actually got and tested with. Option B (raise default to 300_000) would silently extend kill window for callers currently relying on fast-fail.

## Test plan
- [x] jsdoc and code default now both read `30_000` (grep `30_000` in `src/agent.ts` ↔ no remaining `300_000 = 5min` claim)
- [ ] Reviewer: confirm no caller intends 5min tolerance via undefined

Refs PR #544 (silent_exit_void_midprompt RCA), bucket `TIMEOUT:silent_exit_void_midprompt::callClaude`.