### PR TITLE
fix(agent): attach silentMs/watchdog to CLI reject (#573)

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -1110,7 +1110,9 @@ async function execClaude(fullPrompt: string, opts?: ExecOptions): Promise<strin
       } catch { /* fail-open */ }
 
       if (code !== 0 && !resultText) {
-        reject(Object.assign(new Error(`Claude CLI exited with code ${code}`), { stderr, stdout: resultText, status: code, killed: timedOut, signal, duration, timeoutMs: TIMEOUT_MS, toolCallCount, exitReason }));
+        const rejectSilentMs = Date.now() - lastStdoutDataTs;
+        const rejectWatchdog = killReason || exitReason;
+        reject(Object.assign(new Error(`Claude CLI exited with code ${code}`), { stderr, stdout: resultText, status: code, killed: timedOut, signal, duration, timeoutMs: TIMEOUT_MS, toolCallCount, exitReason, silentMs: rejectSilentMs, watchdog: rejectWatchdog }));
       } else {
         // Fallback: if resultText is empty but we received text blocks during streaming,
         // reconstruct from allTextBlocks. Claude CLI 2.x stream-json may return empty


### PR DESCRIPTION
## Summary
- Attach `silentMs` (= `Date.now() - lastStdoutDataTs`) and `watchdog` (= `killReason || exitReason`) to the rejected `Error` at `src/agent.ts:1113`
- `formatProviderWatchdogDiagnostic` (line 285) reads these fields to build the `silentMs=N, watchdog=Y` suffix that the retry wrapper (line 2031) writes into `error-patterns.json.lastMessage`
- Without this, post-PR-575 occurrences (10:29 / 10:35 / 11:07Z on 2026-06-03) had no `silentMs=` / `watchdog=` in `lastMessage` despite real timeouts — the patrol pattern-matcher couldn't differentiate progress-timeout vs hard-timeout vs external kill

## Test plan
- [ ] Merge + soak ~6 hours
- [ ] Inspect next `TIMEOUT:*::callClaude` entry in `~/Workspace/mini-agent-memory/memory/state/error-patterns.json` — its `lastMessage` should now contain `silentMs=` and (when applicable) `watchdog=`
- [ ] Falsifier (negative): if any new `TIMEOUT:*::callClaude` entry post-merge still lacks `silentMs=`, the code path bypasses this reject and a different rejector needs the same treatment

Refs miles990/mini-agent#573