### PR TITLE
fix(agent): propagate silentMs/watchdog into callClaude reject payloads

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -880,6 +880,7 @@ async function execClaude(fullPrompt: string, opts?: ExecOptions): Promise<strin
             slog('CLAUDE', `Force-resolve: close event not received 10s after SIGKILL (pid ${child.pid}), elapsed=${(duration / 1000).toFixed(1)}s`);
             reject(Object.assign(new Error('Claude CLI force-resolved: close event timeout after SIGKILL'), {
               stderr, stdout: resultText, status: null, killed: true, signal: 'SIGKILL', duration, timeoutMs: TIMEOUT_MS,
+              silentMs: Date.now() - lastStdoutDataTs, watchdog: killReason || 'force-resolve',
             }));
           }
         }, 10_000);
@@ -1110,7 +1111,7 @@ async function execClaude(fullPrompt: string, opts?: ExecOptions): Promise<strin
       } catch { /* fail-open */ }
 
       if (code !== 0 && !resultText) {
-        reject(Object.assign(new Error(`Claude CLI exited with code ${code}`), { stderr, stdout: resultText, status: code, killed: timedOut, signal, duration, timeoutMs: TIMEOUT_MS, toolCallCount, exitReason }));
+        reject(Object.assign(new Error(`Claude CLI exited with code ${code}`), { stderr, stdout: resultText, status: code, killed: timedOut, signal, duration, timeoutMs: TIMEOUT_MS, toolCallCount, exitReason, silentMs: Date.now() - lastStdoutDataTs, watchdog: killReason || exitReason || null }));
       } else {
         // Fallback: if resultText is empty but we received text blocks during streaming,
         // reconstruct from allTextBlocks. Claude CLI 2.x stream-json may return empty


### PR DESCRIPTION
## Summary
- Both reject sites in `execClaude` were dropping `silentMs` + `killReason` before `formatProviderWatchdogDiagnostic` could read them, so error logs were missing the watchdog suffix.
- This patch surfaces the watchdog mode (`hard` / `progress` / `force-resolve`) on every CLI timeout — making `TIMEOUT:real_timeout::callClaude` directly diagnosable.

## Why now
Today (2026-06-03) the pattern fired **8× in 3 hours** (08:11–11:07Z) with prompts at 32K chars (well under the 40K hard cap). Every `lastMessage` in `error-patterns.json` ends with `…, loop lane): …` — no watchdog signal, no silentMs. Impossible to tell from the field whether it's progress-timeout starvation, hard-timeout overflow, or force-resolve stuck-close.

## Sites patched
- `src/agent.ts:1113` — exit-handler reject (hot path for timed-out CLI)
- `src/agent.ts:882` — force-resolve safety net (SIGKILL→close stuck >10s)

## Test plan
- [ ] After merge, next `TIMEOUT:real_timeout::callClaude` occurrence in `error-patterns.json` has `lastMessage` containing `, silentMs=` AND (`, watchdog=hard` OR `, watchdog=progress` OR `, watchdog=force-resolve`)
- [ ] If absent → patch ineffective / formatter regression
- [ ] No new TS errors introduced (verified locally — all existing tsc errors are pre-existing @types/node setup issues)

Related: #573 (loop-lane diagnostics gap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)