### PR TITLE
fix(feedback-loops): treat side_query_timeout as protective (#583)

### DIFF
--- a/src/feedback-loops.ts
+++ b/src/feedback-loops.ts
@@ -204,6 +204,10 @@ export const PROTECTIVE_SUBTYPES = new Set([
   // Issue #491: upstream Chinese-localized 400 rejection — structurally ungatable (fires on
   // attempt 1/3 before any window accumulates); re-fires are upstream events, not regressions.
   'upstream_quickreject_cn',
+  // Issue #583: sideQuery is fire-and-forget by design (src/side-query.ts:9-10); timeout is
+  // expected operating behavior, not a bug. Telemetry stays in error-patterns.json but the
+  // footer aggregator must not surface it as actionable recurring noise.
+  'side_query_timeout',
 ]);
 
 /**


### PR DESCRIPTION
Closes #583.

## Change
One entry added to `PROTECTIVE_SUBTYPES`: `side_query_timeout`.

## Why
`sideQuery` is fire-and-forget by design (src/side-query.ts:9-10). Caller contract returns null on any failure including timeout. The timeout path is correctly handled (SIGTERM child, settle null, continue). Logging via `logError` was correct for telemetry, but the recurring-errors footer aggregator (`prompt-builder.ts:432`) was surfacing the count as an actionable bug — driving 3+ cycles of "must fix the timeout handler" loops on a handler that wasn't broken.

`PROTECTIVE_SUBTYPES` already exists for this exact pattern (`sigterm_progress`, `budget_exceeded`, `upstream_quickreject_cn`, etc.) — telemetry preserved, noise suppressed.

## Test plan
- [ ] Next cycle's prompt footer "Recurring Errors" section no longer lists `TIMEOUT:side_query_timeout::sideQuery`
- [ ] `error-patterns.json` still increments the count (verify telemetry preserved)
- [ ] `real_timeout::callClaude` (21×) still shown — that one has no mitigationKind and may be a real bug; left for separate triage

Worktree: `mini-agent-worktrees/fix-timeouts`. Branch: `fix/timeout-handlers`.