### PR TITLE
fix(scheduler): 6h TTL drop for stale Alex-chat-derived tasks (#567)

### DIFF
--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -89,6 +89,7 @@ export interface SchedulerPolicy {
 const ATTENTION_BUDGET = 15;
 const DISCOVERY_INTERVAL = 10;
 const AGING_BOOST_TICKS = 30;
+export const ALEX_CHAT_DERIVED_TASK_TTL_MS = 6 * 60 * 60 * 1000;
 
 /**
  * Reason tag for the creative-trunk fairness floor. The discovery slot is a
@@ -529,6 +530,11 @@ export function schedulerPick(
   const tasks: TaskSnapshot[] = entries.map(entryToSnapshot)
     .filter(t => {
       const entry = entriesById.get(t.id);
+      if (!entry || !completeExpiredAlexChatDerivedTask(memoryDir, entry)) return true;
+      return false;
+    })
+    .filter(t => {
+      const entry = entriesById.get(t.id);
       if (!entry || !isStaleMiddlewareTriageTask(entry)) return true;
       completeStaleMiddlewareTriageTask(memoryDir, entry);
       return false;
@@ -736,6 +742,34 @@ function isStaleMiddlewareTriageTask(entry: MemoryIndexEntry): boolean {
     && String(entry.summary ?? '').startsWith('Triage middleware failed task ')
     && Number.isFinite(ticks)
     && ticks > STALE_MIDDLEWARE_TRIAGE_TICKS;
+}
+
+function completeExpiredAlexChatDerivedTask(memoryDir: string, entry: MemoryIndexEntry, nowMs = Date.now()): boolean {
+  const payload = (entry.payload ?? {}) as Record<string, unknown>;
+  if (entry.source !== 'room') return false;
+  if (payload.from !== 'alex') return false;
+
+  const createdAt = typeof payload.created === 'string' ? payload.created : entry.ts;
+  const createdMs = new Date(createdAt).getTime();
+  if (!Number.isFinite(createdMs)) return false;
+  if (nowMs - createdMs < ALEX_CHAT_DERIVED_TASK_TTL_MS) return false;
+
+  updateMemoryIndexEntrySync(memoryDir, entry.id, {
+    status: 'completed',
+    payload: {
+      ...payload,
+      completed_by: 'alex-chat-derived-ttl',
+      completed_at: new Date(nowMs).toISOString(),
+      ttl_ms: ALEX_CHAT_DERIVED_TASK_TTL_MS,
+    },
+  });
+  slog('SCHED', `alex-chat-ttl: completed stale room task=${entry.id.slice(0, 12)} ${String(entry.summary ?? '').slice(0, 50)}`);
+  eventBus.emit('action:scheduler', {
+    event: 'alex-chat-derived-task-ttl',
+    taskId: entry.id,
+    ts: new Date(nowMs).toISOString(),
+  });
+  return true;
 }
 
 function completeStaleMiddlewareTriageTask(memoryDir: string, entry: MemoryIndexEntry): void {

--- a/tests/scheduler-alex-chat-ttl.test.ts
+++ b/tests/scheduler-alex-chat-ttl.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Scheduler Alex-chat task TTL — GitHub issue #567.
+ *
+ * Alex room messages are promoted to high-priority scheduler tasks. Once the
+ * referenced work has shipped, they can otherwise refeed forever because there
+ * is no artifact-specific resolver for arbitrary chat text.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  appendMemoryIndexEntry,
+  invalidateIndexCache,
+  queryMemoryIndexSync,
+} from '../src/memory-index.js';
+import {
+  ALEX_CHAT_DERIVED_TASK_TTL_MS,
+  resetCurrentTask,
+  resetSchedulerStateForTest,
+  schedulerPick,
+} from '../src/scheduler.js';
+
+let tmpDir: string;
+const now = new Date('2026-05-22T18:00:00.000Z');
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'scheduler-alex-chat-ttl-'));
+  invalidateIndexCache();
+  resetCurrentTask();
+  resetSchedulerStateForTest();
+  vi.setSystemTime(now);
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  invalidateIndexCache();
+  resetCurrentTask();
+  resetSchedulerStateForTest();
+  vi.useRealTimers();
+});
+
+function isoBefore(ms: number): string {
+  return new Date(now.getTime() - ms).toISOString();
+}
+
+describe('scheduler Alex-chat-derived task TTL', () => {
+  it('completes expired Alex room tasks before stack ranking can refeed them', async () => {
+    const task = await appendMemoryIndexEntry(tmpDir, {
+      type: 'task',
+      status: 'pending',
+      source: 'room',
+      summary: '@kuro PR #556 等 review',
+      ts: isoBefore(ALEX_CHAT_DERIVED_TASK_TTL_MS + 1_000),
+      payload: {
+        priority: 0,
+        from: 'alex',
+        roomMsgId: 'room-old',
+        intent: 'execute',
+      },
+    });
+    invalidateIndexCache();
+
+    const decision = schedulerPick(tmpDir, [{ source: 'heartbeat', priority: 3, isAlexDirectMessage: false }]);
+    invalidateIndexCache();
+
+    expect(decision.taskId).toBeNull();
+    const after = queryMemoryIndexSync(tmpDir, { id: task.id, limit: 1 })[0];
+    expect(after.status).toBe('completed');
+    expect((after.payload as Record<string, unknown>).completed_by).toBe('alex-chat-derived-ttl');
+  });
+
+  it('keeps fresh Alex room tasks schedulable', async () => {
+    const task = await appendMemoryIndexEntry(tmpDir, {
+      type: 'task',
+      status: 'pending',
+      source: 'room',
+      summary: '@kuro fresh direct request',
+      ts: isoBefore(ALEX_CHAT_DERIVED_TASK_TTL_MS - 60_000),
+      payload: {
+        priority: 0,
+        from: 'alex',
+        roomMsgId: 'room-fresh',
+        intent: 'execute',
+      },
+    });
+    invalidateIndexCache();
+
+    const decision = schedulerPick(tmpDir, []);
+
+    expect(decision.taskId).toBe(task.id);
+  });
+
+  it('does not TTL non-Alex room tasks', async () => {
+    const task = await appendMemoryIndexEntry(tmpDir, {
+      type: 'task',
+      status: 'pending',
+      source: 'room',
+      summary: '@kuro reviewer follow-up from another agent',
+      ts: isoBefore(ALEX_CHAT_DERIVED_TASK_TTL_MS + 1_000),
+      payload: {
+        priority: 0,
+        from: 'claude',
+        roomMsgId: 'room-reviewer',
+        intent: 'execute',
+      },
+    });
+    invalidateIndexCache();
+
+    const decision = schedulerPick(tmpDir, []);
+
+    expect(decision.taskId).toBe(task.id);
+    const after = queryMemoryIndexSync(tmpDir, { id: task.id, limit: 1 })[0];
+    expect(after.status).toBe('pending');
+  });
+});


### PR DESCRIPTION
## Summary
- Add 6h hard TTL on Alex-chat-derived (`source=room`, `payload.from=alex`) scheduler tasks; when expired, mark `completed_by=alex-chat-derived-ttl` and drop before stack ranking
- Emit `action:scheduler` event `alex-chat-derived-task-ttl` for observability
- New test file `tests/scheduler-alex-chat-ttl.test.ts` — 3 cases (expired → drop, fresh → keep, non-Alex room → untouched)

## Why Option 3
Issue #567 lists 3 repair candidates. kuro-agent's follow-up comment shows the 4th refeed instance is a diagnosis chat with no PR number and no file artifact — only Option 3 (TTL) covers all 4 observed instances. Options 1 / 2 can layer on later for slow-but-real tasks if needed.

## Falsifier
From the issue: if the 4 chat-derived P0s appear in scheduler `activeTasks` after 2026-05-22T18:00Z without manual close, the repair didn't ship.

## Test plan
- [x] `gh issue view 567 --repo miles990/mini-agent --json state,title,labels` returns the open bug
- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 1157 passed (3 new)
- [ ] After merge, observe next scheduler cycle drops the 4 stale Alex P0s

Closes #567

🤖 Generated with [Claude Code](https://claude.com/claude-code)