### PR TITLE
chore(claude-code): add automation tooling layer

### DIFF
--- a/.claude/agents/autonomy-closure-reviewer.md
+++ b/.claude/agents/autonomy-closure-reviewer.md
@@ -1,0 +1,51 @@
+---
+name: autonomy-closure-reviewer
+description: Reviews changes to the OODA autonomy-closure / brain-arbiter / commitment-ledger subsystem for invariant violations. Use after editing autonomy-closure-*.ts, autonomous-work-closure.ts, commitment-ledger.ts, or brain-arbiter.ts.
+tools: Read, Glob, Grep, Bash
+---
+
+你是 mini-agent OODA 自主收斂子系統的專責審查者。Kuro 的自主迴圈
+（perceive → think → act → close）能否「把推進中的承諾收尾、不漂移」，
+靠的就是這群高耦合模組。你的任務是在它們被改動後抓出不變量違反。
+
+## 審查範圍
+
+核心檔案（改動觸發審查）：
+- `src/autonomous-work-closure.ts` — 自主工作收斂
+- `src/autonomy-closure-health.ts` / `-diagnostics.ts` / `-notifier.ts`
+- `src/commitment-ledger.ts` / `src/commitments.ts` — 跨 cycle 承諾帳本
+- `src/brain-arbiter.ts` / `src/brain-run-ledger.ts` — brain 仲裁與紀錄
+- `src/cycle-state.ts` / `src/cycle-tasks.ts` — cycle 狀態機
+
+## 必查不變量
+
+1. **Ledger append-only / 一致性** — commitment ledger 的條目不應被靜默
+   覆寫或刪除；狀態轉移（open → in-progress → closed）必須單向、有紀錄。
+2. **收斂條件存在** — 每個進入「執行中」的承諾都要有可判定的完成條件，
+   否則會永遠漂在帳本裡。檢查新增路徑是否漏了 closure 判定。
+3. **跨 restart 持久化** — closure 狀態寫進檔案/DB，不是只存在記憶體。
+   process 重啟後讀得回來。
+4. **Fail-closed** — 偵測到異常時預設不外洩、不誤判為完成；寧可留 open
+   讓下一 cycle 重試，也不要假性 close。
+5. **Code 而非 prompt 護欄** — 可量化、規則固定的檢查應落在 code 層
+   （deterministic、跨 restart 存活），不要退化成 prompt 指示。
+6. **無 silent catch** — `catch {}` 吞掉 closure 失敗會造成漂移。
+   每個 catch 都要有紀錄或重試。
+
+## 流程
+
+1. `git diff` 看改動範圍，鎖定觸及的核心檔案。
+2. 逐條對照上述不變量，引用 `檔案:行號` 佐證。
+3. 跑 `pnpm check:autonomy-closure` 與相關 `vitest` 測試，附上實際輸出
+   —— 證據先於斷言，typecheck 過 ≠ 收斂邏輯正確。
+4. 輸出分級結論：
+
+   ```
+   ## autonomy-closure 審查
+   - 🔴 阻擋：<不變量違反，必須修>
+   - 🟡 疑慮：<可能漂移風險，建議處理>
+   - 🟢 通過：<已確認的不變量>
+   結論：可合併 / 需修正
+   ```
+
+無證據不下結論；不確定就明說是假設。

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,18 +6,27 @@
         "hooks": [
           {
             "type": "command",
-            "command": "if [[ \"$TOOL_INPUT\" == *\".ts\"* ]]; then cd \"$CLAUDE_PROJECT_DIR\" && npx tsc --noEmit 2>&1 | head -20; fi"
+            "command": "if [[ \"$TOOL_INPUT\" == *\".ts\"* ]]; then cd \"$CLAUDE_PROJECT_DIR\" && npx tsc --noEmit --incremental --tsBuildInfoFile .tsbuildinfo 2>&1 | head -20; fi"
           }
         ]
       }
     ],
     "PreToolUse": [
       {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "INPUT=\"${TOOL_INPUT:-$(cat)}\"; if echo \"$INPUT\" | grep -qE '\"file_path\": ?\"[^\"]*/\\.env\"'; then echo 'BLOCKED: .env 含 secrets（OPENAI_API_KEY 等），請改 .env.example，或在 chat-room 說明需求' >&2; exit 2; fi"
+          }
+        ]
+      },
+      {
         "matcher": "Bash",
         "hooks": [
           {
             "type": "command",
-            "command": "if echo \"$TOOL_INPUT\" | grep -q 'git commit'; then cd \"$CLAUDE_PROJECT_DIR\" && npx tsc --noEmit 2>&1 | tail -5; fi"
+            "command": "if echo \"$TOOL_INPUT\" | grep -q 'git commit'; then cd \"$CLAUDE_PROJECT_DIR\" && npx tsc --noEmit --incremental --tsBuildInfoFile .tsbuildinfo 2>&1 | tail -5; fi"
           }
         ]
       }

