### PR TITLE
fix(pulse): gate P1 error-pattern emission on live resolvedAt (#539)

### DIFF
--- a/src/pulse.ts
+++ b/src/pulse.ts
@@ -147,6 +147,25 @@ interface PulseState {
   lastSkillUpdateMtime?: number;
 }
 
+type LiveErrorPattern = {
+  resolvedAt?: string;
+  lastSeen?: string;
+  lastSeenAt?: string;
+};
+
+export function isLiveErrorPatternResolved(pattern: LiveErrorPattern | undefined): boolean {
+  if (!pattern?.resolvedAt) return false;
+
+  const resolvedTs = Date.parse(pattern.resolvedAt);
+  if (!Number.isFinite(resolvedTs)) return false;
+
+  const seenAt = pattern.lastSeenAt ?? pattern.lastSeen;
+  if (!seenAt) return true;
+
+  const seenTs = Date.parse(seenAt);
+  return !Number.isFinite(seenTs) || seenTs <= resolvedTs;
+}
+
 // =============================================================================
 // Constants
 // =============================================================================
@@ -721,9 +740,23 @@ export async function computePulseMetrics(action: string | null, state: PulseSta
 
       let changed = false;
       const memory = getMemory();
+      const liveErrorPatterns = readJsonFile<Record<string, LiveErrorPattern>>(
+        getStatePath('error-patterns.json'),
+        {},
+      );
 
       for (const [key, count] of groups) {
         if (count < ERROR_PATTERN_THRESHOLD) continue;
+
+        if (isLiveErrorPatternResolved(liveErrorPatterns[key])) {
+          if (state.errorPatterns[key]) {
+            delete state.errorPatterns[key];
+            changed = true;
+          }
+          slog('PULSE', `Resolved error pattern skipped: ${key}`);
+          continue;
+        }
+
         metrics.recurringErrorCount++;
 
         // Protective subtypes (memory_guard / max_turns): guard mechanisms working as intended,

--- a/tests/pulse-error-patterns-resolved.test.ts
+++ b/tests/pulse-error-patterns-resolved.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { isLiveErrorPatternResolved } from '../src/pulse.js';
+
+describe('pulse error-pattern task gating', () => {
+  it('treats a bucket as resolved when lastSeenAt is not after resolvedAt', () => {
+    expect(isLiveErrorPatternResolved({
+      resolvedAt: '2026-05-22T00:07:51.000Z',
+      lastSeenAt: '2026-05-22T00:07:50.000Z',
+    })).toBe(true);
+  });
+
+  it('does not suppress a bucket that re-fired after resolvedAt', () => {
+    expect(isLiveErrorPatternResolved({
+      resolvedAt: '2026-05-22T00:07:51.000Z',
+      lastSeenAt: '2026-05-22T00:07:52.000Z',
+    })).toBe(false);
+  });
+
+  it('uses lastSeen day granularity for legacy buckets', () => {
+    expect(isLiveErrorPatternResolved({
+      resolvedAt: '2026-05-22T00:07:51.000Z',
+      lastSeen: '2026-05-22',
+    })).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- `buildErrorPatternTasks` now reads `error-patterns.json` each tick and skips P1 emission when the live bucket is resolved (resolvedAt set AND lastSeen ≤ resolvedAt).
- Stale internal `state.errorPatterns[key]` is dropped so the "修復重複錯誤" task stops being re-emitted every pulse cycle.
- New `isLiveErrorPatternResolved` helper handles both ISO `lastSeenAt` and the legacy day-granular `lastSeen` field.

Fixes #539 (best-effort variant from the issue's "ranked repairs").

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 138 files / 1148 passed / 2 skipped, including the 3 new cases in `tests/pulse-error-patterns-resolved.test.ts`
- [ ] Post-deploy: confirm `UNKNOWN:midband_no_diag::callClaude` does not re-emit a new P1 within 5 pulse cycles (issue falsifier)

## Notes
- Reopen rule (clear `resolvedAt` when `newLastSeen > resolvedAt`) and dangling-task GC for phantom RATE_LIMIT bucket are out of scope here; tracked as follow-ups in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)