### PR TITLE
chore(claude-code): move typecheck from per-edit PostToolUse to blocking Stop hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,12 +1,13 @@
 {
   "hooks": {
-    "PostToolUse": [
+    "Stop": [
       {
-        "matcher": "Edit|Write",
         "hooks": [
           {
             "type": "command",
-            "command": "if [[ \"$TOOL_INPUT\" == *\".ts\"* ]]; then cd \"$CLAUDE_PROJECT_DIR\" && npx tsc --noEmit --incremental --tsBuildInfoFile .tsbuildinfo 2>&1 | head -20; fi"
+            "command": "cd \"$CLAUDE_PROJECT_DIR\" || exit 0; IN=$(cat); echo \"$IN\" | grep -qE '\"stop_hook_active\": *true' && exit 0; OUT=$(npx tsc --noEmit --incremental --tsBuildInfoFile .tsbuildinfo 2>&1); [ -z \"$OUT\" ] && exit 0; { echo 'TypeScript 型別錯誤（Stop hook）— 請修正後再結束:'; echo \"$OUT\" | tail -30; } >&2; exit 2",
+            "statusMessage": "型別檢查中…",
+            "timeout": 120
           }
         ]
       }


### PR DESCRIPTION
## 變更

把 `.claude/settings.json` 的 TypeScript typecheck 從 **PostToolUse**（每次 `.ts` Edit/Write 都全專案重編 202 檔）改為 **Stop hook**（每回合結束跑一次）。

| | 改動前 | 改動後 |
|---|---|---|
| 觸發 | 每次 `.ts` 編輯 | 每回合結束 1 次 |
| 行為 | 唯讀資訊（`head -20`）| 型別錯誤時 `exit 2` 回饋給 model 修一次 |
| 防迴圈 | — | `stop_hook_active` guard |

PreToolUse 的 `.env` 阻擋與 commit 前 typecheck **不變**。

## 動機

per-edit 全量重編是 cycle 的隱性成本：一回合多次編輯 → 多次全專案 `tsc`。Stop hook 收斂成每回合一次；型別錯誤時仍 `exit 2` 擋一次讓 model 修，pre-commit githook 仍是最終防線。

## 驗證

- forge-lite `yolo`：`pnpm build` + `pnpm typecheck` + `pnpm test`（**1145 passed / 2 skipped**）全綠。
- Stop hook 三分支 pipe-test 通過：clean → exit 0 靜默 / `stop_hook_active` → 0.017s 即跳出不跑 tsc / 有錯誤 → stderr 輸出 + exit 2。
- `jq -e` 確認 JSON 合法。

來源：`/recommend automations` 分析建議。

🤖 Generated with [Claude Code](https://claude.com/claude-code)