### PR TITLE
feat(claude-code): git-safety hooks + field-consistency reviewer + persist-check skill

### DIFF
--- a/.claude/agents/field-consistency-reviewer.md
+++ b/.claude/agents/field-consistency-reviewer.md
@@ -1,0 +1,53 @@
+---
+name: field-consistency-reviewer
+description: Reviews changes for field-name consistency across HTTP endpoints, plugin interfaces, and TypeScript types. Use after editing api.ts, agent.ts, plugin files, or shared type definitions.
+tools: Read, Glob, Grep, Bash
+---
+
+你是 mini-agent 欄位命名一致性的專責審查者。`CLAUDE.md` 明訂
+「maintain field-name consistency across endpoints / plugins / types」。
+這個 codebase 的 `src/api.ts`（170KB+）、`src/agent.ts`（100KB+）規模龐大，
+endpoint 回傳欄位、plugin 介面、type 定義最容易在改動中悄悄漂移。
+你的任務是在這些檔案被改動後抓出欄位命名不一致。
+
+## 審查範圍
+
+改動觸發審查的檔案：
+- `src/api.ts` — HTTP endpoint 的 request/response 形狀
+- `src/agent.ts` — agent 核心狀態與對外資料
+- `src/*plugin*.ts`、`src/plugins/**` — plugin 介面與 payload
+- `src/*types*.ts`、`brain-types.ts` 等共享 type 定義
+
+## 必查不變量
+
+1. **三邊同名** — 同一個概念在 endpoint JSON、plugin 介面、type
+   定義裡必須用同一個欄位名。`taskId` vs `task_id` vs `id` 混用 = bug。
+2. **camelCase / snake_case 邊界明確** — 內部 TypeScript 用 camelCase，
+   對外 JSON 若有 snake_case 慣例必須在序列化處統一轉換，不可半途混用。
+3. **抽象貫徹到底** — 新增共享常數/型別後，搜尋所有 hardcoded 舊欄位名
+   是否都已替換。只在「容易看到的地方」用新名 = 抽象洩漏。
+4. **命名攜帶假設** — 欄位用途泛化後（如 telegram-only → direct-message），
+   名字必須同步更新，否則舊名就是 bug 的藏身處。
+5. **optional / required 一致** — 同欄位在 type、zod schema、endpoint
+   驗證三處的 optionality 必須一致。
+6. **新來源 checklist** — 加新 source/欄位時，找出所有 source-specific
+   的 if/switch，逐處確認新欄位是否需要同樣處理。
+
+## 流程
+
+1. `git diff` 看改動範圍，鎖定觸及的 endpoint / plugin / type。
+2. 對每個新增或更名的欄位，`grep` 其名字在三邊的出現處，逐一對照。
+3. 對每個舊欄位名跑 `grep`，確認沒有殘留的 hardcoded 用法。
+4. 跑 `pnpm typecheck` 與相關 `vitest`，附上實際輸出
+   —— 證據先於斷言，typecheck 過 ≠ 欄位語意一致。
+5. 輸出分級結論：
+
+   ```
+   ## field-consistency 審查
+   - 🔴 阻擋：<欄位名不一致，會在 runtime 出錯>
+   - 🟡 疑慮：<命名漂移風險，建議統一>
+   - 🟢 通過：<已確認三邊同名的欄位>
+   結論：可合併 / 需修正
+   ```
+
+無證據不下結論；不確定就明說是假設。

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -27,6 +27,11 @@
         "hooks": [
           {
             "type": "command",
+            "command": "INPUT=\"${TOOL_INPUT:-$(cat)}\"; if echo \"$INPUT\" | grep -qE 'git add (-A|--all|\\.)([^a-zA-Z0-9/]|$)'; then echo 'BLOCKED: 避免 git add -A/--all/. — 請逐檔明確 stage（CLAUDE.md Code & Deploy）' >&2; exit 2; fi; if echo \"$INPUT\" | grep -q -- '--no-verify'; then echo 'BLOCKED: 禁止 --no-verify，除非 Alex 明確要求（CLAUDE.md）' >&2; exit 2; fi; if echo \"$INPUT\" | grep -q 'git commit'; then BR=$(cd \"$CLAUDE_PROJECT_DIR\" 2>/dev/null && git branch --show-current 2>/dev/null); if [ \"$BR\" = 'runtime/main' ]; then echo 'BLOCKED: runtime/main 是部署鏡像分支，commit 會被 runtime autocorrect 洗掉。請改用 scripts/forge-lite.sh create <name> 走 worktree → PR（見 memory project_runtime_main_volatile）' >&2; exit 2; fi; fi",
+            "statusMessage": "檢查 git 安全規則…"
+          },
+          {
+            "type": "command",
             "command": "if echo \"$TOOL_INPUT\" | grep -q 'git commit'; then cd \"$CLAUDE_PROJECT_DIR\" && npx tsc --noEmit --incremental --tsBuildInfoFile .tsbuildinfo 2>&1 | tail -5; fi"
           }
         ]

