### PR TITLE
feat(sdk-client): add silentMs+watchdog to abort errors (#573)

### DIFF
--- a/src/sdk-client.ts
+++ b/src/sdk-client.ts
@@ -220,6 +220,8 @@ export async function execClaudeViaSdk(
       setTimeout(() => {
         finish(Object.assign(new Error(`SDK query timeout after ${timeoutMs}ms`), {
           duration: Date.now() - startTs, timeoutMs, progressTimeoutMs, source,
+          silentMs: Date.now() - lastProgressTs,
+          watchdog: 'wall-clock' as const,
         }));
       }, 2000);
     }, timeoutMs);
@@ -230,6 +232,8 @@ export async function execClaudeViaSdk(
         setTimeout(() => {
           finish(Object.assign(new Error(`SDK query stalled — no progress for ${progressTimeoutMs}ms`), {
             duration: Date.now() - startTs, timeoutMs, progressTimeoutMs, source,
+            silentMs: Date.now() - lastProgressTs,
+            watchdog: 'silence' as const,
           }));
         }, 2000);
       }


### PR DESCRIPTION
Closes the diagnostic surface enumerated in [#573 comment 4610976345](https://github.com/miles990/mini-agent/issues/573#issuecomment-4610976345).

## What
4 LoC in `src/sdk-client.ts` (218-236). Both abort throws (wall-clock and silence) now carry:
- `silentMs = Date.now() - lastProgressTs`
- `watchdog: 'wall-clock' | 'silence'`

## Why
Today's 5 hits of `TIMEOUT:real_timeout::callClaude` all clustered at exactly `241196ms = 240000 + ~2000` grace. Without `silentMs`, we can't tell which watchdog fired first, which means we can't tell which knob to turn:

| Pattern | Diagnosis | Fix |
|---|---|---|
| `silentMs >= 240000` | silence fired — no observable progress events in window | count thinking / partial tool_use as progress, or raise `progressTimeoutMs` independently |
| `silentMs <  240000` | wall-clock fired — Claude making progress but out of budget | raise `timeoutMs` |

PR #544 aligned the two timeouts at the same value (correct geometry). 240s being too low for today's 31KB-prompt workload is a separate (and so-far indistinguishable) failure mode.

## Risk
Zero behavioral change on green runs — these fields only attach to the error object. No new imports. `lastProgressTs` is already in scope (line 253 mutates it on every `sdk-message`).

## Verification
- `grep -n 'silentMs\|watchdog:' src/sdk-client.ts` → 4 hits at lines 223, 224, 235, 236 ✓
- Next `TIMEOUT:real_timeout::callClaude` event will carry `silentMs=Nms watchdog=W` once the message template propagates them

## Followup (not this PR)
- Wire `silentMs` and `watchdog` into the `claude CLI TIMEOUT (...)` message template feeding `classifyErrorPattern`
- Sweeper bug: `lastSeenAt > resolvedAt` should re-open the pattern but `taskCreated: false` — same geometry as `midband_no_diag` (MEMORY 2026-05-22). Separate issue if no existing one covers it.

— Kuro (kuro-agent) cycle 03bbc29a