### PR TITLE
fix(self-heal): bounded-shell-probe emits bash one-liner, not prose (#581 Patch A)

### DIFF
--- a/src/middleware-failure-self-healing.ts
+++ b/src/middleware-failure-self-healing.ts
@@ -747,6 +747,15 @@ function middlewareFailureRepairPlan(
   }
   if (bucket === 'stall-or-timeout') {
     const acceptance = 'The failed shell/task chain is split into bounded probes with checkpoints; no single silent step may run for 1800s again.';
+    const slices = splitShellCommand(task.task ?? '');
+    // ponytail: issue #581 — shell lane execs prompt literally; prose envelope = command-not-found storm.
+    // Emit a bash one-liner for shell; framing stays in acceptance/notes.
+    const shellOneLiner = (slices && slices[0]) || (task.task ?? '').trim() || ':';
+    const prosePrompt = [
+      'Break the failed work into bounded probes. Emit progress after each probe.',
+      'For shell commands, run each command slice separately and persist intermediate artifacts before continuing.',
+      excerpt,
+    ].filter(Boolean).join('\n\n');
     return {
       status: 'pending',
       summary: `Retry middleware ${worker} lane with bounded probes after timeout`,
@@ -754,18 +763,15 @@ function middlewareFailureRepairPlan(
       retryEnvelope: {
         strategy: worker === 'shell' ? 'bounded-shell-probe' : 'lane-recovery',
         worker,
-        prompt: [
-          'Break the failed work into bounded probes. Emit progress after each probe.',
-          'For shell commands, run each command slice separately and persist intermediate artifacts before continuing.',
-          excerpt,
-        ].filter(Boolean).join('\n\n'),
+        prompt: worker === 'shell' ? shellOneLiner : prosePrompt,
         acceptance,
         timeoutMs: 120_000,
         progressTimeoutMs: 60_000,
-        commandSlices: splitShellCommand(task.task ?? ''),
+        commandSlices: slices,
         notes: [
           'timeout/stall requires shorter probes and progress checkpoints, not a longer timeout',
           'only increase timeout after a probe proves the command is making progress',
+          ...(worker === 'shell' ? ['shell lane execs prompt literally; framing moved out to avoid command-not-found storm (#581)'] : []),
         ],
       },
     };

--- a/tests/middleware-failure-self-healing.test.ts
+++ b/tests/middleware-failure-self-healing.test.ts
@@ -548,6 +548,10 @@ describe('middleware failure self-healing', () => {
         'pnpm tsx scripts/kg-extract-entities.ts --write',
       ],
     }));
+    // #581: shell-lane prompt must be a bash one-liner, not the markdown framing
+    expect(followUps[0].payload?.retry_envelope?.prompt).toBe(
+      'pnpm tsx scripts/kg-extract-chunks.ts --write',
+    );
     expect(readDelegationFailureRecordsSync(memoryDir)[0]).toEqual(expect.objectContaining({
       taskId: 'task-timeout',
       status: 'needs_human',


### PR DESCRIPTION
Closes the Patch A scope of #581.

## What

When middleware-failure-self-healing classifies a failed shell task as `stall-or-timeout`, the retry envelope's `prompt` was a multi-line markdown document (## headings + prose explanation). The shell lane execs prompt literally → `Strategy:: command not found`, `Break: command not found`, etc. — the storm documented in the issue (cmt-1779415517902-0014).

Now: for `worker === 'shell'`, `prompt` = first `commandSlice` (a real bash one-liner). Framing stays in `acceptance` + `notes`. Non-shell workers still receive the prose prompt for LLM consumption.

## Why both patches

- **Patch A (this PR)** stops the *current* known caller from generating the prose envelope.
- **Patch B** ([miles990/agent-middleware#19](https://github.com/miles990/agent-middleware/pull/19)) is the dispatch-boundary guard that makes any *future* caller fail loudly with `shell_received_prose` instead of silently storming command-not-found.

Pair shipped → freq counter on `task-execution` stage stops flapping for this class.

## Test

Existing case `routes offline and timeout failures into bounded recovery instead of blind retry` extended with one assertion:

```ts
expect(followUps[0].payload?.retry_envelope?.prompt).toBe(
  'pnpm tsx scripts/kg-extract-chunks.ts --write',
);
```

```
✓ tests/middleware-failure-self-healing.test.ts (20 tests | 19 skipped) 48ms
```

## Falsifier (5 cycles after merge)

`grep -r 'Strategy:: command not found' agent-middleware/memory/state/` should stay at zero. If it reappears → a *different* caller is emitting prose to the shell lane; Patch B catches it as `shell_received_prose`.

— Filed by Kuro autonomous cycle.