### PR TITLE
fix(feedback-loops): clear resolvedAt when bucket re-fires (#576)

### DIFF
--- a/src/feedback-loops.ts
+++ b/src/feedback-loops.ts
@@ -44,6 +44,8 @@ interface ErrorPatternState {
     lastMessage?: string;
     resolvedAt?: string;
     resolvedBy?: string;
+    staleResolvedAt?: string;
+    staleResolvedBy?: string | null;
   };
 }
 
@@ -581,6 +583,12 @@ export async function detectErrorPatterns(): Promise<void> {
 
     const existing = state[key];
     if (existing) {
+      if (existing.resolvedAt && latestTs && latestTs > existing.resolvedAt) {
+        existing.staleResolvedAt = existing.resolvedAt;
+        existing.staleResolvedBy = existing.resolvedBy ?? null;
+        delete existing.resolvedAt;
+        delete existing.resolvedBy;
+      }
       existing.count = count;
       existing.lastSeen = today;
       if (sampleMsg) existing.lastMessage = sampleMsg;

--- a/tests/feedback-loops-error-patterns-resolution.test.ts
+++ b/tests/feedback-loops-error-patterns-resolution.test.ts
@@ -18,6 +18,9 @@ import path from 'node:path';
 
 let tmpStateDir: string;
 const stateFile = () => path.join(tmpStateDir, 'error-patterns.json');
+const mocks = vi.hoisted(() => ({
+  queryErrorLogs: vi.fn(),
+}));
 
 vi.mock('../src/memory.js', () => ({
   getMemoryStateDir: () => tmpStateDir,
@@ -30,7 +33,12 @@ vi.mock('../src/utils.js', async (importOriginal) => {
   return { ...actual, slog: () => {} };
 });
 
+vi.mock('../src/logging.js', () => ({
+  getLogger: () => ({ queryErrorLogs: mocks.queryErrorLogs }),
+}));
+
 import {
+  detectErrorPatterns,
   readState,
   writeState,
   flushFeedbackState,
@@ -44,6 +52,8 @@ type ErrorPattern = {
   lastMessage?: string;
   resolvedAt?: string;
   resolvedBy?: string;
+  staleResolvedAt?: string;
+  staleResolvedBy?: string | null;
 };
 type State = Record<string, ErrorPattern>;
 
@@ -60,11 +70,15 @@ function bumpMtime(filePath: string, deltaMs = 1000): void {
 }
 
 beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-06-03T12:00:00.000Z'));
   tmpStateDir = mkdtempSync(path.join(tmpdir(), 'fb-loops-422-'));
+  mocks.queryErrorLogs.mockReset();
   _resetFeedbackStateCacheForTests();
 });
 
 afterEach(() => {
+  vi.useRealTimers();
   rmSync(tmpStateDir, { recursive: true, force: true });
 });
 
@@ -170,5 +184,44 @@ describe('issue #422 — error-patterns resolvedAt strip', () => {
     // And it must still be on disk identically.
     const disk = JSON.parse(readFileSync(stateFile(), 'utf-8')) as State;
     expect(disk['X:Y::Z'].count).toBe(5);
+  });
+
+  it('detectErrorPatterns clears resolvedAt when an existing bucket re-fires after resolution', async () => {
+    const key = 'TIMEOUT:real_timeout::callClaude';
+    writeStateFileDirect({
+      [key]: {
+        count: 5,
+        taskCreated: false,
+        lastSeen: '2026-05-22',
+        resolvedAt: '2026-05-22T05:23:17.000Z',
+        resolvedBy: 'abc123',
+      },
+    });
+
+    mocks.queryErrorLogs.mockReturnValue([
+      {
+        timestamp: '2026-06-03T09:27:00.000Z',
+        data: { context: 'callClaude', error: 'TIMEOUT took too long' },
+      },
+      {
+        timestamp: '2026-06-03T09:28:00.000Z',
+        data: { context: 'callClaude', error: 'TIMEOUT took too long' },
+      },
+      {
+        timestamp: '2026-06-03T09:29:00.000Z',
+        data: { context: 'callClaude', error: 'TIMEOUT took too long' },
+      },
+    ]);
+
+    await detectErrorPatterns();
+    flushFeedbackState();
+
+    const onDisk = JSON.parse(readFileSync(stateFile(), 'utf-8')) as State;
+    expect(onDisk[key].resolvedAt).toBeUndefined();
+    expect(onDisk[key].resolvedBy).toBeUndefined();
+    expect(onDisk[key].staleResolvedAt).toBe('2026-05-22T05:23:17.000Z');
+    expect(onDisk[key].staleResolvedBy).toBe('abc123');
+    expect(onDisk[key].lastSeen).toBe('2026-06-03');
+    expect(onDisk[key].lastSeenAt).toBe('2026-06-03T09:29:00.000Z');
   });
 });


### PR DESCRIPTION
## Summary
- Adds re-fire clear in `detectErrorPatterns` existing-entry branch (`src/feedback-loops.ts:585-590`)
- When `latestTs > existing.resolvedAt`, archives resolution into `staleResolvedAt`/`staleResolvedBy` and clears `resolvedAt`/`resolvedBy`
- `pulse.ts buildErrorPatternTasks` already-correct `!resolvedAt` guard now re-emits P1 naturally; no second patch needed

## Why
3 stale entries currently sit invisibly in `error-patterns.json` with `lastSeen > resolvedAt` but resolved-flag still set, exactly the geometry #539's inverse blind spot:
- `UNKNOWN:transient_fast_band::callClaude` (count 10, last 2026-05-11)
- `UNKNOWN:transient_slow_band::callClaude` (count 4, last 2026-05-21)
- `TIMEOUT:real_timeout::callClaude` (count 5, last 2026-06-03 — actively re-firing)

## Verification
- `pnpm test tests/feedback-loops-error-patterns-resolution.test.ts` → 4/4 pass (new test covers the re-fire case end-to-end via `detectErrorPatterns` with mocked logger)
- Falsifier (post-deploy): `jq -r 'to_entries[] | select(.value.resolvedAt and .value.lastSeenAt > .value.resolvedAt)' /Users/user/Workspace/mini-agent-memory/memory/state/error-patterns.json` returns 0 entries within next sweep cycle

Closes #576

🤖 Generated with [Claude Code](https://claude.com/claude-code)