### PR TITLE
fix(claude-code): git-safety hook checks cwd repo, not $CLAUDE_PROJECT_DIR

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -27,7 +27,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "INPUT=\"${TOOL_INPUT:-$(cat)}\"; if echo \"$INPUT\" | grep -qE 'git add (-A|--all|\\.)([^a-zA-Z0-9/]|$)'; then echo 'BLOCKED: 避免 git add -A/--all/. — 請逐檔明確 stage（CLAUDE.md Code & Deploy）' >&2; exit 2; fi; if echo \"$INPUT\" | grep -q -- '--no-verify'; then echo 'BLOCKED: 禁止 --no-verify，除非 Alex 明確要求（CLAUDE.md）' >&2; exit 2; fi; if echo \"$INPUT\" | grep -q 'git commit'; then BR=$(cd \"$CLAUDE_PROJECT_DIR\" 2>/dev/null && git branch --show-current 2>/dev/null); if [ \"$BR\" = 'runtime/main' ]; then echo 'BLOCKED: runtime/main 是部署鏡像分支，commit 會被 runtime autocorrect 洗掉。請改用 scripts/forge-lite.sh create <name> 走 worktree → PR（見 memory project_runtime_main_volatile）' >&2; exit 2; fi; fi",
+            "command": "INPUT=\"${TOOL_INPUT:-$(cat)}\"; if echo \"$INPUT\" | grep -qE 'git add (-A|--all|\\.)([^a-zA-Z0-9/]|$)'; then echo 'BLOCKED: 避免 git add -A/--all/. — 請逐檔明確 stage（CLAUDE.md Code & Deploy）' >&2; exit 2; fi; if echo \"$INPUT\" | grep -q -- '--no-verify'; then echo 'BLOCKED: 禁止 --no-verify，除非 Alex 明確要求（CLAUDE.md）' >&2; exit 2; fi; if echo \"$INPUT\" | grep -q 'git commit'; then BR=$(git branch --show-current 2>/dev/null); RR=$(git rev-parse --show-toplevel 2>/dev/null); if [ \"$BR\" = 'runtime/main' ] && [ \"$RR\" = \"$CLAUDE_PROJECT_DIR\" ]; then echo 'BLOCKED: runtime/main 是部署鏡像分支，commit 會被 runtime autocorrect 洗掉。請改用 scripts/forge-lite.sh create <name> 走 worktree → PR（見 memory project_runtime_main_volatile）' >&2; exit 2; fi; fi",
             "statusMessage": "檢查 git 安全規則…"
           },
           {


### PR DESCRIPTION
## Summary
- claude-code reported false positive: working in another repo (e.g. `knowledge-graph`) on a runtime/main-ish branch triggered the git-safety hook, because the hook always queried `$CLAUDE_PROJECT_DIR` (= mini-agent) instead of cwd's actual repo.
- Fix: read cwd's branch directly via `git branch --show-current`, AND require `git rev-parse --show-toplevel` == `$CLAUDE_PROJECT_DIR` before blocking. This narrows the guard to "you are in mini-agent's main checkout AND on runtime/main" — exactly the original intent.

## Verification
- Before/after both branches of the conditional verified with a synthetic shell harness (see commit message). Mini-agent's runtime/main still blocks; non-mini-agent repos on their own runtime/main no longer collateral-block.
- JSON validity preserved (re-parsed with `python3 json.loads`).
- Diff is a single-line surgical edit inside one hook command.

## Test plan
- [ ] On knowledge-graph repo's `feature/*` branch, `git commit` works (was already fine).
- [ ] On knowledge-graph repo's own `runtime/main` (if any), `git commit` is no longer blocked by mini-agent's hook.
- [ ] On mini-agent's `runtime/main`, `git commit` is still blocked (regression check).
- [ ] On mini-agent forge worktree feature branch, `git commit` works.

Reported-by: @claude-code (kuro room, 2026-05-22T08:27Z)