### PR TITLE
fix(self-healing): drop Triage tasks with no actionable failure payload (#570)

### DIFF
--- a/src/middleware-failure-self-healing.ts
+++ b/src/middleware-failure-self-healing.ts
@@ -172,10 +172,18 @@ export async function classifyMiddlewareFailures(
       delegationStatus = 'needs_human';
       lifecycleAction = 'recover-lane';
       resolution = `${resolution}; created lane recovery follow-up ${followUpTaskId}`;
-    } else if (bucket === 'workspace-isolation' || bucket === 'other') {
+    } else if (bucket === 'workspace-isolation') {
       followUpTaskId = await ensureMiddlewareFailureFollowUpTask(memoryDir, bucket, task, now);
-      lifecycleAction = bucket === 'workspace-isolation' ? 'repair-workspace' : 'triage';
+      lifecycleAction = 'repair-workspace';
       resolution = `${resolution}; created repair follow-up ${followUpTaskId}`;
+    } else if (bucket === 'other') {
+      if (hasActionableTriageExcerpt(task.task ?? '')) {
+        followUpTaskId = await ensureMiddlewareFailureFollowUpTask(memoryDir, bucket, task, now);
+        resolution = `${resolution}; created repair follow-up ${followUpTaskId}`;
+      } else {
+        slog('MIDDLEWARE-SELF-HEAL', `dropped_invalid_excerpt task=${taskId} bucket=${bucket}`);
+        resolution = `${resolution}; dropped_invalid_excerpt: failed_task_excerpt has no stderr, exit code, or diag block`;
+      }
     } else if (bucket === 'cancelled') {
       lifecycleAction = 'terminal-cancelled';
       resolution = `${resolution}; user/system cancellation treated as terminal unless it recurs`;
@@ -219,6 +227,7 @@ async function upgradeMissingFailurePlaybook(
   if (existing.followUpTaskId) return false;
   if (existing.bucket === 'cancelled') return false;
   if (existing.bucket === 'max-turns' && isTerminalBrainMaxTurnTask(task)) return false;
+  if (existing.bucket === 'other' && !hasActionableTriageExcerpt(task.task ?? '')) return false;
 
   const followUpTaskId = await ensureMiddlewareFailureFollowUpTask(memoryDir, existing.bucket, task, now);
   appendMiddlewareFailureClassification(memoryDir, {
@@ -812,6 +821,13 @@ function middlewareFailureRepairPlan(
 
 function compactTaskText(task: string): string {
   return String(task).replace(/\s+/g, ' ').trim().slice(0, 1200);
+}
+
+function hasActionableTriageExcerpt(excerpt: string): boolean {
+  const text = String(excerpt);
+  return /(?:^|\n)\s*stderr\s*[:=]\s*\S/im.test(text)
+    || /\b(?:exit(?:ed)?(?:\s+with)?(?:\s+code)?|code)\s*[=:]?\s*\d+\b/i.test(text)
+    || /(?:^|\n)\s*(?:diag|diagnostic|diagnostics)(?:\s+block)?\s*[:=]\s*\S/im.test(text);
 }
 
 function splitShellCommand(task: string): string[] | undefined {

--- a/tests/middleware-failure-self-healing.test.ts
+++ b/tests/middleware-failure-self-healing.test.ts
@@ -343,12 +343,37 @@ describe('middleware failure self-healing', () => {
       .toEqual(expect.objectContaining({ strategy: 'compressed-provider-resume' }));
   });
 
-  it('creates unknown middleware triage as P1, not scheduler-blocking P0', async () => {
+  it('drops unknown middleware triage when failed_task_excerpt has no failure payload', async () => {
     const result = await classifyMiddlewareFailures(memoryDir, [{
       id: 'task-unknown',
       worker: 'shell',
       status: 'failed',
       task: 'unexpected tool failure',
+      error: 'unrecognized failure shape',
+    }], new Date('2026-05-15T08:32:00.000Z'));
+
+    expect(result).toEqual(expect.objectContaining({ failed: 1, classified: 1 }));
+    const followUps = queryMemoryIndexSync(memoryDir, { type: ['task'], status: ['pending'] });
+    expect(followUps).toHaveLength(0);
+    const classification = readMiddlewareFailureClassificationsSync(memoryDir)[0];
+    expect(classification).toEqual(expect.objectContaining({
+      taskId: 'task-unknown',
+      bucket: 'other',
+    }));
+    expect(classification.followUpTaskId).toBeUndefined();
+    expect(readDelegationFailureRecordsSync(memoryDir)[0]).toEqual(expect.objectContaining({
+      taskId: 'task-unknown',
+      status: 'resolved',
+      resolution: expect.stringContaining('dropped_invalid_excerpt'),
+    }));
+  });
+
+  it('creates unknown middleware triage as P1 when failed_task_excerpt has stderr', async () => {
+    const result = await classifyMiddlewareFailures(memoryDir, [{
+      id: 'task-unknown',
+      worker: 'shell',
+      status: 'failed',
+      task: 'run deploy script\nstderr: permission denied while restarting service',
       error: 'unrecognized failure shape',
     }], new Date('2026-05-15T08:32:00.000Z'));
 


### PR DESCRIPTION
Closes #570

## Summary
- Self-healing emitter was creating phantom Triage tasks when `failed_task_excerpt` only captured caller system-prompt boilerplate (no actual failure payload). Emitter re-fired every ~4 minutes, stacking 11+ pending escalations during the 2026-06-03 CLI 403 outage.
- Add `hasActionableTriageExcerpt` guard: require **stderr line**, **exit-code marker** (`exit N`, `code=N`), or **diag block** before emitting a Triage follow-up for `bucket=other`.
- If none present → log `dropped_invalid_excerpt`, mark `resolved` with explanatory resolution, no follow-up task.
- Mirror guard in `upgradeMissingFailurePlaybook` so a previously-classified invalid excerpt cannot be upgraded into a follow-up later.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test` (1158 passed / 2 skipped)
- [x] New test: dropped excerpt path — no follow-up tasks, resolution contains `dropped_invalid_excerpt`
- [x] New test: excerpt with `stderr:` line — follow-up task still created (regression guard)

## Falsifier (from issue)
After deploy, the grep below should report 0 matches:
```
grep memory/state/middleware-events.jsonl \
  "origin=middleware-self-healing.*excerpt matches /^You are .Kuro/" \
  since:<post-merge>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)