### PR TITLE
fix(telemetry): split sideQuery timeout from callClaude silent_exit_void bucket (#547)

### DIFF
--- a/src/feedback-loops.ts
+++ b/src/feedback-loops.ts
@@ -305,6 +305,10 @@ export function extractErrorSubtype(errorMsg: string): string {
   }
   // 2026-04-20: agent.ts:224 silent_exit message template (shipped 3039f4a3) — complete the label
   // chain so TIMEOUT:generic fallthrough becomes TIMEOUT:silent_exit in recurring-errors.
+  // Issue #547: sideQuery emits its own timeout telemetry, but the message includes
+  // "silent exit" + "stdout=empty" for historical compatibility. Keep it out of
+  // the callClaude silent_exit_void recovery lane.
+  if (lower.includes('sidequery timeout') || lower.includes('side-query timeout')) return 'side_query_timeout';
   if (lower.includes('靜默中斷') || lower.includes('靜默溢位') || lower.includes('silent exit')) {
     if (lower.includes('auth') || lower.includes('unauthorized') || lower.includes('401')) return 'silent_exit_auth';
     if (lower.includes('overloaded') || lower.includes('529')) return 'silent_exit_overload';

--- a/tests/extract-error-subtype.test.ts
+++ b/tests/extract-error-subtype.test.ts
@@ -113,10 +113,10 @@ describe('extractErrorSubtype — silent_exit_void 4-class typed-failure schema 
 });
 
 describe('sideQuery timeout bucket (#547)', () => {
-  it('keeps sideQuery timeout messages in the silent_exit_void subtype', () => {
+  it('keeps sideQuery timeout messages out of the callClaude silent_exit_void subtype', () => {
     const msg = 'sideQuery TIMEOUT: Claude CLI silent exit (30s no stderr). stdout=empty prompt 1234 chars';
     expect(extractErrorCode(msg)).toBe('TIMEOUT');
-    expect(extractErrorSubtype(msg)).toBe('silent_exit_void');
+    expect(extractErrorSubtype(msg)).toBe('side_query_timeout');
   });
 });
 


### PR DESCRIPTION
## Summary
- Route `sideQuery TIMEOUT` messages to a dedicated `side_query_timeout` subtype in `extractErrorSubtype` so they stop polluting `TIMEOUT:silent_exit_void::callClaude`.
- Update test `tests/extract-error-subtype.test.ts` to assert the new bucket.
- Companion: `DEFAULT_SIDE_QUERY_TIMEOUT_MS` already raised 15_000 → 30_000 in `src/side-query.ts` (Haiku preflights hit 15s ceiling under load).

## Why
Two RCAs (`2026-04-26-callClaude-timeout-rca.md`, `timeout-diagnosis-2026-05-22.md`) established the silent_exit_void::callClaude bucket was misattribution — actual source is `semanticRankTopics → sideQuery`. PR #535 raised the wrong timeout. This patch fixes labelling so future bursts route to the correct phantom owner and unblocks recovery recipes scoped to sideQuery.

## Falsifier (per issue #547)
- After ship + first reload, sideQuery timeout messages land in `side_query_timeout` bucket (not `silent_exit_void::callClaude`).
- `grep '15_000' src/side-query.ts` → no match at line 41 (now `30_000`).

## Test plan
- [x] `pnpm typecheck` — pass
- [x] `pnpm test` — 137 files / 1145 tests pass (2 skipped)
- [ ] 7-day burn-in: `silent_exit_void_midprompt::callClaude` count stops climbing (≤2 hits/day attributable to real main-loop calls)

Closes #547

🤖 Generated with [Claude Code](https://claude.com/claude-code)