### PR TITLE
fix(auto-executor): bash one-liner retry-envelope + delegation phantom-gate bypass

### DIFF
--- a/src/auto-executor.ts
+++ b/src/auto-executor.ts
@@ -139,7 +139,10 @@ export function buildRetryEnvelopeDelegation(
   const acceptance = (topPayload.acceptance_criteria as string) ?? envelope.acceptance;
   const delegationId = `retry-${top.id.slice(0, 16).replace(/-+$/, '')}-${now}`;
 
-  const prompt = [
+  const shellCommand = envelope.worker === 'shell'
+    ? envelope.commandSlices?.map(slice => slice.trim()).filter(Boolean).join(' && ')
+    : undefined;
+  const prompt = shellCommand || [
     `## Retry Task: ${top.summary}`,
     '',
     `Task ID: ${top.id}`,

--- a/src/delegation.ts
+++ b/src/delegation.ts
@@ -177,6 +177,7 @@ const TYPE_DEFAULTS: Record<DelegationTaskType, { timeoutMs: number }> = {
   debug:    { timeoutMs: 300_000 },
   graphify: { timeoutMs: 600_000 },
 };
+const RAW_PROMPT_TYPES = new Set<DelegationTaskType>(['shell', 'graphify']);
 
 // P1-d edit-layer: always active (v2-final §6 — no flag, no dual path).
 
@@ -260,7 +261,7 @@ export function spawnDelegation(task: DelegationTask): string {
 
   // Layer 1 phantom-prompt gate (issue #141): reject thin prompts pre-dispatch.
   // Spec pinned by tests/delegation-phantom-prompt.test.ts.
-  if (isPhantomPrompt(task.prompt)) {
+  if (!RAW_PROMPT_TYPES.has(taskType) && isPhantomPrompt(task.prompt)) {
     const preview = (task.prompt ?? '').trim().slice(0, 60);
     slog(
       'DELEGATION',
@@ -503,13 +504,11 @@ function buildBrainRequestForDelegation(entry: ActiveEntry, cwd: string, timeout
     entry.task.context,
     entry.task.acceptance ? `Acceptance: ${entry.task.acceptance}` : undefined,
   ].filter(Boolean).join('\n\n');
-  const rawPromptTypes = new Set<DelegationTaskType>(['shell', 'graphify']);
-
   return {
     taskId: entry.result.id,
     source: 'background',
     intent: workItem.intent,
-    prompt: rawPromptTypes.has(taskType)
+    prompt: RAW_PROMPT_TYPES.has(taskType)
       ? entry.task.prompt
       : [context, entry.task.prompt].filter(Boolean).join('\n\n'),
     systemPrompt: 'You are running as a mini-agent delegated brain provider. Return the requested result with concise evidence.',

--- a/src/middleware-failure-self-healing.ts
+++ b/src/middleware-failure-self-healing.ts
@@ -836,7 +836,7 @@ function splitShellCommand(task: string): string[] | undefined {
     .map(part => part.trim())
     .filter(Boolean)
     .slice(0, 8);
-  return slices.length > 1 ? slices : undefined;
+  return slices.length > 0 ? slices : undefined;
 }
 
 function isTerminalBrainMaxTurnTask(task: MiddlewareTaskRecord): boolean {

--- a/tests/auto-executor.test.ts
+++ b/tests/auto-executor.test.ts
@@ -104,6 +104,10 @@ describe('auto executor task routing', () => {
       acceptance: 'No single silent step may run for 1800s again.',
       timeoutMs: 120_000,
       progressTimeoutMs: 60_000,
+      commandSlices: [
+        'cd /Users/user/Workspace/mini-agent',
+        'pnpm tsx scripts/kg-extract-entities.ts --write --limit 100',
+      ],
       notes: [],
     };
 
@@ -114,6 +118,11 @@ describe('auto executor task routing', () => {
 
     const delegation = buildRetryEnvelopeDelegation(task, envelope);
     expect(delegation.type).toBe('shell');
+    expect(delegation.prompt).toBe(
+      'cd /Users/user/Workspace/mini-agent && pnpm tsx scripts/kg-extract-entities.ts --write --limit 100',
+    );
+    expect(delegation.prompt).not.toContain('## Retry Task:');
+    expect(delegation.prompt).not.toContain('Strategy: bounded-shell-probe');
     expect(delegation.progressTimeoutMs).toBe(60_000);
   });
 });

--- a/tests/middleware-failure-self-healing.test.ts
+++ b/tests/middleware-failure-self-healing.test.ts
@@ -554,6 +554,24 @@ describe('middleware failure self-healing', () => {
     }));
   });
 
+  it('keeps single shell timeout commands as executable bounded probe slices', async () => {
+    await classifyMiddlewareFailures(memoryDir, [{
+      id: 'task-single-timeout',
+      worker: 'shell',
+      status: 'failed',
+      task: 'pnpm tsx scripts/kg-extract-entities.ts --write --limit 100',
+      error: 'Worker stall: no activity timeout',
+    }], new Date('2026-05-06T16:30:00.000Z'));
+
+    const followUps = queryMemoryIndexSync(memoryDir, { type: ['task'], status: ['pending'] });
+    expect(followUps[0].payload?.retry_envelope).toEqual(expect.objectContaining({
+      strategy: 'bounded-shell-probe',
+      commandSlices: [
+        'pnpm tsx scripts/kg-extract-entities.ts --write --limit 100',
+      ],
+    }));
+  });
+
   it('closes historical offline delegation failures once middleware is reachable again', async () => {
     await classifyMiddlewareFailures(memoryDir, [{
       id: 'task-offline',


### PR DESCRIPTION
## Why

Complements miles990/mini-agent#585 (self-healing+pulse layer). #585 patches the generator path; this patches the **auto-executor retry-envelope** path and the **delegation.ts phantom-gate bypass** — without the bypass, bare bash one-liners get rejected as thin prompts before retry.

## What
- auto-executor: retry-envelope for bash one-liner produced by generator
- delegation: phantom-gate bypass for known-good one-liner shape

## Verification
- 3 affected vitest suites: **32 passed** (run locally pre-push)
- Commit `c7531bc9` carried forward from prior worktree (WT 12cdcd5d), parent = current miles990/mini-agent main → clean diff, zero conflict

## Provenance
- author: kuro-agent (Kuro autonomous agent)
- triage notes: \`.kuro-wt-12cdcd5d-triage.md\`, \`.kuro-wt-55668c37-triage.md\` (local)
- complements: #585