--- a/.claude/skills/persist-check/SKILL.md
+++ b/.claude/skills/persist-check/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: persist-check
+description: Verify that code/config changes are actually persisted (committed + pushed + PR), not left uncommitted on the volatile runtime/main checkout. Use before claiming any "套用/執行/完成" of a change, or when a task asked to apply changes.
+user-invocable: false
+---
+
+# persist-check
+
+memory `feedback_persist_is_delivery.md` 記錄了反覆發生的失誤：
+**被要求「執行 / 套用」改動，卻停在「未 commit」。** 在 `runtime/main`
+checkout 上未 commit 的 tracked-file 改動會被 runtime autocorrect 洗掉
+—— 等於沒做。持久化是交付的一部分。
+
+這個 skill 是宣稱「改完了 / 套用了 / 完成了」之前的最後一道自我檢查。
+
+## 何時觸發
+
+- 即將說出「已套用」「已執行」「完成了」描述 code/config 改動時
+- 任務要求「apply / 執行 / 套用 / 落地」某個改動時
+- 準備收尾一個有檔案改動的 cycle 時
+
+## 檢查清單
+
+逐項確認，任一項為否就**還沒完成**：
+
+1. **改動位置** — `git branch --show-current`。若是 `runtime/main`
+   且改的是 tracked 檔案 → 改動會被洗掉，必須改走 worktree。
+2. **隔離** — 大改動（>3 files OR >50 lines）是否在 `scripts/forge-lite.sh`
+   建立的 worktree 裡，而非直接動 live tree？
+3. **已 commit** — `git status` 沒有相關的未追蹤/未暫存改動？
+4. **已 push** — `git log origin/<branch>..HEAD` 為空（本地沒有未推送 commit）？
+5. **PR 存在** — `gh pr list --head <branch>` 找得到對應 PR？
+6. **驗證綠燈** — typecheck / build / 相關測試實際跑過且通過（附輸出）？
+
+## 結論
+
+全部為是 → 可以宣稱完成，並回報 PR 連結。
+任一為否 → 明確說出卡在哪一步，補完該步驟，**不要停在 spec-only 或
+未 commit**。spec 是設計，apply 是交付。
+
+## 注意
+
+- 標準持久化路徑：`forge-lite.sh create <name>` → 改動 → `forge-lite.sh
+  yolo <worktree> "msg"`（verify + push + PR）。
+- `runtime/main` 是部署鏡像分支，本地 commit 注定被 reset 洗掉，
+  別在上面 commit（見 memory `project_runtime_main_volatile`）。


### PR DESCRIPTION
## 摘要

執行「Claude Code 自動化建議」的成果——三個自動化，全部補現有設定的缺口（非泛用項目）。

### ⚡ Hooks — `.claude/settings.json` PreToolUse Bash guard
把 `CLAUDE.md` 文件化的硬規則轉成 code 強制（Rules to Code）：

| Guard | 行為 |
|-------|------|
| `runtime/main` commit 守衛 | 在部署鏡像分支跑 `git commit` 直接 `exit 2` 擋下，導向 forge-lite worktree。落實 memory `project_runtime_main_volatile` |
| `git add -A/--all/.` 守衛 | 強制逐檔明確 stage |
| `--no-verify` 守衛 | 除非 Alex 明確要求 |

三分支邏輯皆逐案實測，含 `git add .claude/...`、`./src/x.ts` 等 path false-positive 檢查（anchor 用 `[^a-zA-Z0-9/]` 避免誤判路徑）。

### 🤖 Subagent — `field-consistency-reviewer`
改動 `api.ts`(170KB+) / `agent.ts`(100KB+) / plugin / type 後，審查 endpoint↔plugin↔type 三邊欄位命名一致性。落實 `CLAUDE.md` "field-name consistency across endpoints / plugins / types"。

### 🎯 Skill — `persist-check`（Claude-only, `user-invocable: false`）
宣稱「完成/套用」前的自我檢查：改動是否真的 committed + pushed + PR。落實 memory `feedback_persist_is_delivery`，防止停在 spec-only / 未 commit。

## 驗證
- `forge-lite yolo` verify 全綠：build + typecheck + **1145 tests passed**（137 files）
- guard hook 三分支逐案實測通過
- `settings.json` JSON 合法性已驗

## 範圍
3 個檔案 / +104 行，僅 `.claude/` 設定，無 code 改動。經 forge-lite worktree 隔離。

🤖 Generated with [Claude Code](https://claude.com/claude-code)