### PR TITLE
fix(claude-code): filter npm warnings from Stop hook tsc output

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cd \"$CLAUDE_PROJECT_DIR\" || exit 0; IN=$(cat); echo \"$IN\" | grep -qE '\"stop_hook_active\": *true' && exit 0; OUT=$(npx tsc --noEmit --incremental --tsBuildInfoFile .tsbuildinfo 2>&1); [ -z \"$OUT\" ] && exit 0; { echo 'TypeScript 型別錯誤（Stop hook）— 請修正後再結束:'; echo \"$OUT\" | tail -30; } >&2; exit 2",
+            "command": "cd \"$CLAUDE_PROJECT_DIR\" || exit 0; IN=$(cat); echo \"$IN\" | grep -qE '\"stop_hook_active\": *true' && exit 0; OUT=$(npx tsc --noEmit --incremental --tsBuildInfoFile .tsbuildinfo 2>&1 | grep -vE '^npm (warn|warning|notice|err!)'); [ -z \"$OUT\" ] && exit 0; { echo 'TypeScript 型別錯誤（Stop hook）— 請修正後再結束:'; echo \"$OUT\" | tail -30; } >&2; exit 2",
             "statusMessage": "型別檢查中…",
             "timeout": 120
           }


### PR DESCRIPTION
## Problem
Stop hook runs `npx tsc --noEmit ... 2>&1` and treats any non-empty output as a TypeScript error. npm prints warnings to stderr (e.g. `Unknown env config "verify_deps_before_run"`), which got merged into `OUT` and blocked session end even when the type-check was clean.

Reported by @claude-code in room-2026-05-22.

## Fix
Pipe tsc output through `grep -vE '^npm (warn|warning|notice|err!)'` before the emptiness check. Real `tsc` diagnostics start with file paths or `error TS...`, never with `npm `, so the filter is safe.

## Verification
On runtime/main HEAD:
```
$ OUT=$(npx tsc --noEmit --incremental --tsBuildInfoFile .tsbuildinfo 2>&1 | grep -vE '^npm (warn|warning|notice|err!)')
$ [ -z "$OUT" ] && echo CLEAN || echo ERRORS
CLEAN
```

Switch back to `2>&1` only and the npm warning reappears — confirming the filter is doing the right thing.

## Blast radius
One-line config change in `.claude/settings.json` Stop hook. No code/runtime impact. Restores Claude Code's ability to end sessions; real TS errors still surface (tail -30).