### PR TITLE
fix(pulse): skip protective subtypes before existing-task short-circuit

### DIFF
--- a/src/pulse.ts
+++ b/src/pulse.ts
@@ -759,10 +759,17 @@ export async function computePulseMetrics(action: string | null, state: PulseSta
 
         metrics.recurringErrorCount++;
 
-        // Protective subtypes (memory_guard / max_turns): guard mechanisms working as intended,
-        // not bugs. Count but skip task creation — high frequency = pressure signal (log only).
+        // Protective subtypes (memory_guard / max_turns / side_query_timeout): guard mechanisms
+        // working as intended, not bugs. Skip BEFORE the existing-task short-circuit so subtypes
+        // promoted to protective after a task was already created (e.g. side_query_timeout) stop
+        // refreshing lastSeen and age out via the 7-day cleanup below.
         const subtype = key.split(':')[1] ?? '';
         const isProtective = PROTECTIVE_SUBTYPES.has(subtype);
+
+        if (isProtective) {
+          slog('PULSE', `Protective subtype ${key} (${count}×) — signal logged, no task (guard working)`);
+          continue;
+        }
 
         const existing = state.errorPatterns[key];
         if (existing?.taskCreated) {
@@ -774,11 +781,6 @@ export async function computePulseMetrics(action: string | null, state: PulseSta
 
         state.errorPatterns[key] = { count, taskCreated: true, lastSeen: today };
         changed = true;
-
-        if (isProtective) {
-          slog('PULSE', `Protective subtype ${key} (${count}×) — signal logged, no task (guard working)`);
-          continue;
-        }
 
         const [code, context] = key.split('::');
         const dueDate = new Date(Date.now() + 3 * 86400_000).toISOString().split('T')[0];


### PR DESCRIPTION
## Problem
Protective subtypes (`memory_guard` / `max_turns` / `side_query_timeout`) were checked **after** the existing-task short-circuit in `computePulseMetrics`. A subtype promoted to protective *after* its task was already created (e.g. `side_query_timeout`, classified in #583) hit the `existing?.taskCreated` branch first, refreshing `lastSeen` every cycle so it **never aged out** — producing the recurring phantom P1 tasks I keep seeing in HEARTBEAT (`TIMEOUT:side_query_timeout::sideQuery`, count=21, resolvedAt=null).

## Fix
Move the `isProtective` guard (`continue`) **ahead** of the existing-task short-circuit. Protective keys now bail before any state mutation, so stale entries age out via the existing 7-day cleanup (`pulse.ts:792`). Complements #583 (which only added the *classification*) — without this reorder the classification has no effect on already-created tasks.

## Verification
- `git diff`: +9/-7, single file `src/pulse.ts`, base = current `main` (one clean commit over `origin/main`).
- Logic: `PROTECTIVE_SUBTYPES` imported from feedback-loops; `continue` placed before `state.errorPatterns[key]` write; 7-day cleanup at `:792` reachable.
- Lands via main → runtime/main deploy promotion (not a hot-merge of the live runtime branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)