### PR TITLE
feat(delegation): reject prose-shaped shell prompts at dispatch boundary

### DIFF
--- a/src/delegation.ts
+++ b/src/delegation.ts
@@ -67,6 +67,56 @@ export function isPhantomPrompt(prompt: string): boolean {
   return true;
 }
 
+export interface ShellPromptValidation {
+  ok: boolean;
+  reason?: string;
+  line?: string;
+}
+
+/**
+ * Shell delegations are passed to `/bin/bash -c` literally. Reject markdown or
+ * prose envelopes at the dispatch boundary so one bad caller fails once with a
+ * typed error instead of producing a command-not-found storm.
+ */
+export function validateShellPrompt(prompt: string): ShellPromptValidation {
+  const lines = prompt.split(/\r?\n/);
+  let hasExecutableLine = false;
+
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    if (line.startsWith('#!')) {
+      continue;
+    }
+    if (/^#{2,6}\s+\S/.test(line)) {
+      return { ok: false, reason: 'markdown_heading', line };
+    }
+    if (/^#/.test(line)) continue;
+    if (/^```/.test(line)) {
+      return { ok: false, reason: 'markdown_fence', line };
+    }
+    if (/^(?:[-*]|\d+\.)\s+/.test(line)) {
+      return { ok: false, reason: 'markdown_list', line };
+    }
+    if (/^<\/?[A-Za-z][^>]*>$/.test(line)) {
+      return { ok: false, reason: 'xml_envelope', line };
+    }
+    if (/^(?:Task ID|Strategy|Instructions|Acceptance Criteria|Notes|Retry Task)\s*:/i.test(line)) {
+      return { ok: false, reason: 'prose_field', line };
+    }
+    if (/^[A-Z][A-Za-z]+(?:\s+[a-z][A-Za-z/'-]+){2,}[.!?]?$/.test(line)) {
+      return { ok: false, reason: 'prose_sentence', line };
+    }
+    hasExecutableLine = true;
+  }
+
+  if (!hasExecutableLine) {
+    return { ok: false, reason: 'empty_or_comment_only' };
+  }
+
+  return { ok: true };
+}
+
 // =============================================================================
 // Types (stable external surface)
 // =============================================================================
@@ -437,6 +487,18 @@ export function spawnDelegation(task: DelegationTask): string {
       finalizeTask(entry, {
         status: 'failed',
         output: `blocked by write lease: ${err instanceof Error ? err.message : String(err)}`,
+      });
+      return taskId;
+    }
+  }
+
+  if (worker === 'shell') {
+    const shellPrompt = validateShellPrompt(task.prompt);
+    if (!shellPrompt.ok) {
+      const detail = shellPrompt.line ? ` at line "${shellPrompt.line.slice(0, 120)}"` : '';
+      finalizeTask(entry, {
+        status: 'failed',
+        output: `shell_received_prose: ${shellPrompt.reason ?? 'invalid_shell_prompt'}${detail}. Shell delegations execute literal bash; pass an executable command/script or route prose through a non-shell worker.`,
       });
       return taskId;
     }

--- a/tests/delegation-arbiter.test.ts
+++ b/tests/delegation-arbiter.test.ts
@@ -66,6 +66,7 @@ import {
   killAllDelegations,
   spawnDelegation,
 } from '../src/delegation.js';
+import { readDelegationFailureRecordsSync } from '../src/delegation-failure-guard.js';
 import { prepareForgeWorkspace } from '../src/forge.js';
 
 function validPrompt(text: string): string {
@@ -237,6 +238,30 @@ describe('delegation arbitration mapping', () => {
 
     expect(getTaskResult(id)?.status).toBe('failed');
     expect(getTaskResult(id)?.output).toContain('blocked by arbiter');
+  });
+
+  it('rejects prose-shaped shell prompts before middleware dispatch', () => {
+    const id = spawnDelegation({
+      prompt: [
+        '## Retry Task: Retry middleware shell lane with bounded probes after timeout',
+        'Task ID: idx-af45d4ff-b34f-478e-a680-f3fe33bdaaf3',
+        'Strategy: bounded-shell-probe',
+        '',
+        'Break the failed work into bounded probes.',
+        '',
+        'cd /Users/user/Workspace/mini-agent && pnpm tsx scripts/kg-extract-entities.ts --write --limit 100',
+      ].join('\n'),
+      workdir: '/repo',
+      type: 'shell',
+    });
+
+    expect(getTaskResult(id)?.status).toBe('failed');
+    expect(getTaskResult(id)?.output).toContain('shell_received_prose');
+    expect(readDelegationFailureRecordsSync(testMemoryDir!)[0]).toEqual(expect.objectContaining({
+      taskId: id,
+      taskType: 'shell',
+      error: expect.stringContaining('shell_received_prose'),
+    }));
   });
 
   it('can execute delegations through BrainRuntime when enabled', async () => {

--- a/tests/delegation-phantom-prompt.test.ts
+++ b/tests/delegation-phantom-prompt.test.ts
@@ -14,7 +14,7 @@
  * lives in src/delegation.ts (or a dedicated guard module) once landed.
  */
 import { describe, expect, it } from 'vitest';
-import { isPhantomPrompt } from '../src/delegation.js';
+import { isPhantomPrompt, validateShellPrompt } from '../src/delegation.js';
 
 describe('phantom-prompt classifier (issue #141 layer 1)', () => {
   it('rejects the exact fail-ejkd7t signature', () => {
@@ -48,5 +48,29 @@ describe('phantom-prompt classifier (issue #141 layer 1)', () => {
     expect(
       isPhantomPrompt('## Task: ship\n\n## Instructions\nedit forge.ts:62 to surface stderr'),
     ).toBe(false);
+  });
+});
+
+describe('shell prompt boundary guard (issue #581)', () => {
+  it('accepts executable shell one-liners and comments', () => {
+    expect(validateShellPrompt('cd /repo && pnpm typecheck && pnpm test')).toEqual({ ok: true });
+    expect(validateShellPrompt('# progress checkpoint\npnpm tsx scripts/kg-extract-entities.ts --write --limit 100')).toEqual({ ok: true });
+  });
+
+  it('rejects bounded-shell-probe markdown envelopes before bash sees them', () => {
+    const prompt = [
+      '## Retry Task: Retry middleware shell lane with bounded probes after timeout',
+      'Task ID: idx-af45d4ff-b34f-478e-a680-f3fe33bdaaf3',
+      'Strategy: bounded-shell-probe',
+      '',
+      'Break the failed work into bounded probes.',
+      '',
+      'cd /Users/user/Workspace/mini-agent && pnpm tsx scripts/kg-extract-entities.ts --write --limit 100',
+    ].join('\n');
+
+    expect(validateShellPrompt(prompt)).toEqual(expect.objectContaining({
+      ok: false,
+      reason: 'markdown_heading',
+    }));
   });
 });


### PR DESCRIPTION
## Summary
- `validateShellPrompt()` rejects markdown headings/fences/lists, XML envelopes, prose field labels (`Task ID:`, `Strategy:`...) and prose sentences before `/bin/bash -c` ever sees them.
- `spawnDelegation()` shell branch calls it and emits a typed `shell_received_prose: <reason>` failure with the offending line — one failure instead of a command-not-found storm.
- Followup to #581: stops bounded-shell-probe envelopes from being dispatched literally.

## Test plan
- [x] `pnpm vitest run tests/delegation-phantom-prompt.test.ts tests/delegation-arbiter.test.ts` — 20 pass
- [x] Negative case asserts the exact `## Retry Task / Task ID / Strategy` envelope shape

🤖 Co-authored by Kuro (kuro-agent)