### PR TITLE
fix(autonomy-closure): resume consensus after PR evidence auto-repair

### DIFF
--- a/src/autonomy-closure-diagnostics.ts
+++ b/src/autonomy-closure-diagnostics.ts
@@ -6,7 +6,7 @@ import {
   type AutonomyClosureStageResult,
 } from './autonomy-closure-health.js';
 import { snapshotCuratedMemoryChanges } from './external-memory-health.js';
-import { autoRepairPrVerificationEvidence, githubAutoActions } from './github.js';
+import { autoRepairPrVerificationEvidenceAndResumeConsensus, githubAutoActions } from './github.js';
 import { slog } from './utils.js';
 
 export type AutonomyClosureMechanicalAction =
@@ -52,7 +52,7 @@ export async function diagnoseAndRepairAutonomyClosure(
 
   for (const diagnostic of cases) {
     if (diagnostic.mechanicalAction === 'repair-pr-verification-evidence') {
-      await autoRepairPrVerificationEvidence();
+      await autoRepairPrVerificationEvidenceAndResumeConsensus();
       actionsRun.push(diagnostic.mechanicalAction);
       continue;
     }

--- a/src/github.ts
+++ b/src/github.ts
@@ -662,6 +662,16 @@ export async function autoRepairPrVerificationEvidence(): Promise<void> {
   }
 }
 
+export async function autoRepairPrVerificationEvidenceAndResumeConsensus(): Promise<void> {
+  if (!await ghAvailable()) return;
+
+  await autoRepairPrVerificationEvidence();
+  await autoProduceInternalPrReviewClaims();
+  await autoTrackPrReviewConsensus();
+  await autoApplyInternalPrReviewConsensus();
+  await autoMergeInternallyApprovedPR();
+}
+
 async function viewPullRequest(prNumber: number): Promise<GhPrView | null> {
   try {
     const { stdout } = await gh(['pr', 'view', String(prNumber), '--json', 'number,title,body,headRefOid,labels,files,isDraft,reviewDecision,baseRefName,mergeable,url']);


### PR DESCRIPTION
## Summary
- Add `autoRepairPrVerificationEvidenceAndResumeConsensus()` wrapper that runs evidence-repair → produce-claims → track-consensus → apply-consensus → merge in one shot.
- Wire it into the `repair-pr-verification-evidence` diagnostic branch so the closure stage self-heals in one OODA cycle instead of waiting for the next pulse.

## Why
`autonomy-closure-diagnostics` was repairing the PR body but leaving claim/consensus/merge for a later cycle. This bundles the follow-through so the diagnostic action actually completes the closure transition.

## Verification
- `pnpm check:autonomy-closure -- --json` → exit 0
- Diff: +12 / -2 across 2 files, no behavior change for the `github-autopilot` branch (which already runs the full pipeline via `githubAutoActions`).

## Test plan
- [x] Verify command exits 0
- [ ] Next pulse confirms `pr-review-consensus` stage clears warn after evidence repair

🤖 Generated with [Claude Code](https://claude.com/claude-code)