--- a/.claude/skills/health-sweep/SKILL.md
+++ b/.claude/skills/health-sweep/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: health-sweep
+description: Run all mini-agent health-check and janitor scripts in one pass and summarize the results. Use when the user wants a project health check or types /health-sweep.
+disable-model-invocation: true
+---
+
+# health-sweep
+
+一鍵執行 mini-agent 所有健康檢查與 janitor 腳本，彙整成一份報告。
+
+`package.json` 裡的健康檢查指令散落各處，這個 skill 把它們收攏成單一入口。
+全部用 `tsx` 直接跑 `.ts`，**不需要先 `pnpm build`**。
+
+## 步驟
+
+1. 依序執行下列指令（每個都用 Bash，`cd` 到 `$CLAUDE_PROJECT_DIR`）。
+   janitor 全部跑 **dry-run**（不加 `--apply`），只報告不動檔案：
+
+   | # | 指令 | 檢查項目 |
+   |---|------|---------|
+   | 1 | `pnpm check:autonomy-closure` | OODA 自主收斂健康度 |
+   | 2 | `pnpm check:test-health` | 測試套件健康度 |
+   | 3 | `pnpm check:design-governance` | 設計治理規範 |
+   | 4 | `pnpm check:pr-lifecycle` | PR 生命週期 |
+   | 5 | `pnpm check:runtime-workspace` | runtime workspace 狀態 |
+   | 6 | `pnpm guard:issue-evidence` | issue 證據門檻 |
+   | 7 | `pnpm janitor:workspaces` | 殘留 worktree（dry-run）|
+   | 8 | `pnpm janitor:stash` | 殘留 stash（dry-run）|
+   | 9 | `pnpm typecheck` | TypeScript strict 型別 |
+
+2. 某個指令失敗或不存在時不要中斷 —— 記下來，繼續跑下一個。
+
+3. 全部跑完後輸出一張總表：
+
+   ```
+   | 檢查 | 結果 | 摘要 |
+   |------|------|------|
+   | autonomy-closure | ✅ / ⚠️ / ❌ | 一行重點 |
+   ...
+   ```
+
+   最後列出**需要處理的項目**（⚠️ / ❌），各附一句建議的下一步動作。
+
+## 注意
+
+- 這是唯讀巡檢。要真的清理時，janitor 改用 `pnpm janitor:workspaces:apply` /
+  `pnpm janitor:stash:apply`，且須先向使用者確認。
+- 跑之前先確認 Kuro 狀態：`curl -sf localhost:3001/status`。若 cycle 進行中，
+  檢查腳本仍可安全執行（皆唯讀），但要留意輸出可能反映變動中的狀態。

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ sessions/
 .claude/*
 !.claude/settings.json
 !.claude/skills/
+!.claude/agents/
 output.md
 agent-compose.yaml
 .DS_Store
@@ -49,3 +50,6 @@ _tm-c3.json
 .graphify_*.json
 .graphify_python
 .tm_*.json
+
+# CC session 2026-05-22: incremental typecheck cache
+.tsbuildinfo

--- a/.mcp.json
+++ b/.mcp.json
@@ -9,6 +9,15 @@
       "env": {
         "AGENT_URL": "http://127.0.0.1:3001"
       }
+    },
+    "memory-db": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "-y",
+        "mcp-server-sqlite-npx",
+        "/Users/user/.mini-agent/instances/03bbc29a/memory-index.db"
+      ]
     }
   }
 }


### PR DESCRIPTION
## 摘要

由 `claude-automation-recommender` skill 分析 codebase 後產出的 5 項 Claude Code 自動化，全部已驗證。皆為 **CC 工具層**設定，不碰 `src/` 與 `memory/`。

> 背景：這批檔案先前 commit 在 `runtime/main`（部署鏡像分支，會被持續 reset 到 `origin/main`）而遺失。改走正規 feature branch → PR 流程確保持久化。

## 變更內容

- **`.claude/settings.json`** — typecheck hook 改用 `--incremental`（冷啟 3.3s → 熱快取 1.3s）；新增 PreToolUse `Edit|Write` guard，阻擋對 `.env`（含 secrets）的編輯，`.env.example` 不受影響。
- **`.mcp.json`** — 新增 `memory-db` SQLite MCP，指向 live instance 的 `memory-index.db`，可直查 FTS5 schema 與記憶內容做 debug。
- **`.claude/skills/health-sweep/SKILL.md`** — 一鍵執行所有 `check:*` / `janitor:*` 腳本的 runner（user-invocable only）。
- **`.claude/agents/autonomy-closure-reviewer.md`** — OODA closure / commitment-ledger / brain-arbiter 子系統的不變量審查 subagent。
- **`.gitignore`** — 忽略 `.tsbuildinfo`（增量快取），納管 `.claude/agents/`。

## 驗證

- `tsc --noEmit --incremental` exit 0；增量快取 3.3s → 1.3s
- `.env` guard 邏輯：`.env` → BLOCKED，`.env.example` / `src/*.ts` → allowed
- SQLite MCP DB 路徑存在、`mcp-server-sqlite-npx` v0.8.0 可解析
- pre-push guard（conflict-governance + pr-lifecycle）通過

## 部署影響

5 個檔案皆**不在** `deploy.yml` 觸發路徑（`src/**`、`package.json`、`scripts/**` 等）內，合併**不會觸發部署**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)